### PR TITLE
Add wifi.sta.getrssi()

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -501,7 +501,7 @@ static int wifi_station_getrssi( lua_State* L )
 			config.bssid = sta_conf.bssid;
 		}
 	}
-	else //STATION is NOT configured to connnect to a specific
+	else //STATION is NOT configured to connect to a specific AP
 	{
 		config.bssid = NULL;
 	}

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -490,13 +490,14 @@ static int wifi_station_getrssi( lua_State* L )
 //		return luaL_error(L, "%s\n", "Can't get RSSI when disconnected from AP");
 	gL = L;
 	struct station_config sta_conf;
-	wifi_station_get_config(&sta_conf);
-	uint8_t channel; // get current wifi channel to speed up AP scan
+	wifi_station_get_config(&sta_conf); //get current STATION configuration
+	uint8_t channel;
 	uint8_t status = wifi_station_get_connect_status();
 
-	struct scan_config config; //get current STATION configuration
+	struct scan_config config;
 	int8_t len;
 	char ssid[32];
+
 	c_strcpy(ssid, sta_conf.ssid);
 	len=c_strlen(sta_conf.ssid);
 	if(len == -1)
@@ -512,24 +513,25 @@ static int wifi_station_getrssi( lua_State* L )
 		config.ssid = ssid;
 	}
 
-	if(lua_isnumber(L, 1))
+	if(lua_isnumber(L, 1)) //did user specify a channel?
 	{
-	  channel=luaL_checkinteger( L, 1 );;
+	  channel=luaL_checkinteger( L, 1 ); //get user specified channel
 	  if (!(channel>=0 && channel <= 13))
 	    return luaL_error( L, "channel:0 or 1-13" );
 	}
-	else if (lua_isnil(L, 1))
+	else if (lua_isnil(L, 1)) //if user specified nil then...
 	{
-		if (status==5)
+		if (status==5) // if currently connected to AP then...
 		{
-		  channel=wifi_get_channel();
+		  channel=wifi_get_channel(); // get current wifi channel to speed up AP scan
 		}
-		else
-			channel=0;
+		else // if not connected to AP then...
+			channel=0; //set channel to 0, scans all channels
 
 	}
-	else
+	else //if user did not specify a number or nil then...
 		return luaL_error( L, "wrong arg type" );
