### PR TITLE
Added the hold and unhold methods to tcp socket  

### DIFF
--- a/app/include/lwip/app/espconn.h
+++ b/app/include/lwip/app/espconn.h
@@ -394,5 +394,21 @@ extern sint8 espconn_igmp_join(ip_addr_t *host_ip, ip_addr_t *multicast_ip);
 *******************************************************************************/
 extern sint8 espconn_igmp_leave(ip_addr_t *host_ip, ip_addr_t *multicast_ip);
 
+/******************************************************************************
+ * FunctionName : espconn_recv_hold
+ * Description  : hold tcp receive
+ * Parameters   : espconn -- espconn to hold
+ * Returns      : none
+*******************************************************************************/
+extern sint8 espconn_recv_hold(struct espconn *pespconn);
+
+/******************************************************************************
+ * FunctionName : espconn_recv_unhold
+ * Description  : unhold tcp receive
+ * Parameters   : espconn -- espconn to unhold
+ * Returns      : none
+*******************************************************************************/
+extern sint8 espconn_recv_unhold(struct espconn *pespconn);
+
 #endif
 

--- a/app/include/lwip/tcp.h
+++ b/app/include/lwip/tcp.h
@@ -277,6 +277,8 @@ struct tcp_pcb {
 
   /* KEEPALIVE counter */
   u8_t keep_cnt_sent;
+
+  u8_t hold;
 };
 
 struct tcp_pcb_listen {  

--- a/app/lwip/app/espconn.c
+++ b/app/lwip/app/espconn.c
@@ -718,3 +718,32 @@ espconn_gethostbyname(struct espconn *pespconn, const char *hostname, ip_addr_t 
     return dns_gethostbyname(hostname, addr, found, pespconn);
 }
 
+sint8 espconn_recv_hold(struct espconn *pespconn) {
+  espconn_msg *pnode = NULL;
+
+  if (pespconn == NULL) {
+    return ESPCONN_ARG;
+  }
+  pespconn->state = ESPCONN_WRITE;
+  if (!espconn_find_connection(pespconn, &pnode)) {
+      return ESPCONN_ARG;
+  }
+
+  espconn_tcp_hold(pnode);
+  return ESPCONN_OK;
+}
+
+sint8 espconn_recv_unhold(struct espconn *pespconn) {
+  espconn_msg *pnode = NULL;
+
+  if (pespconn == NULL) {
+    return ESPCONN_ARG;
+  }
+  pespconn->state = ESPCONN_WRITE;
+  if (!espconn_find_connection(pespconn, &pnode)) {
+      return ESPCONN_ARG;
+  }
+
+  espconn_tcp_unhold(pnode);
+  return ESPCONN_OK;
+}

--- a/app/lwip/app/espconn_tcp.c
+++ b/app/lwip/app/espconn_tcp.c
@@ -948,3 +948,19 @@ sint8 ICACHE_FLASH_ATTR espconn_tcp_delete(struct espconn *pdeletecon)
 			return ESPCONN_ARG;
 	}
 }
+
+void espconn_tcp_hold(void *arg) {
+    espconn_msg *ptcp_sent = arg;
+    struct tcp_pcb *pcb = NULL;
+    pcb = ptcp_sent->pcommon.pcb;
+
+    pcb->hold = 1;
+}
+
+void espconn_tcp_unhold(void *arg) {
+    espconn_msg *ptcp_sent = arg;
+    struct tcp_pcb *pcb = NULL;
+    pcb = ptcp_sent->pcommon.pcb;
+
+    pcb->hold = 0;
+}

--- a/app/lwip/core/tcp.c
+++ b/app/lwip/core/tcp.c
@@ -1259,6 +1259,7 @@ tcp_alloc(u8_t prio)
 #endif /* LWIP_TCP_KEEPALIVE */
 
     pcb->keep_cnt_sent = 0;									//���ķ��ʹ���
+    pcb->hold = 0;
   }
   return pcb;
 }

--- a/app/lwip/core/tcp_in.c
+++ b/app/lwip/core/tcp_in.c
@@ -1137,7 +1137,7 @@ tcp_receive(struct tcp_pcb *pcb)
 
   /* If the incoming segment contains data, we must process it
      further. */
