### PR TITLE
Makefile fix: "-Os" was overridden by "-O2"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,9 +103,15 @@ OIMAGES := $(GEN_IMAGES:%=$(IMAGEODIR)/%)
 BINODIR := $(ODIR)/$(TARGET)/$(FLAVOR)/bin
 OBINS := $(GEN_BINS:%=$(BINODIR)/%)
 
+#
+# Note: 
+# https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
+# If you add global optimize options like "-O2" here 
+# they will override "-Os" defined above.
+# "-Os" should be used to reduce code size
+#
 CCFLAGS += 			\
 	-g			\
-	-O2			\
 	-Wpointer-arith		\
 	-Wundef			\
 	-Werror			\


### PR DESCRIPTION
Moin,

wrong global optimize flag "-O2" was effective in Makefile.

Before:
  0 .irom0.text   0005967e  40210000  40210000  0000c660  2**4
                  CONTENTS, ALLOC, LOAD, CODE
  1 .text         00007d1c  40100000  40100000  00004940  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .data         00000b48  3ffe8000  3ffe8000  000000e0  2**4
                  CONTENTS, ALLOC, LOAD, DATA
  3 .rodata       00003d10  3ffe8b50  3ffe8b50  00000c30  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  4 .bss          00008868  3ffec860  3ffec860  00004940  2**4
                  ALLOC

With extra "-O2" removed .irom0.text size is reduced:

Idx Name          Size      VMA       LMA       File off  Algn
  0 .irom0.text   000565ae  40210000  40210000  0000c650  2**4
                  CONTENTS, ALLOC, LOAD, CODE
  1 .text         00007d10  40100000  40100000  00004940  2**2
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .data         00000b48  3ffe8000  3ffe8000  000000e0  2**4
                  CONTENTS, ALLOC, LOAD, DATA
  3 .rodata       00003d10  3ffe8b50  3ffe8b50  00000c30  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  4 .bss          00008868  3ffec860  3ffec860  00004940  2**4
                  ALLOC

Cal101 (was model101 before)
