### PR TITLE
Added fix to adc.readvdd33() to prevent crashing in station mode 

### DIFF
--- a/app/modules/adc.c
+++ b/app/modules/adc.c
@@ -24,11 +24,23 @@ static int adc_sample( lua_State* L )
 static int adc_readvdd33( lua_State* L )
 {
   uint32_t vdd33 = 0;
-  
-  os_intr_lock();
-  vdd33 = readvdd33();
-  os_intr_unlock();
 
+  if(STATION_MODE == wifi_get_opmode())
+  {
+    // Bug fix
+	  if (wifi_station_get_connect_status()!=0)
+	  {
+        return luaL_error( L, "Can't read vdd33 while station is connected" );
+	  }
+	  else
+	  {
+		  vdd33 = readvdd33();
+	  }
+  }
+  else
+  {
+    vdd33 = readvdd33();
+  }
   lua_pushinteger(L, vdd33);
   return 1;
 }


### PR DESCRIPTION
concerning issue #433, when station is connected to an Access Point, a call to adc.readvdd33() causes a reset.
I believe this issue is either a limitation of the SDK or the esp8266ex hardware it's self.

I changed the adc.readvdd33 function to first check if the chip is in station mode and if so it will next check if the station is connected and if the station is connected it will return an error. otherwise it will read vdd33.