### PR TITLE
wifi event monitor update

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -901,12 +901,12 @@ static void wifi_station_event_mon_stop(lua_State* L)
 
 static void wifi_status_cb(int arg)
 {
-  if (wifi_get_opmode()==2)
+  int wifi_status=wifi_station_get_connect_status();
+  if (wifi_status==255)
   {
 	  os_timer_disarm(&wifi_sta_status_timer);
 	  return;
   }
-  int wifi_status=wifi_station_get_connect_status();
   if (wifi_status!=prev_wifi_status)
   {
  	if(wifi_status_cb_ref[wifi_status]!=LUA_NOREF)

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -911,8 +911,9 @@ static void wifi_status_cb(int arg)
   {
  	if(wifi_status_cb_ref[wifi_status]!=LUA_NOREF)
  	{
-	  lua_rawgeti(gL, LUA_REGISTRYINDEX, wifi_status_cb_ref[wifi_status]);
-	  lua_call(gL, 0, 0);
+ 	  lua_rawgeti(gL, LUA_REGISTRYINDEX, wifi_status_cb_ref[wifi_status]);
+	  lua_pushnumber(gL, prev_wifi_status);
+	  lua_call(gL, 1, 0);
  	}
   }
   prev_wifi_status=wifi_status;


### PR DESCRIPTION
First commit:
I discovered that when the wifi opmode is set to softap, wifi_station_get_connect_status() returns 255, so I altered the callback to use the wifi status value to determine if esp8266 is in softap mode or not, instead of using wifi_get_opmode() to determine opmode. all of which leads to faster execution of the callback.


Second Commit:
In writing my Lua scripts I determined that I needed to know the previous wifi state, so I added code to return the previous wifi state to the user's callback.

Example: 
```lua
wifi.sta.eventMonReg(wifi.STA_APNOTFOUND, function(X)
  print("STATION_NO_AP_FOUND\tPrevious wifi state was "..X)
end)

```


@vowstar should I be submitting this PR to dev instead of dev096?