### PR TITLE
Fixed bug in wifi_scan_done (Issue #434)

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -84,7 +84,7 @@ static void wifi_scan_done(void *arg, STATUS status)
   }
   else
   {
-    lua_pushnil(gL);
+    lua_newtable( gL );
   }
   lua_call(gL, 1, 0);
   if(wifi_scan_succeed != LUA_NOREF)


### PR DESCRIPTION
If the Lua function wifi.sta.getap() is called in rapid succession, wifi_scan_done() returns a nil to the user's callback function causing a fault with the pairs() function.

To fix this this, I changed wifi_scan_done so it now returns a empty table to the function.

This bug was brought to my attention by issue #434