### PR TITLE
Revert "Use python2 instead of python(2/3)"

### DIFF
--- a/tools/esptool.py
+++ b/tools/esptool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 #
 # ESP8266 ROM Bootloader Utility
 # https://github.com/themadinventor/esptool


### PR DESCRIPTION
Reverts nodemcu/nodemcu-firmware#182
reported that not work in mac.