### PR TITLE
Unbreak AP mode after rodata changes

### DIFF
--- a/app/lwip/app/dhcpserver.c
+++ b/app/lwip/app/dhcpserver.c
@@ -13,7 +13,7 @@
 #include "user_interface.h"
 
 ////////////////////////////////////////////////////////////////////////////////////
-static const uint8_t xid[4] = {0xad, 0xde, 0x12, 0x23};
+static uint8_t xid[4] = {0xad, 0xde, 0x12, 0x23};
 static u8_t old_xid[4] = {0};
 static const uint8_t magic_cookie[4] = {99, 130, 83, 99};
 static struct udp_pcb *pcb_dhcps = NULL;


### PR DESCRIPTION
This fixes the problem where nodeMCU crashes when in SOFTAP/STATIONAP mode after the changes to the rodata sections.

Turns out the dhcpserver code was os_memcpy()ing into a const array...