### PR TITLE
new sleep set options added (from 0.9.5 sdk)

### DIFF
--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -26,12 +26,24 @@ static int node_deepsleep( lua_State* L )
 {
   s32 us;
   us = luaL_checkinteger( L, 1 );
-  if ( us <= 0 )
+ // if ( us <= 0 )
+ if ( us < 0 )
     return luaL_error( L, "wrong arg range" );
   system_deep_sleep( us );
   return 0;  
 }
 
+// Lua: dsleep_set_options
+static int node_deepsleep_setoption( lua_State* L )
+{
+  s32 option;
+  option = luaL_checkinteger( L, 1 );
+  if ( option < 0 || option > 4)
+    return luaL_error( L, "wrong arg range" );
+  else
+	  deep_sleep_set_option( option );
+  return 0;
+}
 // Lua: info()
 static int node_info( lua_State* L )
 {
@@ -295,6 +307,7 @@ const LUA_REG_TYPE node_map[] =
   { LSTRKEY( "input" ), LFUNCVAL( node_input ) },
   { LSTRKEY( "output" ), LFUNCVAL( node_output ) },
   { LSTRKEY( "readvdd33" ), LFUNCVAL( node_readvdd33) },
+  { LSTRKEY( "dsleepsetoption" ), LFUNCVAL( node_deepsleep_setoption) },
 #if LUA_OPTIMIZE_MEMORY > 0
 
 #endif


### PR DESCRIPTION
usage:
-- no wakeup until rst pin to low 
```
node.dsleep(0) 
```
-- 4 mean disable RF after deepsleep or restart. (esp8266 consuming ~13mA in this mode.)
-- 1 mean enable RF after deepsleep or restart.
```
node.dsleepsetoption(4)
```