### PR TITLE
Add -Os flag to release and debug builds

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -53,11 +53,11 @@ TARGET_LDFLAGS =		\
 	--text-section-literals
 
 ifeq ($(FLAVOR),debug)
-    TARGET_LDFLAGS += -g -O2
+    TARGET_LDFLAGS += -g -Os
 endif
 
 ifeq ($(FLAVOR),release)
-    TARGET_LDFLAGS += -g -O0
+    TARGET_LDFLAGS += -Os
 endif
 
 LD_FILE = $(LDDIR)/eagle.app.v6.ld


### PR DESCRIPTION
To fit the build on boards with 512K of flash, build using the -Os flag.