### PR TITLE
Allow user to specify the serial port the ESP is attached to

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -161,8 +161,12 @@ $(BINODIR)/%.bin: $(IMAGEODIR)/%.out
 	@mkdir -p $(BINODIR)
 	../tools/esptool.py elf2image $< -o $(BINODIR)/
 
+ifndef $(PORT)
+    PORT = /dev/ttyUSB0
+endif
+
 flash:
-	../tools/esptool.py write_flash 0x00000 $(BINODIR)/0x00000.bin 0x10000 $(BINODIR)/0x10000.bin
+	../tools/esptool.py -p $(PORT) write_flash 0x00000 $(BINODIR)/0x00000.bin 0x10000 $(BINODIR)/0x10000.bin
 
 .PHONY: FORCE
 FORCE:


### PR DESCRIPTION
For example on Windows it would be:

```make flash PORT=COM3```

On Linux you can use the default /dev/ttyUSB0:

```make flash```