### PR TITLE
Change format of table that is output by wifi_scan_done function

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -70,8 +70,6 @@ static void wifi_scan_done(void *arg, STATUS status)
       {
         c_memcpy(ssid, bss_link->ssid, 32);
       }
-//      c_sprintf(temp,"%d,%d,"MACSTR",%d", bss_link->authmode, bss_link->rssi,
-//                 MAC2STR(bss_link->bssid),bss_link->channel);
       c_sprintf(temp,"%s,%d,%d,%d", ssid, bss_link->rssi, bss_link->authmode, bss_link->channel);
 
       lua_pushstring(gL, temp);

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -70,11 +70,13 @@ static void wifi_scan_done(void *arg, STATUS status)
       {
         c_memcpy(ssid, bss_link->ssid, 32);
       }
-      c_sprintf(temp,"%d,%d,"MACSTR",%d", bss_link->authmode, bss_link->rssi,
-                 MAC2STR(bss_link->bssid),bss_link->channel);
+//      c_sprintf(temp,"%d,%d,"MACSTR",%d", bss_link->authmode, bss_link->rssi,
+//                 MAC2STR(bss_link->bssid),bss_link->channel);
+      c_sprintf(temp,"%s,%d,%d,%d", ssid, bss_link->rssi, bss_link->authmode, bss_link->channel);
 
       lua_pushstring(gL, temp);
-      lua_setfield( gL, -2, ssid );
+      c_sprintf(temp,MACSTR, MAC2STR(bss_link->bssid));
+      lua_setfield( gL, -2,  temp);
 
       // NODE_DBG(temp);
 


### PR DESCRIPTION
The current way the function wifi_scan_done formats the output in the table (SSID : Authmode, RSSI, BSSID, Channel) drops all duplicate SSIDs be it same name or no name(hidden SSID). This pull request solves this issue by changing the format to (BSSID : SSID, RSSI, Authmode, Channel) which will prevent lua_setfield() from overwriting entries since BSSID is generally unique.