### PR TITLE
Accidentally removed ROM_MODULES_U8G

### DIFF
--- a/app/modules/modules.h
+++ b/app/modules/modules.h
@@ -139,6 +139,7 @@
         ROM_MODULES_PWM     \
         ROM_MODULES_WIFI    \
         ROM_MODULES_MQTT    \
+        ROM_MODULES_U8G     \
         ROM_MODULES_I2C     \
         ROM_MODULES_SPI     \
         ROM_MODULES_TMR     \


### PR DESCRIPTION
I am sorry, I made an error in my last pull request and accidentally
removed ROM_MODULES_U8G.  Here is it back again.