### PR TITLE
Updated SPIFFS to 0.3.2.

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -110,7 +110,7 @@ static int file_seek (lua_State *L)
   int op = luaL_checkoption(L, 1, "cur", modenames);
   long offset = luaL_optlong(L, 2, 0);
   op = fs_seek(file_fd, offset, mode[op]);
-  if (op)
+  if (op < 0)
     lua_pushnil(L);  /* error */
   else
     lua_pushinteger(L, fs_tell(file_fd));

--- a/app/spiffs/spiffs_cache.c
+++ b/app/spiffs/spiffs_cache.c
@@ -195,7 +195,7 @@ s32_t spiffs_phys_wr(
     cache->last_access++;
     cp->last_access = cache->last_access;
 
-    if (cp->flags && SPIFFS_CACHE_FLAG_WRTHRU) {
+    if (cp->flags & SPIFFS_CACHE_FLAG_WRTHRU) {
       // page is being updated, no write-cache, just pass thru
       return fs->cfg.hal_write_f(addr, len, src);
     } else {

--- a/app/spiffs/spiffs_config.h
+++ b/app/spiffs/spiffs_config.h
@@ -119,6 +119,14 @@ typedef uint8_t u8_t;
 #define SPIFFS_COPY_BUFFER_STACK        (64)
 #endif
 
+// Enable this to have an identifiable spiffs filesystem. This will look for
+// a magic in all sectors to determine if this is a valid spiffs system or
+// not on mount point. If not, SPIFFS_format must be called prior to mounting
+// again.
+#ifndef SPIFFS_USE_MAGIC
+#define SPIFFS_USE_MAGIC                (0)
+#endif
+
 // SPIFFS_LOCK and SPIFFS_UNLOCK protects spiffs from reentrancy on api level
 // These should be defined on a multithreaded system
 

--- a/app/spiffs/spiffs_gc.c
+++ b/app/spiffs/spiffs_gc.c
@@ -8,30 +8,10 @@ static s32_t spiffs_gc_erase_block(
     spiffs *fs,
     spiffs_block_ix bix) {
   s32_t res;
-  u32_t addr = SPIFFS_BLOCK_TO_PADDR(fs, bix);
-  s32_t size = SPIFFS_CFG_LOG_BLOCK_SZ(fs);
 
   SPIFFS_GC_DBG("gc: erase block %i\n", bix);
-
-  // here we ignore res, just try erasing the block
-  while (size > 0) {
-    SPIFFS_GC_DBG("gc: erase %08x:%08x\n", addr,  SPIFFS_CFG_PHYS_ERASE_SZ(fs));
-    (void)fs->cfg.hal_erase_f(addr, SPIFFS_CFG_PHYS_ERASE_SZ(fs));
-    addr += SPIFFS_CFG_PHYS_ERASE_SZ(fs);
-    size -= SPIFFS_CFG_PHYS_ERASE_SZ(fs);
-  }
-  fs->free_blocks++;
-
-  // register erase count for this block
-  res = _spiffs_wr(fs, SPIFFS_OP_C_WRTHRU | SPIFFS_OP_T_OBJ_LU2, 0,
-      SPIFFS_ERASE_COUNT_PADDR(fs, bix),
-      sizeof(spiffs_obj_id), (u8_t *)&fs->max_erase_count);
+  res = spiffs_erase_block(fs, bix);
   SPIFFS_CHECK_RES(res);
-
-  fs->max_erase_count++;
-  if (fs->max_erase_count == SPIFFS_OBJ_ID_IX_FLAG) {
-    fs->max_erase_count = 0;
-  }
 
 #if SPIFFS_CACHE
   {
@@ -48,7 +28,7 @@ static s32_t spiffs_gc_erase_block(
 // the block is erased. Compared to the non-quick gc, the quick one ensures
 // that no updates are needed on existing objects on pages that are erased.
 s32_t spiffs_gc_quick(
-    spiffs *fs) {
+    spiffs *fs, u16_t max_free_pages) {
   s32_t res = SPIFFS_OK;
   u32_t blocks = fs->block_count;
   spiffs_block_ix cur_block = 0;
@@ -67,6 +47,7 @@ s32_t spiffs_gc_quick(
   // check each block
   while (res == SPIFFS_OK && blocks--) {
     u16_t deleted_pages_in_block = 0;
+    u16_t free_pages_in_block = 0;
 
     int obj_lookup_page = 0;
     // check each object lookup page
@@ -83,9 +64,12 @@ s32_t spiffs_gc_quick(
           deleted_pages_in_block++;
         } else if (obj_id == SPIFFS_OBJ_ID_FREE) {
           // kill scan, go for next block
-          obj_lookup_page = SPIFFS_OBJ_LOOKUP_PAGES(fs);
-          res = 1; // kill object lu loop
-          break;
+          free_pages_in_block++;
+          if (free_pages_in_block > max_free_pages) {
+            obj_lookup_page = SPIFFS_OBJ_LOOKUP_PAGES(fs);
+            res = 1; // kill object lu loop
+            break;
+          }
         }  else {
           // kill scan, go for next block
           obj_lookup_page = SPIFFS_OBJ_LOOKUP_PAGES(fs);
@@ -98,7 +82,9 @@ s32_t spiffs_gc_quick(
     } // per object lookup page
     if (res == 1) res = SPIFFS_OK;
 
-    if (res == SPIFFS_OK && deleted_pages_in_block == SPIFFS_PAGES_PER_BLOCK(fs)-SPIFFS_OBJ_LOOKUP_PAGES(fs)) {
+    if (res == SPIFFS_OK &&
+        deleted_pages_in_block + free_pages_in_block == SPIFFS_PAGES_PER_BLOCK(fs)-SPIFFS_OBJ_LOOKUP_PAGES(fs) &&
+        free_pages_in_block <= max_free_pages) {
       // found a fully deleted block
       fs->stats_p_deleted -= deleted_pages_in_block;
       res = spiffs_gc_erase_block(fs, cur_block);
@@ -110,10 +96,13 @@ s32_t spiffs_gc_quick(
     cur_block_addr += SPIFFS_CFG_LOG_BLOCK_SZ(fs);
   } // per block
 
+  if (res == SPIFFS_OK) {
+    res = SPIFFS_ERR_NO_DELETED_BLOCKS;
+  }
   return res;
 }
 
-// Checks if garbaga collecting is necessary. If so a candidate block is found,
+// Checks if garbage collecting is necessary. If so a candidate block is found,
 // cleansed and erased
 s32_t spiffs_gc_check(
     spiffs *fs,
@@ -130,11 +119,14 @@ s32_t spiffs_gc_check(
   }
 
   u32_t needed_pages = (len + SPIFFS_DATA_PAGE_SIZE(fs) - 1) / SPIFFS_DATA_PAGE_SIZE(fs);
-  if (fs->free_blocks <= 2 && (s32_t)needed_pages > free_pages) {
+//  if (fs->free_blocks <= 2 && (s32_t)needed_pages > free_pages) {
+//    SPIFFS_GC_DBG("gc: full freeblk:%i needed:%i free:%i dele:%i\n", fs->free_blocks, needed_pages, free_pages, fs->stats_p_deleted);
+//    return SPIFFS_ERR_FULL;
+//  }
+  if ((s32_t)needed_pages > (s32_t)(free_pages + fs->stats_p_deleted)) {
+    SPIFFS_GC_DBG("gc_check: full freeblk:%i needed:%i free:%i dele:%i\n", fs->free_blocks, needed_pages, free_pages, fs->stats_p_deleted);
     return SPIFFS_ERR_FULL;
   }
-
-  //printf("gcing started  %i dirty, blocks %i free, want %i bytes\n", fs->stats_p_allocated + fs->stats_p_deleted, fs->free_blocks, len);
 
   do {
     SPIFFS_GC_DBG("\ngc_check #%i: run gc free_blocks:%i pfree:%i pallo:%i pdele:%i [%i] len:%i of %i\n",
@@ -145,11 +137,13 @@ s32_t spiffs_gc_check(
     spiffs_block_ix *cands;
     int count;
     spiffs_block_ix cand;
-    res = spiffs_gc_find_candidate(fs, &cands, &count);
+    s32_t prev_free_pages = free_pages;
+    // if the fs is crammed, ignore block age when selecting candidate - kind of a bad state
+    res = spiffs_gc_find_candidate(fs, &cands, &count, free_pages <= 0);
     SPIFFS_CHECK_RES(res);
     if (count == 0) {
       SPIFFS_GC_DBG("gc_check: no candidates, return\n");
-      return res;
+      return (s32_t)needed_pages < free_pages ? SPIFFS_OK : SPIFFS_ERR_FULL;
     }
 #if SPIFFS_GC_STATS
     fs->stats_gc_runs++;
@@ -175,6 +169,12 @@ s32_t spiffs_gc_check(
     free_pages =
           (SPIFFS_PAGES_PER_BLOCK(fs) - SPIFFS_OBJ_LOOKUP_PAGES(fs)) * (fs->block_count - 2)
           - fs->stats_p_allocated - fs->stats_p_deleted;
+
+    if (prev_free_pages <= 0 && prev_free_pages == free_pages) {
+      // abort early to reduce wear, at least tried once
+      SPIFFS_GC_DBG("gc_check: early abort, no result on gc when fs crammed\n");
+      break;
+    }
 
   } while (++tries < SPIFFS_GC_MAX_RUNS && (fs->free_blocks <= 2 ||
       (s32_t)len > free_pages*(s32_t)SPIFFS_DATA_PAGE_SIZE(fs)));
@@ -234,7 +234,8 @@ s32_t spiffs_gc_erase_page_stats(
 s32_t spiffs_gc_find_candidate(
     spiffs *fs,
     spiffs_block_ix **block_candidates,
-    int *candidate_count) {
+    int *candidate_count,
+    char fs_crammed) {
   s32_t res = SPIFFS_OK;
   u32_t blocks = fs->block_count;
   spiffs_block_ix cur_block = 0;
@@ -307,7 +308,7 @@ s32_t spiffs_gc_find_candidate(
       s32_t score =
           deleted_pages_in_block * SPIFFS_GC_HEUR_W_DELET +
           used_pages_in_block * SPIFFS_GC_HEUR_W_USED +
-          erase_age * SPIFFS_GC_HEUR_W_ERASE_AGE;
+          erase_age * (fs_crammed ? 0 : SPIFFS_GC_HEUR_W_ERASE_AGE);
       int cand_ix = 0;
       SPIFFS_GC_DBG("gc_check: bix:%i del:%i use:%i score:%i\n", cur_block, deleted_pages_in_block, used_pages_in_block, score);
       while (cand_ix < max_candidates) {

--- a/app/spiffs/spiffs_nucleus.h
+++ b/app/spiffs/spiffs_nucleus.h
@@ -124,12 +124,16 @@
 #define SPIFFS_EV_IX_NEW                1
 #define SPIFFS_EV_IX_DEL                2
 
-#define SPIFFS_OBJ_ID_IX_FLAG           (1<<(8*sizeof(spiffs_obj_id)-1))
+#define SPIFFS_OBJ_ID_IX_FLAG           ((spiffs_obj_id)(1<<(8*sizeof(spiffs_obj_id)-1)))
 
 #define SPIFFS_UNDEFINED_LEN            (u32_t)(-1)
 
 #define SPIFFS_OBJ_ID_DELETED           ((spiffs_obj_id)0)
 #define SPIFFS_OBJ_ID_FREE              ((spiffs_obj_id)-1)
+
+#define SPIFFS_MAGIC(fs)                ((spiffs_obj_id)(0x20140529 ^ SPIFFS_CFG_LOG_PAGE_SZ(fs)))
+
+#define SPIFFS_CONFIG_MAGIC             (0x20090315)
 
 #if SPIFFS_SINGLETON == 0
 #define SPIFFS_CFG_LOG_PAGE_SZ(fs) \
@@ -189,9 +193,18 @@
 // returns data size in a data page
 #define SPIFFS_DATA_PAGE_SIZE(fs) \
     ( SPIFFS_CFG_LOG_PAGE_SZ(fs) - sizeof(spiffs_page_header) )
-// returns physical address for block's erase count
+// returns physical address for block's erase count,
+// always in the physical last entry of the last object lookup page
 #define SPIFFS_ERASE_COUNT_PADDR(fs, bix) \
   ( SPIFFS_BLOCK_TO_PADDR(fs, bix) + SPIFFS_OBJ_LOOKUP_PAGES(fs) * SPIFFS_CFG_LOG_PAGE_SZ(fs) - sizeof(spiffs_obj_id) )
+// returns physical address for block's magic,
+// always in the physical second last entry of the last object lookup page
+#define SPIFFS_MAGIC_PADDR(fs, bix) \
+  ( SPIFFS_BLOCK_TO_PADDR(fs, bix) + SPIFFS_OBJ_LOOKUP_PAGES(fs) * SPIFFS_CFG_LOG_PAGE_SZ(fs) - sizeof(spiffs_obj_id)*2 )
+// checks if there is any room for magic in the object luts
+#define SPIFFS_CHECK_MAGIC_POSSIBLE(fs) \
+  ( (SPIFFS_OBJ_LOOKUP_MAX_ENTRIES(fs) % (SPIFFS_CFG_LOG_PAGE_SZ(fs)/sizeof(spiffs_obj_id))) * sizeof(spiffs_obj_id) \
+    <= (SPIFFS_CFG_LOG_PAGE_SZ(fs)-sizeof(spiffs_obj_id)*2) )
 
 // define helpers object
 
@@ -238,7 +251,10 @@
 
 
 #define SPIFFS_CHECK_MOUNT(fs) \
-  ((fs)->block_count > 0)
+  ((fs)->mounted != 0)
+
+#define SPIFFS_CHECK_CFG(fs) \
+  ((fs)->config_magic == SPIFFS_CONFIG_MAGIC)
 
 #define SPIFFS_CHECK_RES(res) \
   do { \
@@ -248,6 +264,12 @@
 #define SPIFFS_API_CHECK_MOUNT(fs) \
   if (!SPIFFS_CHECK_MOUNT((fs))) { \
     (fs)->err_code = SPIFFS_ERR_NOT_MOUNTED; \
+    return -1; \
+  }
+
+#define SPIFFS_API_CHECK_CFG(fs) \
+  if (!SPIFFS_CHECK_CFG((fs))) { \
+    (fs)->err_code = SPIFFS_ERR_NOT_CONFIGURED; \
     return -1; \
   }
 
@@ -381,6 +403,8 @@ typedef struct {
 // object structs
 
 // page header, part of each page except object lookup pages
+// NB: this is always aligned when the data page is an object index,
+// as in this case struct spiffs_page_object_ix is used
 typedef struct __attribute(( packed )) {
   // object id
   spiffs_obj_id obj_id;
@@ -391,11 +415,10 @@ typedef struct __attribute(( packed )) {
 } spiffs_page_header;
 
 // object index header page header
-typedef struct __attribute(( packed )) {
+typedef struct __attribute(( packed, aligned(4) ))
+{
   // common page header
   spiffs_page_header p_hdr;
-  // alignment
-  u8_t _align[4 - ((sizeof(spiffs_page_header)+sizeof(spiffs_obj_type)+SPIFFS_OBJ_NAME_LEN)&3)==0 ? 4 : ((sizeof(spiffs_page_header)+sizeof(spiffs_obj_type)+SPIFFS_OBJ_NAME_LEN)&3)];
   // size of object
   u32_t size;
   // type of object
@@ -405,9 +428,8 @@ typedef struct __attribute(( packed )) {
 } spiffs_page_object_ix_header;
 
 // object index page header
-typedef struct __attribute(( packed )) {
+typedef struct __attribute(( packed, aligned(4) )) {
  spiffs_page_header p_hdr;
- u8_t _align[4 - (sizeof(spiffs_page_header)&3)==0 ? 4 : (sizeof(spiffs_page_header)&3)];
 } spiffs_page_object_ix;
 
 // callback func for object lookup visitor
@@ -477,6 +499,10 @@ s32_t spiffs_obj_lu_find_entry_visitor(
     void *user_p,
     spiffs_block_ix *block_ix,
     int *lu_entry);
+
+s32_t spiffs_erase_block(
+    spiffs *fs,
+    spiffs_block_ix bix);
 
 // ---------------
 
@@ -625,14 +651,15 @@ s32_t spiffs_gc_erase_page_stats(
 s32_t spiffs_gc_find_candidate(
     spiffs *fs,
     spiffs_block_ix **block_candidate,
-    int *candidate_count);
+    int *candidate_count,
+    char fs_crammed);
 
 s32_t spiffs_gc_clean(
     spiffs *fs,
     spiffs_block_ix bix);
 
 s32_t spiffs_gc_quick(
-    spiffs *fs);
+    spiffs *fs, u16_t max_free_pages);
 
 // ---------------
 


### PR DESCRIPTION
Just updated SPIFFS to 0.3.2 to get the latest bug-fixes.

Ideally we should make use of the new SPIFFS_format() function, but unless we enable the new SPIFFS_USE_MAGIC #define it's not strictly needed.