### PR TITLE
Add multicastJoin and multicastLeave to net module

### DIFF
--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -1119,7 +1119,6 @@ static int net_dns( lua_State* L, const char* mt )
   return 0;  
 }
 
-
 // Lua: s = net.createServer(type, function(server))
 static int net_createServer( lua_State* L )
 {
@@ -1284,6 +1283,55 @@ static int net_socket_dns( lua_State* L )
   return net_dns(L, mt);
 }
 
+static int net_multicastJoinLeave( lua_State *L, int join)
+{
+	  size_t il;
+	  ip_addr_t multicast_addr;
+	  ip_addr_t if_addr;
+	  const char *multicast_ip;
+	  const char *if_ip;
+
+	  NODE_DBG("net_multicastJoin is called.\n");
+	  if(! lua_isstring(L,1) ) return luaL_error( L, "wrong arg type" );
+	  if_ip = luaL_checklstring( L, 1, &il );
+	  if (if_ip != NULL)
+		 if ( if_ip[0] == '\0' || stricmp(if_ip,"any") == 0)
+	     {
+			 if_ip = "0.0.0.0";
+			 il = 7;
+	     }
+	  if (if_ip == NULL || il > 15 || il < 7) return luaL_error( L, "invalid if ip" );
+	  if_addr.addr = ipaddr_addr(if_ip);
+
+	  if(! lua_isstring(L,2) ) return luaL_error( L, "wrong arg type" );
+	  multicast_ip = luaL_checklstring( L, 2, &il );
+	  if (multicast_ip == NULL || il > 15 || il < 7) return luaL_error( L, "invalid multicast ip" );
+	  multicast_addr.addr = ipaddr_addr(multicast_ip);
+	  if (join)
+	  {
+		  espconn_igmp_join(&if_addr, &multicast_addr);
+	  }
+	  else
+	  {
+		  espconn_igmp_leave(&if_addr, &multicast_addr);
+	  }
+	  return 0;
+}
+// Lua: net.multicastJoin(ifip, multicastip)
+// if ifip "" or "any" all interfaces are affected
+static int net_multicastJoin( lua_State* L )
+{
+	return net_multicastJoinLeave(L,1);
+}
+
+// Lua: net.multicastLeave(ifip, multicastip)
+// if ifip "" or "any" all interfaces are affected
+static int net_multicastLeave( lua_State* L )
+{
+	return net_multicastJoinLeave(L,0);
+}
+
+
 #if 0
 static int net_array_index( lua_State* L )
 {
@@ -1358,6 +1406,8 @@ const LUA_REG_TYPE net_map[] =
 {
   { LSTRKEY( "createServer" ), LFUNCVAL ( net_createServer ) },
   { LSTRKEY( "createConnection" ), LFUNCVAL ( net_createConnection ) },
+  { LSTRKEY( "multicastJoin"), LFUNCVAL( net_multicastJoin ) },
+  { LSTRKEY( "multicastLeave"), LFUNCVAL( net_multicastLeave ) },
 #if LUA_OPTIMIZE_MEMORY > 0
   { LSTRKEY( "TCP" ), LNUMVAL( TCP ) },
   { LSTRKEY( "UDP" ), LNUMVAL( UDP ) },


### PR DESCRIPTION
net.multicastJoin(if_ip, multicast_ip)
net.multicastLeave(if_ip, multicast_ip)

if_ip is a string containing the interface ip to join/leave the
multicast group.  multicast_ip is the multicast ip of the group to
join/leave. if_ip can be "" or "any" to affect all interfaces.

Paves the way for things like an mDNS module