-  if (tcplen > 0) {
+  if ((tcplen > 0) && (!pcb->hold)) {
     /* This code basically does three things:
 
     +) If the incoming segment contains data that is the next

--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -725,8 +725,15 @@ static int mqtt_socket_connect( lua_State* L )
   if(mud == NULL)
     return 0;
 
-  if(mud->pesp_conn)
-    	c_free(mud->pesp_conn);
+  if(mud->pesp_conn){   //TODO: should I free tcp struct directly or ask user to call close()???
+    mud->pesp_conn->reverse = NULL;
+    if(mud->pesp_conn->proto.tcp)
+      c_free(mud->pesp_conn->proto.tcp);
+    mud->pesp_conn->proto.tcp = NULL;
+    c_free(mud->pesp_conn);
+    mud->pesp_conn = NULL;
+  }
+
   struct espconn *pesp_conn = NULL;
 	pesp_conn = mud->pesp_conn = (struct espconn *)c_zalloc(sizeof(struct espconn));
 	if(!pesp_conn)

--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -665,6 +665,10 @@ static int net_start( lua_State* L, const char* mt )
   	return 0;
   }
 
+  if(nud->pesp_conn == NULL){
+    NODE_DBG("nud->pesp_conn is NULL.\n");
+    return 0;
+  }
   pesp_conn = nud->pesp_conn;
   port = luaL_checkinteger( L, stack );
   stack++;
@@ -1074,6 +1078,10 @@ static int net_dns( lua_State* L, const char* mt )
     return 0;
   }
 
+  if(nud->pesp_conn == NULL){
+    NODE_DBG("nud->pesp_conn is NULL.\n");
+    return 0;
+  }
   pesp_conn = nud->pesp_conn;
 
   if(!isserver || pesp_conn->type == ESPCONN_UDP){    // self_ref is only needed by socket userdata, or udp server

--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -1193,6 +1193,54 @@ static int net_socket_send( lua_State* L )
   return net_send(L, mt);
 }
 
+static int net_socket_hold( lua_State* L )
+{
+  const char *mt = "net.socket";
+  struct espconn *pesp_conn = NULL;
+  lnet_userdata *nud;
+  size_t l;
+
+  nud = (lnet_userdata *)luaL_checkudata(L, 1, mt);
+  luaL_argcheck(L, nud, 1, "Server/Socket expected");
+  if(nud==NULL){
+    NODE_DBG("userdata is nil.\n");
+    return 0;
+  }
+
+  if(nud->pesp_conn == NULL){
+    NODE_DBG("nud->pesp_conn is NULL.\n");
+    return 0;
+  }
+  pesp_conn = nud->pesp_conn;
+  espconn_recv_hold(pesp_conn);
+
+  return 0;
+}
+
+static int net_socket_unhold( lua_State* L )
+{
+  const char *mt = "net.socket";
+  struct espconn *pesp_conn = NULL;
+  lnet_userdata *nud;
+  size_t l;
+
+  nud = (lnet_userdata *)luaL_checkudata(L, 1, mt);
+  luaL_argcheck(L, nud, 1, "Server/Socket expected");
+  if(nud==NULL){
+    NODE_DBG("userdata is nil.\n");
+    return 0;
+  }
+
+  if(nud->pesp_conn == NULL){
+    NODE_DBG("nud->pesp_conn is NULL.\n");
+    return 0;
+  }
+  pesp_conn = nud->pesp_conn;
+  espconn_recv_unhold(pesp_conn);
+
+  return 0;
+}
+
 // Lua: socket:dns( string, function(ip) )
 static int net_socket_dns( lua_State* L )
 {
@@ -1251,6 +1299,8 @@ static const LUA_REG_TYPE net_socket_map[] =
   { LSTRKEY( "close" ), LFUNCVAL ( net_socket_close ) },
   { LSTRKEY( "on" ), LFUNCVAL ( net_socket_on ) },
   { LSTRKEY( "send" ), LFUNCVAL ( net_socket_send ) },
+  { LSTRKEY( "hold" ), LFUNCVAL ( net_socket_hold ) },
+  { LSTRKEY( "unhold" ), LFUNCVAL ( net_socket_unhold ) },
   { LSTRKEY( "dns" ), LFUNCVAL ( net_socket_dns ) },
   // { LSTRKEY( "delete" ), LFUNCVAL ( net_socket_delete ) },
   { LSTRKEY( "__gc" ), LFUNCVAL ( net_socket_delete ) },


### PR DESCRIPTION
While implementing a simple echo server (https://gist.github.com/Point-less/27ec0a2284f2d82d6a9c) i found out that the data was been lost because of espconn_sent new implementation ignores calls been done before the data can be sent. The only way of avoiding this is having some kind of callback which tells us when we can send new data. While I was trying to implement the echo server using that callback I came to realize that there is was no way of stopping data from coming in and be ACKed or throttling the TCP connection, so I added the support for hold/unhold in the tcp socket, which lets us stop the ack of incomming data by dropping the payload of the tcp packets (so that the protocol "looses" some packets and adjust the speed according to our needs).

This is a really simple approach and can be enhanced (buffering for a small time the payload for example, so when we call unhold we can have data right on time). The espresiff sdk has the same two functions in it's api, so i used the same interface.

With this feature i can have a working echo server (https://gist.github.com/Point-less/51eafb0e2d48021de03e).