### PR TITLE
Update dht22.lua to address issue #225

### DIFF
--- a/lua_modules/dht22/dht22.lua
+++ b/lua_modules/dht22/dht22.lua
@@ -62,17 +62,17 @@ function M.read(pin)
 
   --DHT data acquired, process.
   for i = 1, 16, 1 do
-    if (bitStream[i] > 4) then
+    if (bitStream[i] > 3) then
       humidity = humidity + 2 ^ (16 - i)
     end
   end
   for i = 1, 16, 1 do
-    if (bitStream[i + 16] > 4) then
+    if (bitStream[i + 16] > 3) then
       temperature = temperature + 2 ^ (16 - i)
     end
   end
   for i = 1, 8, 1 do
-    if (bitStream[i + 32] > 4) then
+    if (bitStream[i + 32] > 3) then
       checksum = checksum + 2 ^ (8 - i)
     end
   end


### PR DESCRIPTION
Addresses issue #225, slower loop timing due to the use of floats. Should be safe to use with integer-only builds, since on integer-only builds I could never see "3" as a valid value for either low or high