### PR TITLE
Crypto module improvements

### DIFF
--- a/app/crypto/digests.c
+++ b/app/crypto/digests.c
@@ -29,35 +29,43 @@
  */
 #include "digests.h"
 #include "user_config.h"
+#include "rom.h"
 #include "lwip/mem.h"
-#include "lwip/arch.h"
-#include "ssl/ssl_crypto.h"
-#include "sha2.h"
 #include <string.h>
 #include <c_errno.h>
+
+#ifdef MD2_ENABLE
+#include "ssl/ssl_crypto.h"
+#endif
+
+#ifdef SHA2_ENABLE
+#include "sha2.h"
+#endif
 
 typedef char ensure_int_and_size_t_same[(sizeof(int)==sizeof(size_t)) ? 0 : -1];
 
 /* None of the functions match the prototype fully due to the void *, and in
    some cases also the int vs size_t len, so wrap declarations in a macro. */
-#define MECH(pfx, ds, bs) \
+#define MECH(pfx, u, ds, bs) \
   { #pfx, \
-    (create_ctx_fn)pfx ## _Init, \
-    (update_ctx_fn)pfx ## _Update, \
-    (finalize_ctx_fn)pfx ## _Final, \
+    (create_ctx_fn)pfx ## u ## Init, \
+    (update_ctx_fn)pfx ## u ## Update, \
+    (finalize_ctx_fn)pfx ## u ## Final, \
     sizeof(pfx ## _CTX), \
     ds, \
     bs }
 
 static const digest_mech_info_t hash_mechs[] =
 {
-   MECH(MD2,  MD2_SIZE,  16)
-  ,MECH(MD5,  MD5_SIZE,  64)
-  ,MECH(SHA1, SHA1_SIZE, 64)
+#ifdef MD2_ENABLE
+   MECH(MD2, _ , MD2_SIZE,  16),
+#endif
+   MECH(MD5,   , MD5_DIGEST_LENGTH,  64)
+  ,MECH(SHA1,  , SHA1_DIGEST_LENGTH, 64)
 #ifdef SHA2_ENABLE
-  ,MECH(SHA256, SHA256_DIGEST_LENGTH, SHA256_BLOCK_LENGTH)
-  ,MECH(SHA384, SHA384_DIGEST_LENGTH, SHA384_BLOCK_LENGTH)
-  ,MECH(SHA512, SHA512_DIGEST_LENGTH, SHA512_BLOCK_LENGTH)
+  ,MECH(SHA256, _ , SHA256_DIGEST_LENGTH, SHA256_BLOCK_LENGTH)
+  ,MECH(SHA384, _ , SHA384_DIGEST_LENGTH, SHA384_BLOCK_LENGTH)
+  ,MECH(SHA512, _ , SHA512_DIGEST_LENGTH, SHA512_BLOCK_LENGTH)
 #endif
 };
 

--- a/app/crypto/digests.c
+++ b/app/crypto/digests.c
@@ -55,7 +55,7 @@ typedef char ensure_int_and_size_t_same[(sizeof(int)==sizeof(size_t)) ? 0 : -1];
     ds, \
     bs }
 
