### PR TITLE
Allow connecting to unsecured WiFi networks

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -328,8 +328,8 @@ static int wifi_station_config( lua_State* L )
   if (sl>32 || ssid == NULL)
     return luaL_error( L, "ssid:<32" );
   const char *password = luaL_checklstring( L, 2, &pl );
-  if (pl<8 || pl>64 || password == NULL)
-    return luaL_error( L, "pwd:8~64" );
+  if (pl!=0 && (pl<8 || pl>64) || password == NULL)
+    return luaL_error( L, "pwd:0,8~64" );
 
   c_memset(sta_conf.ssid, 0, 32);
   c_memset(sta_conf.password, 0, 64);


### PR DESCRIPTION
When checking if the WiFi password is between 8 and 63 chars it is not possible to connect a ESP module to an unsecured WiFi network. This allows either an empty password or passwords between 8 adn 63 chars in length.