### PR TITLE
Fix file.seek() return value

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -111,7 +111,7 @@ static int file_seek (lua_State *L)
   long offset = luaL_optlong(L, 2, 0);
   op = fs_seek(file_fd, offset, mode[op]);
   if (op)
-    lua_pushboolean(L, 1);  /* error */
+    lua_pushnil(L);  /* error */
   else
     lua_pushinteger(L, fs_tell(file_fd));
   return 1;


### PR DESCRIPTION
Hi,

this is a very minor fix to make `file.seek()` behave as described in the documentation, i.e. return nil on error / EOF. As it stands it returns true on EOF, which means a construct like `if file.seek("set", <some_offset>) then`
will always be entered even if you were expecting it to skip if offset is after EOF.

Thanks !