### PR TITLE
Only set ESPTOOL if not set before

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ else
     endif
 endif
 #############################################################
-ESPTOOL = ../tools/esptool.py
+ESPTOOL ?= ../tools/esptool.py
 
 
 CSRCS ?= $(wildcard *.c)


### PR DESCRIPTION
This allows setting the path to esptool.py as an option on make, allowing the use of alternative tools, or modified esptool.py versions.