### PR TITLE
Added DS3231 module, documentation, and examples

### DIFF
--- a/lua_modules/ds3231/ds3231-example.lua
+++ b/lua_modules/ds3231/ds3231-example.lua
@@ -1,0 +1,15 @@
+require("ds3231")
+
+-- ESP-01 GPIO Mapping
+gpio0, gpio2 = 3, 4
+
+ds3231.init(gpio0, gpio2)
+
+second, minute, hour, day, date, month, year = ds3231.getTime();
+
+-- Get current time
+print(string.format("Time & Date: %s:%s:%s %s/%s/%s", hour, minute, second, date, month, year))
+
+-- Don't forget to release it after use
+ds3231 = nil
+package.loaded["ds3231"]=nil

--- a/lua_modules/ds3231/ds3231-web.lua
+++ b/lua_modules/ds3231/ds3231-web.lua
@@ -1,0 +1,54 @@
+require('ds3231')
+
+port = 80
+
+-- ESP-01 GPIO Mapping
+gpio0, gpio2 = 3, 4
+
+days = {
+    [1] = "Sunday",
+    [2] = "Monday",
+    [3] = "Tuesday",
+    [4] = "Wednesday",
+    [5] = "Thursday",
+    [6] = "Friday",
+    [7] = "Saturday"
+}
+
+months = {
+    [1] = "January",
+    [2] = "Febuary",
+    [3] = "March",
+    [4] = "April",
+    [5] = "May",
+    [6] = "June",
+    [7] = "July",
+    [8] = "August",
+    [9] = "September",
+    [10] = "October",
+    [11] = "November",
+    [12] = "December"
+}
+
+ds3231.init(gpio0, gpio2)
+
+srv=net.createServer(net.TCP)
+srv:listen(port,
+    function(conn)
+
+        second, minute, hour, day, date, month, year = ds3231.getTime()
+        prettyTime = string.format("%s, %s %s %s %s:%s:%s", days[day], date, months[month], year, hour, minute, second)
+
+        conn:send("HTTP/1.1 200 OK\nContent-Type: text/html\nRefresh: 5\n\n" ..
+            "<!DOCTYPE HTML>" ..
+            "<html><body>" ..
+            "<b>ESP8266</b></br>" ..
+            "Time and Date: " .. prettyTime .. "<br>" ..
+            "Node ChipID : " .. node.chipid() .. "<br>" ..
+            "Node MAC : " .. wifi.sta.getmac() .. "<br>" ..
+            "Node Heap : " .. node.heap() .. "<br>" ..
+            "Timer Ticks : " .. tmr.now() .. "<br>" ..
+            "</html></body>")
+        conn:on("sent",function(conn) conn:close() end)
+    end
+)

--- a/lua_modules/ds3231/ds3231.EN.md
+++ b/lua_modules/ds3231/ds3231.EN.md
@@ -1,0 +1,114 @@
+#DS3231 Module
+##Require
+```lua
+ds3231 = require("ds3231")
+```
+## Release
+```lua
+ds3231 = nil
+package.loaded["ds3231"]=nil
+```
+<a id="ds3231_init"></a>
+##init()
+####Description
+Setting the pins of DS3231.
+
+####Syntax
+init(sda, scl)
+
+####Parameters
+sda: 1~10, IO index.  
+scl: 1~10, IO index.
+
+####Returns
+nil
+
+####Example
+```lua
+ds3231 = require("ds3231")
+ds3231.init(3, 4)
+-- Don't forget to release it after use
+ds3231 = nil
+package.loaded["ds3231"]=nil
+```
+
+####See also
+**-**   []()
+
+
+<a id="ds3231_settime"></a>
+## setTime()
+####Description
+Sets the current date and time.
+
+####Syntax
+setTime(second, minute, hour, day, date, month, year)
+
+####Parameters
+second: 00-59  
+minute: 00-59  
+hour: 00-23  
+day: 1-7 (Sunday = 1, Saturday = 7)  
+date: 01-31  
+month: 01-12  
+year: 00-99
+
+####Returns
+nil
+
+####Example
+```lua
+ds3231 = require("ds3231")
+ds3231.init(3, 4)
+
+-- Set date and time to Sunday, January 18th 2015 6:30PM
+ds3231.setTime(0, 30, 18, 1, 18, 1, 15);
+
+-- Don't forget to release it after use
+ds3231 = nil
+package.loaded["ds3231"]=nil
+```
+
+####See also
+**-**   []()
+
+
+<a id="ds3231_getTime"></a>
+## getTime()
+####Description
+Get the current date and time.
+
+####Syntax
+getTime()
+
+####Parameters
+nil
+
+####Returns
+second: integer. Second 00-59  
+minute: integer. Minute 00-59  
+hour: integer. Hour 00-23  
+day: integer. Day 1-7 (Sunday = 1, Saturday = 7)  
+date: integer. Date 01-31  
+month: integer. Month 01-12  
+year: integer. Year 00-99  
+
+####Example
+```lua
+ds3231=require("ds3231")
+ds3231.init(3, 4)
+
+-- Get date and time
+second, minute, hour, day, date, month, year = ds3231.getTime();
+
+-- Print date and time
+print(string.format("Time & Date: %s:%s:%s %s/%s/%s", 
+    hour, minute, second, date, month, year))
+
+-- Don't forget to release it after use
+ds3231 = nil
+package.loaded["ds3231"]=nil
+
+```
+####See also
+**-**   []()

