### PR TITLE
Disabled automatic detection of larger flash sizes

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -9,11 +9,11 @@
 #define NODE_VERSION	"NodeMCU 0.9.5"
 #define BUILD_DATE	    "build 20150127"
 
-// #define FLASH_512K
+#define FLASH_512K
 // #define FLASH_1M
 // #define FLASH_2M
 // #define FLASH_4M
-#define FLASH_AUTOSIZE
+//#define FLASH_AUTOSIZE
 // #define DEVELOP_VERSION
 #define FULL_VERSION_FOR_USER
 


### PR DESCRIPTION
The autodetection is broken and causes a number of strange reliability issues, see here: 
http://www.esp8266.com/viewtopic.php?f=18&t=1418&p=9082#p9082
and here: 
http://www.esp8266.com/viewtopic.php?f=18&t=1180

and numerous other threads in the esp8266 forum. 

Of course this is not a fix, but it will work as a workaround to fix the crashes on short term.