### PR TITLE
Expose boot reason in Lua

### DIFF
--- a/app/include/rom.h
+++ b/app/include/rom.h
@@ -39,6 +39,9 @@ extern unsigned char * base64_decode(const unsigned char *src, size_t len, size_
 extern void mem_init(void * start_addr);
 
 
+// 2, 3 = reset (module dependent?), 4 = wdt
+int rtc_get_reset_reason (void);
+
 // Hardware exception handling
 struct exception_frame
 {

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -414,6 +414,13 @@ static int node_setcpufreq(lua_State* L)
   return 1;
 }
 
+// Lua: code = bootreason()
+static int node_bootreason (lua_State *L)
+{
+  lua_pushnumber (L, rtc_get_reset_reason ());
+  return 1;
+}
+
 // Module function map
 #define MIN_OPT_LEVEL 2
 #include "lrodefs.h"
@@ -438,6 +445,7 @@ const LUA_REG_TYPE node_map[] =
   { LSTRKEY( "CPU80MHZ" ), LNUMVAL( CPU80MHZ ) },
   { LSTRKEY( "CPU160MHZ" ), LNUMVAL( CPU160MHZ ) },
   { LSTRKEY( "setcpufreq" ), LFUNCVAL( node_setcpufreq) },
+  { LSTRKEY( "bootreason" ), LFUNCVAL( node_bootreason) },
 // Combined to dsleep(us, option)
 // { LSTRKEY( "dsleepsetoption" ), LFUNCVAL( node_deepsleep_setoption) },
 #if LUA_OPTIMIZE_MEMORY > 0


### PR DESCRIPTION
Since someone was asking for this over in #442 and I happen to know how to get it, here is a small patch to provide a node.bootreason() function.