### PR TITLE
Workaround write-protected flash when using esptool.py to flash in DIO mode

### DIFF
--- a/tools/esptool.py
+++ b/tools/esptool.py
@@ -262,6 +262,15 @@ class ESPROM:
 
         return data
 
+    """ Abuse the loader protocol to force flash to be left in write mode """
+    def flash_unlock_dio(self):
+        # Enable flash write mode
+        self.flash_begin(0, 0)
+        # Reset the chip rather than call flash_finish(), which would have
+        # write protected the chip again (why oh why does it do that?!)
+        self.mem_begin(0,0,0,0x40100000)
+        self.mem_finish(0x40000080)
+
     """ Perform a chip erase of SPI flash """
     def flash_erase(self):
         # Trick ROM to initialize SFlash
@@ -560,7 +569,10 @@ if __name__ == '__main__':
                 seq += 1
             print
         print '\nLeaving...'
-        esp.flash_finish(False)
+        if args.flash_mode == 'dio':
+            esp.flash_unlock_dio()
+        else:
+            esp.flash_finish(False)
 
     elif args.operation == 'run':
         esp.run()

--- a/tools/esptool.py
+++ b/tools/esptool.py
@@ -128,38 +128,32 @@ class ESPROM:
     def connect(self):
         print 'Connecting...'
 
-        # RTS = CH_PD (i.e reset)
-        # DTR = GPIO0
-        # self._port.setRTS(True)
-        # self._port.setDTR(True)
-        # self._port.setRTS(False)
-        # time.sleep(0.1)
-        # self._port.setDTR(False)
+        for _ in xrange(4):
+            # issue reset-to-bootloader:
+            # RTS = either CH_PD or nRESET (both active low = chip in reset)
+            # DTR = GPIO0 (active low = boot to flasher)
+            self._port.setDTR(False)
+            self._port.setRTS(True)
+            time.sleep(0.05)
+            self._port.setDTR(True)
+            self._port.setRTS(False)
+            time.sleep(0.05)
+            self._port.setDTR(False)
 
-        # NodeMCU devkit
-        self._port.setRTS(True)
-        self._port.setDTR(True)
-        time.sleep(0.1)
-        self._port.setRTS(False)
-        self._port.setDTR(False)
-        time.sleep(0.1)
-        self._port.setRTS(True)
-        time.sleep(0.1)
-        self._port.setDTR(True)
-        self._port.setRTS(False)
-        time.sleep(0.3)
-        self._port.setDTR(True)
-
-        self._port.timeout = 0.5
-        for i in xrange(10):
-            try:
-                self._port.flushInput()
-                self._port.flushOutput()
-                self.sync()
-                self._port.timeout = 5
-                return
-            except:
-                time.sleep(0.1)
+            self._port.timeout = 0.3 # worst-case latency timer should be 255ms (probably <20ms)
+            for _ in xrange(4):
+                try:
+                    self._port.flushInput()
+                    self._port.flushOutput()
+                    self.sync()
+                    self._port.timeout = 5
+                    return
+                except:
+                    time.sleep(0.05)
+            # this is a workaround for the CH340 serial driver on current versions of Linux,
+            # which seems to sometimes set the serial port up with wrong parameters
+            self._port.close()
+            self._port.open()
         raise Exception('Failed to connect')
 
     """ Read memory address in target """


### PR DESCRIPTION
When flashing an ESP-12 or ESP-12E in DIO mode using esptool.py, the nodemcu spiffs filesystem ends up unwriteable. Given that the ESP-12E *has* to be flashed in DIO mode, that is Not Good(tm).

For whatever reason, when flashing in DIO mode the ROM'd bootloader write-protects the flash at the end of the flash programming. In DIO mode the SPI status register has 0x1c written to it, which effectively write-protects the entire chip. This part of the register is non-volatile(!), so whatever the bootloader leaves in there, stays. Before booting the user application, the status register also gets locked, making it impossible to change this part of the status register in a user application. Meanwhile, if programming an image in QIO mode, the SPI status register has 0x00 written to it, meaning it is not write protected.

To work around this write-protect issue, it appears necessary to **not** instruct the bootloader that we have finished the flash programming, as it is during this step that the flash ends up write protected. The nodemcu-flasher and the Expressif ESP Flash Download Tool both use this approach (though perhaps accidentally so - the block count value seemed rather strange), and with the changes on this branch, the esptool.py also does it (but only for DIO mode).

We did try to load a RAM routine via the bootloader, to call SPI_write_status() after finishing the flash programming, but we had no luck in clearing the status register this way. It would appear some addition setup is required in order for SPI_write_status() to work. If someone wants to investigate that further they're most welcome to, as it would be a considerably cleaner approach...


I also pulled in some changes from upstream esptool.py that makes it capable of more reliably getting the nodemcu devkit boards (both 0.9 and 1.0) into programming mode automatically.


Final thought: This was a royal P.I.T.A. to track down the underlying cause of - we've spent two days chasing this. What were Expressif thinking when they made DIO mode write protect the flash?!