### PR TITLE
fixes nodemcu/nodemcu-firmware#155 lwt qos, retain

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -472,7 +472,8 @@ static int mqtt_socket_client( lua_State* L )
     stack++;
   }
   if(username == NULL)
-    return 1;
+	  il = 0;
+  NODE_DBG("lengh username: %d\r\n", il);
   mud->connect_info.username = (uint8_t *)c_zalloc(il + 1);
   if(!mud->connect_info.username){
 		return luaL_error(L, "not enough memory");
@@ -486,7 +487,9 @@ static int mqtt_socket_client( lua_State* L )
     stack++;
   }
   if(password == NULL)
-    return 1;
+  	  il = 0;
+  NODE_DBG("lengh password: %d\r\n", il);
+
   mud->connect_info.password = (uint8_t *)c_zalloc(il + 1);
   if(!mud->connect_info.password){
 		return luaL_error(L, "not enough memory");
@@ -659,7 +662,7 @@ static int mqtt_socket_lwt( lua_State* L )
 	lwtMsg = luaL_checklstring( L, stack, &il );
 	if (lwtMsg == NULL)
 	{
-		return luaL_error( L, "need lwt topic");
+		return luaL_error( L, "need lwt message");
 	}
 
 	mud->connect_info.will_topic = (uint8_t*) c_zalloc( topicSize + 1 );

--- a/app/mqtt/mqtt_msg.c
+++ b/app/mqtt/mqtt_msg.c
@@ -47,7 +47,7 @@ struct __attribute((__packed__)) mqtt_connect_variable_header
 {
   uint8_t lengthMsb;
   uint8_t lengthLsb;
-  uint8_t magic[6];
+  uint8_t magic[4];
   uint8_t version;
   uint8_t flags;
   uint8_t keepaliveMsb;
@@ -293,9 +293,9 @@ mqtt_message_t* mqtt_msg_connect(mqtt_connection_t* connection, mqtt_connect_inf
   connection->message.length += sizeof(*variable_header);
 
   variable_header->lengthMsb = 0;
-  variable_header->lengthLsb = 6;
-  memcpy(variable_header->magic, "MQIsdp", 6);
-  variable_header->version = 3;
+  variable_header->lengthLsb = 4;
+  memcpy(variable_header->magic, "MQTT", 4);
+  variable_header->version = 4;
   variable_header->flags = 0;
   variable_header->keepaliveMsb = info->keepalive >> 8;
   variable_header->keepaliveLsb = info->keepalive & 0xff;
@@ -322,7 +322,7 @@ mqtt_message_t* mqtt_msg_connect(mqtt_connection_t* connection, mqtt_connect_inf
     variable_header->flags |= MQTT_CONNECT_FLAG_WILL;
     if(info->will_retain)
       variable_header->flags |= MQTT_CONNECT_FLAG_WILL_RETAIN;
-    variable_header->flags |= (info->will_qos & 3) << 4;
+    variable_header->flags |= (info->will_qos & 3) << 3;
   }
 
   if(info->username != NULL && info->username[0] != '\0')


### PR DESCRIPTION
change header support MQTT 3.1.1 valid by https://eclipse.org/paho/clients/testing/
fixes error if username or password = null,