### PR TITLE
wifi station connection event monitor

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -17,6 +17,12 @@
 
 static int wifi_smart_succeed = LUA_NOREF;
 static uint8 getap_output_format=0;
+//variables for wifi event monitor
+static sint32_t wifi_status_cb_ref[6] = {LUA_NOREF,LUA_NOREF,LUA_NOREF,LUA_NOREF,LUA_NOREF,LUA_NOREF};
+static volatile os_timer_t wifi_sta_status_timer;
+static uint8 prev_wifi_status=0;
+
+
 #if defined( NODE_SMART_OLDSTYLE )
 #else
 static lua_State* smart_L = NULL;
@@ -852,6 +858,166 @@ static int wifi_station_status( lua_State* L )
   return 1; 
 }
 
+static void wifi_status_cb(int arg)
+{
+  int wifi_status=wifi_station_get_connect_status();
+  if (wifi_status!=prev_wifi_status)
+  {
+ 	if(wifi_status_cb_ref[wifi_status]!=LUA_NOREF)
+ 	{
+	  lua_rawgeti(gL, LUA_REGISTRYINDEX, wifi_status_cb_ref[wifi_status]);
+	  lua_call(gL, 0, 0);
+ 	}
+  }
+  prev_wifi_status=wifi_status;
+}
+
+/**
+  * wifi.sta.eventMonReg()
+  * Description:
+  * 	Register callback for wifi station status event
+  * Syntax:
+  * 	wifi.sta.eventMonReg(wifi_status, function)
+  * 	wifi.sta.eventMonReg(wifi.status, "unreg") //unregister callback
+  * Parameters:
+  * 	wifi_status: wifi status you would like to set callback for
+  * 		Valid wifi states:
+   				wifi.STA_IDLE
+  				wifi.STA_CONNECTING
+  				wifi.STA_WRONGPWD
+				wifi.STA_APNOTFOUND
+  				wifi.STA_FAIL
+  				wifi.STA_GOTIP
+  * 	function: function to perform
+  * 	"unreg": unregister previously registered function
+  * Returns:
+  * 	Nothing.
+  *
+  *	Example:
+  	  	--register callback
+  	  	wifi.sta.eventMonReg(0, function() print("STATION_IDLE") end)
+		wifi.sta.eventMonReg(1, function() print("STATION_CONNECTING") end)
+		wifi.sta.eventMonReg(2, function() print("STATION_WRONG_PASSWORD") end)
+		wifi.sta.eventMonReg(3, function() print("STATION_NO_AP_FOUND") end)
+		wifi.sta.eventMonReg(4, function() print("STATION_CONNECT_FAIL") end)
+		wifi.sta.eventMonReg(5, function() print("STATION_GOT_IP") end)
+
+		--unregister callback
+		wifi.sta.eventMonReg(0, "unreg")
+  */
+static int wifi_station_event_mon_reg(lua_State* L)
+{
+  gL=L;
+  uint8 id=luaL_checknumber(L, 1);
+  if (!(id >= 0 && id <=5))
+  {
+	return luaL_error( L, "valid wifi status:0-5" );
+  }
+
+  if (lua_type(L, 2) == LUA_TFUNCTION || lua_type(L, 2) == LUA_TLIGHTFUNCTION)
+  {
+    lua_pushvalue(L, 2);  // copy argument (func) to the top of stack
+    if(wifi_status_cb_ref[id] != LUA_NOREF)
+    {
+      luaL_unref(L, LUA_REGISTRYINDEX, wifi_status_cb_ref[id]);
+    }
+    wifi_status_cb_ref[id] = luaL_ref(L, LUA_REGISTRYINDEX);
+  }
+  else if (c_strcmp(luaL_checkstring(L, 2), "unreg")==0)
+  {
+    if(wifi_status_cb_ref[id] != LUA_NOREF)
+    {
+      luaL_unref(L, LUA_REGISTRYINDEX, wifi_status_cb_ref[id]);
+      wifi_status_cb_ref[id] = LUA_NOREF;
+    }
+  }
+  return 0;
+}
+
+
+/**
+  * wifi.sta.eventMonStart()
+  * Description:
+  * 	Start wifi station event monitor
+  * Syntax:
+  * 	wifi.sta.eventMonStart()
+  * 	wifi.sta.eventMonStart(mS)
+  * Parameters:
+  * 	mS:interval between checks in milliseconds. defaults to 150 mS if not provided
+  * Returns:
+  * 	Nothing.
+  *
+  *	Example:
+ 		--start wifi event monitor with default interval
+ 		wifi.sta.eventMonStart()
+
+ 		--start wifi event monitor with 100 mS interval
+ 		wifi.sta.eventMonStart(100)
+  */
+static int wifi_station_event_mon_start(lua_State* L)
+{
+  if(wifi_get_opmode() == SOFTAP_MODE)
+  {
+	return luaL_error( L, "Can't monitor station in SOFTAP mode" );
+  }
+  if (wifi_status_cb_ref[0]==LUA_NOREF && wifi_status_cb_ref[1]==LUA_NOREF &&
+		  wifi_status_cb_ref[2]==LUA_NOREF && wifi_status_cb_ref[3]==LUA_NOREF &&
+		  wifi_status_cb_ref[4]==LUA_NOREF && wifi_status_cb_ref[5]==LUA_NOREF )
+  {
+		return luaL_error( L, "No callbacks defined" );
+  }
+  uint32 ms=150;
+  if(lua_isnumber(L, 1))
+  {
+    ms=luaL_checknumber(L, 1);
+  }
+
+  os_timer_disarm(&wifi_sta_status_timer);
+  os_timer_setfn(&wifi_sta_status_timer, (os_timer_func_t *)wifi_status_cb, NULL);
+  os_timer_arm(&wifi_sta_status_timer, ms, 1);
+  return 0;
+}
+
+/**
+  * wifi.sta.eventMonStart()
+  * Description:
+  * 	Stop wifi station event monitor
+  * Syntax:
+  * 	wifi.sta.eventMonStop()
+  * 	wifi.sta.eventMonStop("unreg all")
+  * Parameters:
+  * 	"unreg all": unregister all previously registered functions
+  * Returns:
+  * 	Nothing.
+  *
+  *	Example:
+  	  	  --stop wifi event monitor
+  	  	  wifi.sta.eventMonStop()
+
+  	  	  --stop wifi event monitor and unregister all callbacks
+  	  	  wifi.sta.eventMonStop("unreg all")
+  */
+static void wifi_station_event_mon_stop(lua_State* L)
+{
+  os_timer_disarm(&wifi_sta_status_timer);
+  if(lua_isstring(L,1))
+  {
+
+    if (c_strcmp(luaL_checkstring(L, 1), "unreg all")==0)
+    {
+	  int i;
+	  for (i=0;i<6;i++)
+  	  {
+  	    if(wifi_status_cb_ref[i] != LUA_NOREF)
+	    {
+		  luaL_unref(L, LUA_REGISTRYINDEX, wifi_status_cb_ref[i]);
+		  wifi_status_cb_ref[i] = LUA_NOREF;
+	    }
+	  }
+    }
+  }
+}
+
 // Lua: wifi.ap.getmac()
 static int wifi_ap_getmac( lua_State* L ){
   return wifi_getmac(L, SOFTAP_IF);
@@ -1113,6 +1279,9 @@ static const LUA_REG_TYPE wifi_station_map[] =
   { LSTRKEY( "setmac" ), LFUNCVAL ( wifi_station_setmac ) },
   { LSTRKEY( "getap" ), LFUNCVAL ( wifi_station_listap ) },
   { LSTRKEY( "status" ), LFUNCVAL ( wifi_station_status ) },
+  { LSTRKEY( "eventMonReg" ), LFUNCVAL ( wifi_station_event_mon_reg ) },
+  { LSTRKEY( "eventMonStart" ), LFUNCVAL ( wifi_station_event_mon_start ) },
+  { LSTRKEY( "eventMonStop" ), LFUNCVAL ( wifi_station_event_mon_stop ) },
   { LNILKEY, LNILVAL }
 };
 