-static const digest_mech_info_t hash_mechs[] =
+static const digest_mech_info_t hash_mechs[] ICACHE_RODATA_ATTR =
 {
 #ifdef MD2_ENABLE
    MECH(MD2, _ , MD2_SIZE,  16),
@@ -71,7 +71,7 @@ static const digest_mech_info_t hash_mechs[] =
 
 #undef MECH
 
-const digest_mech_info_t *crypto_digest_mech (const char *mech)
+const digest_mech_info_t *ICACHE_FLASH_ATTR crypto_digest_mech (const char *mech)
 {
   if (!mech)
     return 0;
@@ -86,28 +86,22 @@ const digest_mech_info_t *crypto_digest_mech (const char *mech)
   return 0;
 }
 
-static const char hex[] = "0123456789abcdef";
+const char crypto_hexbytes[] = "0123456789abcdef";
+
 // note: supports in-place encoding
-void crypto_encode_asciihex (const char *bin, size_t binlen, char *outbuf)
+void ICACHE_FLASH_ATTR crypto_encode_asciihex (const char *bin, size_t binlen, char *outbuf)
 {
   size_t aidx = binlen * 2 -1;
   int i;
   for (i = binlen -1; i >= 0; --i)
   {
-    outbuf[aidx--] = hex[bin[i] & 0xf];
-    outbuf[aidx--] = hex[bin[i] >>  4];
+    outbuf[aidx--] = crypto_hexbytes[bin[i] & 0xf];
+    outbuf[aidx--] = crypto_hexbytes[bin[i] >>  4];
   }
 }
 
 
-size_t crypto_digest_size (const char *mech)
-{
-  const digest_mech_info_t *mi = crypto_digest_mech (mech);
-  return mi ? mi->digest_size : 0;
-}
-
-
-int crypto_hash (const digest_mech_info_t *mi,
+int ICACHE_FLASH_ATTR crypto_hash (const digest_mech_info_t *mi,
   const char *data, size_t data_len,
   uint8_t *digest)
 {
@@ -127,7 +121,7 @@ int crypto_hash (const digest_mech_info_t *mi,
 }
 
 
-int crypto_hmac (const digest_mech_info_t *mi,
+int ICACHE_FLASH_ATTR crypto_hmac (const digest_mech_info_t *mi,
    const char *data, size_t data_len,
    const char *key, size_t key_len,
    uint8_t *digest)

--- a/app/crypto/digests.h
+++ b/app/crypto/digests.h
@@ -24,13 +24,14 @@ typedef void (*finalize_ctx_fn)(uint8_t *digest, void *ctx);
  */
 typedef struct
 {
+  /* Note: All entries are 32bit to enable placement using ICACHE_RODATA_ATTR.*/
   const char *    name;
   create_ctx_fn   create;
   update_ctx_fn   update;
   finalize_ctx_fn finalize;
-  uint16_t        ctx_size;
-  uint16_t        digest_size;
-  uint16_t        block_size;
+  uint32_t        ctx_size;
+  uint32_t        digest_size;
+  uint32_t        block_size;
 } digest_mech_info_t;
 
 
@@ -77,5 +78,8 @@ int crypto_hmac (const digest_mech_info_t *mi, const char *data, size_t data_len
  */
 void crypto_encode_asciihex (const char *bin, size_t bin_len, char *outbuf);
 
+
+/** Text string "0123456789abcdef" */
+const char crypto_hexbytes[17];
 
 #endif

--- a/app/crypto/sha2.c
+++ b/app/crypto/sha2.c
@@ -172,7 +172,7 @@ void SHA512_Transform(SHA512_CTX*, const sha2_word64*);
 
 /*** SHA-XYZ INITIAL HASH VALUES AND CONSTANTS ************************/
 /* Hash constant words K for SHA-256: */
-const static sha2_word32 K256[64] = {
+const static sha2_word32 K256[64] ICACHE_RODATA_ATTR = {
 	0x428a2f98UL, 0x71374491UL, 0xb5c0fbcfUL, 0xe9b5dba5UL,
 	0x3956c25bUL, 0x59f111f1UL, 0x923f82a4UL, 0xab1c5ed5UL,
 	0xd807aa98UL, 0x12835b01UL, 0x243185beUL, 0x550c7dc3UL,
@@ -192,7 +192,7 @@ const static sha2_word32 K256[64] = {
 };
 
 /* Initial hash value H for SHA-256: */
-const static sha2_word32 sha256_initial_hash_value[8] = {
+const static sha2_word32 sha256_initial_hash_value[8] ICACHE_RODATA_ATTR = {
 	0x6a09e667UL,
 	0xbb67ae85UL,
 	0x3c6ef372UL,
@@ -204,7 +204,7 @@ const static sha2_word32 sha256_initial_hash_value[8] = {
 };
 
 /* Hash constant words K for SHA-384 and SHA-512: */
-const static sha2_word64 K512[80] = {
+const static sha2_word64 K512[80] ICACHE_RODATA_ATTR = {
 	0x428a2f98d728ae22ULL, 0x7137449123ef65cdULL,
 	0xb5c0fbcfec4d3b2fULL, 0xe9b5dba58189dbbcULL,
 	0x3956c25bf348b538ULL, 0x59f111f1b605d019ULL,
@@ -248,7 +248,7 @@ const static sha2_word64 K512[80] = {
 };
 
 /* Initial hash value H for SHA-384 */
-const static sha2_word64 sha384_initial_hash_value[8] = {
+const static sha2_word64 sha384_initial_hash_value[8] ICACHE_RODATA_ATTR = {
 	0xcbbb9d5dc1059ed8ULL,
 	0x629a292a367cd507ULL,
 	0x9159015a3070dd17ULL,
@@ -260,7 +260,7 @@ const static sha2_word64 sha384_initial_hash_value[8] = {
 };
 
 /* Initial hash value H for SHA-512 */
-const static sha2_word64 sha512_initial_hash_value[8] = {
+const static sha2_word64 sha512_initial_hash_value[8] ICACHE_RODATA_ATTR = {
 	0x6a09e667f3bcc908ULL,
 	0xbb67ae8584caa73bULL,
 	0x3c6ef372fe94f82bULL,

--- a/app/include/rom.h
+++ b/app/include/rom.h
@@ -15,6 +15,20 @@ extern void SHA1Init(SHA1_CTX *);
 extern void SHA1Final(uint8_t[SHA1_DIGEST_LENGTH], SHA1_CTX *);
 extern void SHA1Update(SHA1_CTX *, const uint8_t *, unsigned int);
 
+
+// MD5 is assumed to match the NetBSD md5.h header
+#define MD5_DIGEST_LENGTH		16
+typedef struct
+{
+  uint32_t state[5];
+  uint32_t count[2];
+  uint8_t buffer[64];
+} MD5_CTX;
+
+extern void MD5Init(MD5_CTX *);
+extern void MD5Update(MD5_CTX *, const unsigned char *, unsigned int);
+extern void MD5Final(unsigned char[MD5_DIGEST_LENGTH], MD5_CTX *);
+
 // base64_encode/decode derived by Cal
 // Appears to match base64.h from netbsd wpa utils.
 extern unsigned char * base64_encode(const unsigned char *src, size_t len, size_t *out_len);

--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -41,6 +41,7 @@
 
 #define CLIENT_SSL_ENABLE
 #define GPIO_INTERRUPT_ENABLE
+//#define MD2_ENABLE
 #define SHA2_ENABLE
 
 // #define BUILD_WOFS		1

--- a/app/modules/crypto.c
+++ b/app/modules/crypto.c
@@ -65,7 +65,6 @@ static int crypto_base64_encode( lua_State* L )
   return 1;
 }
 
-static const char* byteshex = "0123456789abcdef";
 /**
   * encoded = crypto.toHex(raw)
   *
@@ -78,8 +77,8 @@ static int crypto_hex_encode( lua_State* L)
   char* out = (char*)c_malloc(len * 2);
   int i, j = 0;
   for (i = 0; i < len; i++) {
-    out[j++] = byteshex[msg[i] >> 4];
-    out[j++] = byteshex[msg[i] & 0xf];
+    out[j++] = crypto_hexbytes[msg[i] >> 4];
+    out[j++] = crypto_hexbytes[msg[i] & 0xf];
   }
   lua_pushlstring(L, out, len*2);
   c_free(out);


### PR DESCRIPTION
As per discussion over on https://github.com/nodemcu/nodemcu-firmware/pull/462 I've updated the crypto module to use the ROM MD5 & SHA1 functions instead of the libssl versions. Prototypes for the MD5 functions have been added to rom.h.

Additionally most of the static const data used by this module has been relocated to irom0.text in order to free up precious RAM.