### PR TITLE
Use python2 instead of python(2/3)

### DIFF
--- a/tools/esptool.py
+++ b/tools/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # ESP8266 ROM Bootloader Utility
 # https://github.com/themadinventor/esptool


### PR DESCRIPTION
On modern systems "python" refers to python3, and the script won't work, so I suggest changing it to python2 with this patch.

This patch shouldn't break compatibility with older systems.