@@ -1174,12 +1343,12 @@ const LUA_REG_TYPE wifi_map[] =
   { LSTRKEY( "WPA2_PSK" ), LNUMVAL( AUTH_WPA2_PSK ) },
   { LSTRKEY( "WPA_WPA2_PSK" ), LNUMVAL( AUTH_WPA_WPA2_PSK ) },
 
-  // { LSTRKEY( "STA_IDLE" ), LNUMVAL( STATION_IDLE ) },
-  // { LSTRKEY( "STA_CONNECTING" ), LNUMVAL( STATION_CONNECTING ) },
-  // { LSTRKEY( "STA_WRONGPWD" ), LNUMVAL( STATION_WRONG_PASSWORD ) },
-  // { LSTRKEY( "STA_APNOTFOUND" ), LNUMVAL( STATION_NO_AP_FOUND ) },
-  // { LSTRKEY( "STA_FAIL" ), LNUMVAL( STATION_CONNECT_FAIL ) },
-  // { LSTRKEY( "STA_GOTIP" ), LNUMVAL( STATION_GOT_IP ) },
+   { LSTRKEY( "STA_IDLE" ), LNUMVAL( STATION_IDLE ) },
+   { LSTRKEY( "STA_CONNECTING" ), LNUMVAL( STATION_CONNECTING ) },
+   { LSTRKEY( "STA_WRONGPWD" ), LNUMVAL( STATION_WRONG_PASSWORD ) },
+   { LSTRKEY( "STA_APNOTFOUND" ), LNUMVAL( STATION_NO_AP_FOUND ) },
+   { LSTRKEY( "STA_FAIL" ), LNUMVAL( STATION_CONNECT_FAIL ) },
+   { LSTRKEY( "STA_GOTIP" ), LNUMVAL( STATION_GOT_IP ) },
 
   { LSTRKEY( "__metatable" ), LROVAL( wifi_map ) },
 #endif