+
 	if(lua_isstring(L, 2)) //check if user specified an alternate BSSID to check
 	{
 	  char mac[6];

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -432,13 +432,13 @@ static int wifi_station_config( lua_State* L )
   *			Note: If bssid_set==1 in STATION configuration, Configured BSSID will be used to get RSSI of specific Access Point.
   *
   * Syntax:
-  *		wifi.sta.getrssi(channel, "MAC_Address", function(value))
+  *		wifi.sta.getrssi(channel, "BSSID", function(value))
   * Parameters:
   * 	Channel:wifi channel the AP is on
   * 		NOTE: If nil is specified and station IS NOT connected to AP, channel will default to 0  (will take longer to get RSSI)
   * 			  If nil is specified and station IS connected to AP, channel will be set to the current wifi channel
   *
-  *		MAC_Address: if multiple APs with the same ssid are present, an alternate MAC address can be specified to get the corresponding AP's RSSI.
+  *		BSSID: If multiple APs with the same ssid are present, an alternate MAC address can be specified to get the corresponding AP's RSSI.
   *			If this field is nil and station IS configured to connect to specific AP, Configured BSSID is used
   *			IF station IS NOT configured to connect to specific AP, this field should be set to nil
   *			NOTE: if BSSID of alternate AP is on a different channel than the currently connected AP, the channel MUST be specified or RSSI will not be retrieved
@@ -449,15 +449,37 @@ static int wifi_station_config( lua_State* L )
   * 	nil
   *
   *	Example:
-  	  --Get RSSI of currently configured AP
-  	  wifi.sta.getrssi(function(I) RSSI=I end)
-  	  print(RSSI)
-  	  RSSI=nil
+  	  --Assume that there is 1 AP configured like this: "myssid 4,-15,FF:FF:FF:FF:FF:FF,11"
+  	  	--and the station is configured with the command "wifi.sta.config("myssid", "mypassword")"
+  	  	  --Get RSSI of currently configured AP(while connected)
+  	  	  wifi.sta.getrssi(nil, nil, function(I) RSSI=I end) --since station is connected channel need not be entered
+  	  	  print(RSSI) --returns -15
+  	  	  RSSI=nil
 
-  	  --Get RSSI of currently configured AP
-  	  wifi.sta.getrssi(function(I) RSSI=I end, "FF:FF:FF:FF:FF:FF")
-  	  print(RSSI)
-  	  RSSI=nil
+  	  	  --Get RSSI of currently configured AP(while disconnected)
+  	  	  --if channel is nil function will take significantly longer to get RSSI
+  	  	  wifi.sta.getrssi(11, nil, function(I) RSSI=I end) --changing channel to 11(channel of AP) solves this problem
+  	  	  print(RSSI)  --returns -15
+  	  	  RSSI=nil
+
+  	  --Assume that there is 3 APs configured like this: "myssid 4,-15,AA:AA:AA:AA:AA:AA,1", "myssid 4,-43,BB:BB:BB:BB:BB:BB,1", "myssid 4,-38,CC:CC:CC:CC:CC:CC,6"
+  	  	--and the station is configured with the command "wifi.sta.config("myssid", "mypassword", "AA:AA:AA:AA:AA:AA")"
+
+  	  	  --Get RSSI of currently configured AP(while connected)
+  	  	  wifi.sta.getrssi(nil, nil, function(I) RSSI=I end) --Since station is configured to connect to specific AP("AA:AA:AA:AA:AA:AA"), leaving BSSID set to nil will return configured AP's RSSI
+  	  	  print(RSSI) --returns -15
+  	  	  RSSI=nil
+
+    	  --Get RSSI of AP with same SSID on the same channel
+    	  wifi.sta.getrssi(nil, "BB:BB:BB:BB:BB:BB", function(I) RSSI=I end)  --since "BB:BB:BB:BB:BB:BB" is on same channel, channel can remain nil
+  	      print(RSSI) --returns -43
+  	      RSSI=nil
+
+  	      --Get RSSI of AP with same SSID on a different channel
+    	  wifi.sta.getrssi(6, "CC:CC:CC:CC:CC:CC", function(I) RSSI=I end)  --since AP "CC:CC:CC:CC:CC:CC" is on channel 6, channel must be set to 6
+  	      print(RSSI) --returns -38
+  	      RSSI=nil
+
   *
   */
 static int wifi_station_getrssi( lua_State* L )

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -483,27 +483,23 @@ static int wifi_station_getrssi( lua_State* L )
 		config.ssid = ssid;
 	}
 
-	if(sta_conf.bssid_set==1) // check if STATION is configured to connect to a specific AP's BSSID
+	if(lua_isstring(L, 2)) //check if user specified an alternate BSSID to check
 	{
-		if(lua_isstring(L, 2)) //check if user specified an alternate BSSID to check
-		{
-			char mac[6];
-			unsigned len = 0;
-			const char *macaddr = luaL_checklstring( L, 2, &len );
-			if(len!=17)
-				return luaL_error( L, "wrong arg type" );
-			os_str2macaddr(mac, macaddr);
-			config.bssid = mac;
-//			c_memcpy(config.bssid, mac, 6);
-		}
-		else //user did NOT specify an alternate BSSID to check
-		{
-			config.bssid = sta_conf.bssid;
-		}
+	  char mac[6];
+	  unsigned len = 0;
+	  const char *macaddr = luaL_checklstring( L, 2, &len );
+	  if(len!=17)
+	  return luaL_error( L, "wrong arg type" );
+	  os_str2macaddr(mac, macaddr);
+	  config.bssid = mac;
+	}
+	else if (sta_conf.bssid_set==1) // check if STATION is configured to connect to a specific AP's BSSID
+	{
+	   config.bssid = sta_conf.bssid;
 	}
 	else //STATION is NOT configured to connect to a specific AP
 	{
-		config.bssid = NULL;
+	  config.bssid = NULL;
 	}
 
 	config.channel=channel;


### PR DESCRIPTION
To conserve space I modified wifi_scan_done so it could be used with both wifi.sta.getap() and wifi.sta.getrssi()

The function wifi.sta.getrssi() first gets the current station configuration, then it gets the current wifi channel, then uses that information to setup a scan configuration to use with wifi_station_scan to get the AP info, then the C callback wifi_scan_done takes the RSSI value and forwards it to the users callback function.

This is complementary to my previous pull request https://github.com/nodemcu/nodemcu-firmware/pull/404