### PR TITLE
Unify memory section usage for u8g

### DIFF
--- a/app/u8glib/u8g.h
+++ b/app/u8glib/u8g.h
@@ -88,7 +88,7 @@ extern "C" {
 #    define U8G_FONT_SECTION(name) U8G_SECTION(".progmem." name)
 #  endif
 #  if defined(__XTENSA__)
-#    define U8G_FONT_SECTION(name) U8G_SECTION(".u8g_progmem." name)
+#    define U8G_FONT_SECTION(name)
 #  endif
 #else
 #  define U8G_NOINLINE
@@ -116,10 +116,10 @@ typedef uint8_t u8g_fntpgm_uint8_t;
 
 #elif defined(__XTENSA__)
 #  define U8G_PROGMEM
-#  define PROGMEM U8G_SECTION(".u8g_progmem.data")
+#  define PROGMEM
    typedef uint8_t u8g_pgm_uint8_t;
    typedef uint8_t u8g_fntpgm_uint8_t;
-   u8g_pgm_uint8_t u8g_pgm_read(const u8g_pgm_uint8_t *adr);
+#  define u8g_pgm_read(adr) (*(const u8g_pgm_uint8_t *)(adr)) 
 #  define U8G_PSTR(s) ((u8g_pgm_uint8_t *)(s))
 
 #else

--- a/ld/eagle.app.v6.ld
+++ b/ld/eagle.app.v6.ld
@@ -72,9 +72,6 @@ SECTIONS
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
     *(.literal.* .text.*)
 
-    /* put font and progmem data into irom0 */
-    *(.u8g_progmem.*)
-
     /* Trade some performance for lots of ram. At the time of writing the
      * available Lua heap went from 18248 to 34704. */
     *(.rodata*)


### PR DESCRIPTION
This update to u8g unifies the memory section layout based on the irom0 support by @jmattsson #504.
There is no need anymore to handle the large constants of font_data etc. separately with a dedicated read-from-flash function.