### PR TITLE
Fix for HMAC with long keys

### DIFF
--- a/app/crypto/digests.c
+++ b/app/crypto/digests.c
@@ -140,7 +140,7 @@ int ICACHE_FLASH_ATTR crypto_hmac (const digest_mech_info_t *mi,
     mi->update (ctx, key, key_len);
     mi->finalize (digest, ctx);
     key = digest;
-    key_len = mi->block_size;
+    key_len = mi->digest_size;
   }
 
   const size_t bs = mi->block_size;


### PR DESCRIPTION
Hashing of too long keys was broken due to using the wrong key length for the resulting hash. Not sure how I missed this earlier. :(