### PR TITLE
Fixed RAM_CONST_ATTR macro.

### DIFF
--- a/include/c_types.h
+++ b/include/c_types.h
@@ -85,7 +85,7 @@ typedef enum {
 #endif /* ICACHE_FLASH */
 
 #define TEXT_SECTION_ATTR __attribute__((section(".text")))
-#define RAM_CONST_ATTR __attribute__((section(".text")))
+#define RAM_CONST_ATTR __attribute__((section(".rodata")))
 
 #ifndef __cplusplus
 typedef unsigned char   bool;


### PR DESCRIPTION
It needs to point to the .rodata section, not the .text. While both reside in RAM, the .text goes into iram rather than dram and as such would still incur the overhead of the exception handler.

Thanks to @fabianhu for spotting this one.