### PR TITLE
Declare wifi.ap.getconfig() in the right map.

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1105,7 +1105,6 @@ static const LUA_REG_TYPE wifi_station_map[] =
   { LSTRKEY( "connect" ), LFUNCVAL ( wifi_station_connect4lua ) },
   { LSTRKEY( "disconnect" ), LFUNCVAL ( wifi_station_disconnect4lua ) },
   { LSTRKEY( "autoconnect" ), LFUNCVAL ( wifi_station_setauto ) },
-  { LSTRKEY( "getconfig" ), LFUNCVAL( wifi_ap_getconfig ) },
   { LSTRKEY( "getip" ), LFUNCVAL ( wifi_station_getip ) },
   { LSTRKEY( "setip" ), LFUNCVAL ( wifi_station_setip ) },
   { LSTRKEY( "getbroadcast" ), LFUNCVAL ( wifi_station_getbroadcast) },
@@ -1133,6 +1132,7 @@ static const LUA_REG_TYPE wifi_ap_map[] =
   { LSTRKEY( "getmac" ), LFUNCVAL ( wifi_ap_getmac ) },
   { LSTRKEY( "setmac" ), LFUNCVAL ( wifi_ap_setmac ) },
   { LSTRKEY( "getclient" ), LFUNCVAL ( wifi_ap_listclient ) },
+  { LSTRKEY( "getconfig" ), LFUNCVAL( wifi_ap_getconfig ) },
 #if LUA_OPTIMIZE_MEMORY > 0
   { LSTRKEY( "dhcp" ), LROVAL( wifi_ap_dhcp_map ) },
 


### PR DESCRIPTION
The wifi.ap.getconfig() command isn't available, even though there are functions for it, since it's registered in the wifi.sta table (and is being hidden by the actual wifi.sta.getconfig()). This patch fixes that.