### PR TITLE
Add function wifi.sta.getconfig() and more parameters to wifi.sta.config()

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -459,9 +459,8 @@ static int wifi_station_config( lua_State* L )
   }
   else if (lua_isstring(L, 3)&& !(lua_isnumber(L, 3)))
   {
-	  const char *mactemp=luaL_checklstring( L, 3, &ml );
-	  lua_pushstring(L, mactemp);
-	  lua_insert(L, 4);
+	  lua_pushnil(L);
+	  lua_insert(L, 3);
 	  auto_connect=1;
 
   }

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -418,6 +418,26 @@ static int wifi_station_getconfig( lua_State* L )
   * 	bssid: MAC address of Access Point you would like to connect to.
   * Returns:
   * 	Nothing.
+  *
+  *	Example:
+  	  	--Connect to Access Point automatically when in range
+  	  	wifi.sta.getconfig("myssid", "password")
+
+  	  	--Connect to Access Point, User decides when to connect/disconnect to/from AP
+  	  	wifi.sta.getconfig("myssid", "mypassword", 0)
+  	  	wifi.sta.connect()
+  	  	--do some wifi stuff
+  	  	wifi.sta.disconnect()
+
+  	  	--Connect to specific Access Point automatically when in range
+  	  	wifi.sta.getconfig("myssid", "mypassword", "12:34:56:78:90:12")
+
+  	  	--Connect to specific Access Point, User decides when to connect/disconnect to/from AP
+  	  	wifi.sta.getconfig("myssid", "mypassword", 0)
+  	  	wifi.sta.connect()
+  	  	--do some wifi stuff
+  	  	wifi.sta.disconnect()
+  *
   */
 static int wifi_station_config( lua_State* L )
 {


### PR DESCRIPTION
I added to the function wifi.sta.config the option to set whether or not auto-connect is enabled upon configuration and also the option to connect to different APs that have the same SSID