### PR DESCRIPTION
The event monitor watches the station's connection state, executing a user callback when the connection state changes.

If anybody has any suggestions for changes(function name, default interval, etc.) or any questions please feel free to comment comments.

CONTRIBUTORS: Before merging, please allow a few days for others to comment.

This is also a fix for issue #173 

Here are the functions to be added:

## wifi.sta.eventMonReg()
#### Description
  Register callback for wifi station status event
#### Syntax
  wifi.sta.eventMonReg(wifi_status, function)
  wifi.sta.eventMonReg(wifi.status, "unreg")
#### Parameters
- wifi_status: wifi status you would like to set callback for
  - Valid wifi states:
    - wifi.STA_IDLE
    - wifi.STA_CONNECTING
    - wifi.STA_WRONGPWD
    - wifi.STA_APNOTFOUND
    - wifi.STA_FAIL
    - wifi.STA_GOTIP
- function: function to perform when event occurs
- "unreg": unregister previously registered callback

#### Returns
Nothing.
#### Example
```lua 
  --register callback
  wifi.sta.eventMonReg(wifi.STA_IDLE, function() print("STATION_IDLE") end)
  wifi.sta.eventMonReg(wifi.STA_CONNECTING, function() print("STATION_CONNECTING") end)
  wifi.sta.eventMonReg(wifi.STA_WRONGPWD, function() print("STATION_WRONG_PASSWORD") end)
  wifi.sta.eventMonReg(wifi.STA_APNOTFOUND, function() print("STATION_NO_AP_FOUND") end)
  wifi.sta.eventMonReg(wifi.STA_FAIL, function() print("STATION_CONNECT_FAIL") end)
  wifi.sta.eventMonReg(wifi.STA_GOTIP, function() print("STATION_GOT_IP") end)
  
  --unregister callback
  wifi.sta.eventMonReg(0, "unreg")
```

## wifi.sta.eventMonStart()
#### Description
Start wifi station event monitor
#### Syntax
 wifi.sta.eventMonStart()
 wifi.sta.eventMonStart(ms)

### Parameters
- ms: interval between checks in milliseconds. defaults to 150 ms if not provided.

#### Returns
  Nothing.

#### Example
```lua
  --start wifi event monitor with default interval
  wifi.sta.eventMonStart()

  --start wifi event monitor with 100 ms interval
  wifi.sta.eventMonStart(100)
```

## wifi.sta.eventMonStop()
#### Description
Stop wifi station event monitor
#### Syntax
wifi.sta.eventMonStop()
wifi.sta.eventMonStop("unreg all")

#### Parameters
- "unreg all": unregister all previously registered functions

#### Returns
Nothing.
#### Example
```lua
  --stop wifi event monitor
  wifi.sta.eventMonStop()

  --stop wifi event monitor and unregister all callbacks
  wifi.sta.eventMonStop("unreg all")
```