--- a/lua_modules/ds3231/ds3231.lua
+++ b/lua_modules/ds3231/ds3231.lua
@@ -1,0 +1,75 @@
+--------------------------------------------------------------------------------
+-- DS3231 I2C module for NODEMCU
+-- NODEMCU TEAM
+-- LICENCE: http://opensource.org/licenses/MIT
+-- Tobie Booth <tbooth@hindbra.in>
+--------------------------------------------------------------------------------
+
+local moduleName = ...
+local M = {}
+_G[moduleName] = M
+
+-- Default value for i2c communication
+local id = 0
+
+--device address
+local dev_addr = 0x68
+
+local function decToBcd(val)
+  return((val/10*16) + (val%10))
+end
+
+local function bcdToDec(val)
+  return((val/16*10) + (val%16))
+end
+
+-- initialize i2c
+--parameters:
+--d: sda
+--l: scl
+function M.init(d, l)
+  if (d ~= nil) and (l ~= nil) and (d >= 0) and (d <= 11) and (l >= 0) and ( l <= 11) and (d ~= l) then
+    sda = d
+    scl = l
+  else
+    print("iic config failed!") return nil
+  end
+    print("init done")
+    i2c.setup(id, sda, scl, i2c.SLOW)
+end
+
+--get time from DS3231
+function M.getTime()
+  i2c.start(id)
+  i2c.address(id, dev_addr, i2c.TRANSMITTER)
+  i2c.write(id, 0x00)
+  i2c.stop(id)
+  i2c.start(id)
+  i2c.address(id, dev_addr, i2c.RECEIVER)
+  local c=i2c.read(id, 7)
+  i2c.stop(id)
+  return bcdToDec(tonumber(string.byte(c, 1))),
+  bcdToDec(tonumber(string.byte(c, 2))),
+  bcdToDec(tonumber(string.byte(c, 3))),
+  bcdToDec(tonumber(string.byte(c, 4))),
+  bcdToDec(tonumber(string.byte(c, 5))),
+  bcdToDec(tonumber(string.byte(c, 6))),
+  bcdToDec(tonumber(string.byte(c, 7)))
+end
+
+--set time for DS3231
+function M.setTime(second, minute, hour, day, date, month, year)
+  i2c.start(id)
+  i2c.address(id, dev_addr, i2c.TRANSMITTER)
+  i2c.write(id, 0x00)
+  i2c.write(id, decToBcd(second))
+  i2c.write(id, decToBcd(minute))
+  i2c.write(id, decToBcd(hour))
+  i2c.write(id, decToBcd(day))
+  i2c.write(id, decToBcd(date))
+  i2c.write(id, decToBcd(month))
+  i2c.write(id, decToBcd(year))
+  i2c.stop(id)
+end
+
+return M


### PR DESCRIPTION
Added a module for communicating with a DS3231 RTC chip via I2C. Currently supports getting and setting the date and time. 

Includes documentation and examples (heavily borrowed from the DS18b20 module).

```lua
ds3231=require("ds3231")
ds3231.init(3, 4)

-- Get date and time
second, minute, hour, day, date, month, year = ds3231.getTime();

-- Print date and time
print(string.format("Time & Date: %s:%s:%s %s/%s/%s", 
    hour, minute, second, date, month, year))

-- Don't forget to release it after use
ds3231 = nil
package.loaded["ds3231"]=nil

```