### PR TITLE
Fix i2c.address range from 127 to 255 (Issue #416)

### DIFF
--- a/app/modules/i2c.c
+++ b/app/modules/i2c.c
@@ -56,7 +56,7 @@ static int i2c_address( lua_State *L )
   int direction = luaL_checkinteger( L, 3 );
 
   MOD_CHECK_ID( i2c, id );
-  if ( address < 0 || address > 127 )
+  if ( address < 0 || address > 255 )
     return luaL_error( L, "wrong arg range" );
   lua_pushboolean( L, platform_i2c_send_address( id, (u16)address, direction ) );
   return 1;


### PR DESCRIPTION
Fixed ```i2c.address``` to accept I2C addresses from 0 to 255 (previously was from 0 to 127) .
Please see if this is all need to be done to this fix.
Issue: https://github.com/nodemcu/nodemcu-firmware/issues/416