### PR TITLE
LUAL_BUFFERSIZE back to 1K and warning notice added

### DIFF
--- a/app/lua/luaconf.h
+++ b/app/lua/luaconf.h
@@ -541,8 +541,12 @@ extern int readline4lua(const char *prompt, char *buffer, int length);
 
 /*
 @@ LUAL_BUFFERSIZE is the buffer size used by the lauxlib buffer system.
+** Attention: This value should probably not be set higher than 1K.
+** The size has direct impact on the C stack size needed be auxlib functions.
+** For example: If set to 4K a call to string.gsub will need more than 
+** 5k C stack space.
 */
-#define LUAL_BUFFERSIZE		((BUFSIZ)*4)
+#define LUAL_BUFFERSIZE		BUFSIZ
 
 /* }================================================================== */
 


### PR DESCRIPTION
Moin,

with some filesystem fix the buffer size (LUAL_BUFFERSIZE) was increased to 4 K.
That costs more than 5K C stack space for multiple functions, e.g. string.gsub.
This patch corrects this back to 1K.
One may consider reducing it even more.

Cal