### PR TITLE
Fix LED blink example so it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ braudrate:9600
 ####And blink it
 ```lua
   lighton=0
-  tmr.alarm(1000,1,function()
+  tmr.alarm(1,1000,1,function()
     if lighton==0 then 
       lighton=1 
       led(512,512,512) 


### PR DESCRIPTION
Two fixes to the LED blink example:
- The ID and delay time have been swapped (should be ID followed by delay time).
- By default the alarm only fires once, there needs to be an extra `1` as a parameter before the function definition.
