### PR TITLE
Improvements to cjson memory handling

### DIFF
--- a/app/cjson/cjson_mem.c
+++ b/app/cjson/cjson_mem.c
@@ -1,0 +1,28 @@
+#include "cjson_mem.h"
+#include "../lua/lauxlib.h"
+#include <c_stdlib.h>
+
+static lua_State *gL;
+static const char errfmt[] = "cjson %salloc: out of mem (%d bytes)";
+
+void cjson_mem_setlua (lua_State *L)
+{
+  gL = L;
+}
+
+void *cjson_mem_malloc (uint32_t sz)
+{
+  void *p = (void*)c_malloc (sz);
+  if (!p && gL)
+    luaL_error (gL, errfmt, "m", sz);
+  return p;
+}
+
+
+void *cjson_mem_realloc (void *o, uint32_t sz)
+{
+  void *p = (void*)c_realloc (o, sz);
+  if (!p && gL)
+    luaL_error (gL, errfmt, "re", sz);
+  return p;
+}

--- a/app/cjson/cjson_mem.h
+++ b/app/cjson/cjson_mem.h
@@ -1,0 +1,11 @@
+#ifndef _CJSON_MEM_H_
+#define _CJSON_MEM_H_
+
+#include "../lua/lua.h"
+
+void cjson_mem_setlua (lua_State *L);
+
+void *cjson_mem_malloc (uint32_t sz);
+void *cjson_mem_realloc (void *p, uint32_t sz);
+
+#endif

--- a/app/cjson/strbuf.c
+++ b/app/cjson/strbuf.c
@@ -151,7 +151,7 @@ static int calculate_new_size(strbuf_t *s, int len)
             newsize *= -s->increment;
     } else {
         /* Linear sizing */
-        newsize = ((newsize + s->increment - 1) / s->increment) * s->increment;
+        newsize = (((reqsize -1) / s->increment) + 1) * s->increment;
     }
 
     return newsize;

--- a/app/cjson/strbuf.c
+++ b/app/cjson/strbuf.c
@@ -28,6 +28,7 @@
 #include "c_string.h"
 
 #include "strbuf.h"
+#include "cjson_mem.h"
 
 int strbuf_init(strbuf_t *s, int len)
 {
@@ -46,7 +47,7 @@ int strbuf_init(strbuf_t *s, int len)
     s->reallocs = 0;
     s->debug = 0;
 
-    s->buf = (char *)c_malloc(size);
+    s->buf = (char *)cjson_mem_malloc(size);
     if (!s->buf){
         NODE_ERR("not enough memory\n");
         return -1;
@@ -60,7 +61,7 @@ strbuf_t *strbuf_new(int len)
 {
     strbuf_t *s;
 
-    s = (strbuf_t *)c_malloc(sizeof(strbuf_t));
+    s = (strbuf_t *)cjson_mem_malloc(sizeof(strbuf_t));
     if (!s){
         NODE_ERR("not enough memory\n");
         return NULL;
@@ -170,7 +171,7 @@ int strbuf_resize(strbuf_t *s, int len)
                 (long)s, s->size, newsize);
     }
 
-    s->buf = (char *)c_realloc(s->buf, newsize);
+    s->buf = (char *)cjson_mem_realloc(s->buf, newsize);
     if (!s->buf){
         NODE_ERR("not enough memory");
         return -1;

--- a/app/cjson/strbuf.h
+++ b/app/cjson/strbuf.h
@@ -24,6 +24,7 @@
 
 #include "c_stdlib.h"
 #include "c_stdarg.h"
+#include "user_config.h"
 
 /* Size: Total bytes allocated to *buf
  * Length: String length, excluding optional NULL terminator.

--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -68,4 +68,6 @@
 #define LED_LOW_COUNT_DEFAULT 0
 #endif
 
+#define STRBUF_DEFAULT_INCREMENT 32
+
 #endif	/* __USER_CONFIG_H__ */

--- a/app/modules/cjson.c
+++ b/app/modules/cjson.c
@@ -45,6 +45,7 @@
 #include "flash_api.h"
 
 #include "strbuf.h"
+#include "cjson_mem.h"
 
 #define FPCONV_G_FMT_BUFSIZE   32
 #define fpconv_strtod c_strtod
@@ -1461,7 +1462,7 @@ static int json_decode(lua_State *l)
      * string must be smaller than the entire json string */
     json.tmp = strbuf_new(json_len);
     if(json.tmp == NULL){
-        return luaL_error(l, "not enought memory");
+        return luaL_error(l, "not enough memory");
     }
 
     json_next_token(&json, &token);
@@ -1552,6 +1553,8 @@ const LUA_REG_TYPE cjson_map[] =
 
 LUALIB_API int luaopen_cjson( lua_State *L )
 {
+  cjson_mem_setlua (L);
+
   /* Initialise number conversions */
   // fpconv_init();         // not needed for a specific cpu.
   if(-1==cfg_init(&_cfg)){


### PR DESCRIPTION
The cjson code is woefully bad at checking whether memory allocation requests actually succeeded, and as such likes to scribble through null pointers and thereby cause system crashes.

The patches here do three things:
  1. Wraps the malloc/realloc calls, and raises a Lua error on allocation failure. This makes it possible to pcall() the cjson module, thus preventing a system crash.
  1. Switches the cjson memory allocation strategy to linear rather than the default exponential. This means the cjson module can now handle somewhat larger objects without running out of RAM. Also, the allocation strategy/increment is now easily configurable from user_config.h.
  1. Fixes the linear growth memory allocation strategy to work for requests > increment size too.

Note that when cjson fails a memory allocation, it leaks a bit of memory. Fixing that would involve a substantial cleanup of the cjson code. At least for now it's possible to detect that it did fail, and schedule a restart at a convenient time to clean up.