### PR TITLE
Fix getFSF to abide by the function contract

### DIFF
--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -659,13 +659,19 @@ typedef struct LoadFSF {
 static const char *getFSF (lua_State *L, void *ud, size_t *size) {
   LoadFSF *lf = (LoadFSF *)ud;
   (void)L;
+
+  if (L == NULL && size == NULL) // Direct mode check
+    return NULL;
+
   if (lf->extraline) {
     lf->extraline = 0;
     *size = 1;
     return "\n";
   }
+
   if (fs_eof(lf->f)) return NULL;
   *size = fs_read(lf->f, lf->buff, sizeof(lf->buff));
+
   return (*size > 0) ? lf->buff : NULL;
 }
 


### PR DESCRIPTION
This fixes getFSF in lauxlib.c to abide by the 'direct read' contract of returning NULL or a pointer if the Lua pointer and the size pointer are NULL. This fixes at least issue #239.