### PR TITLE
Reclaim ~1.5k RAM by tuning down SPIFFS cache, use dynamic DNS table names

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -47,6 +47,8 @@
 // #define BUILD_WOFS		1
 #define BUILD_SPIFFS	1
 
+#define SPIFFS_CACHE 1
+
 // #define LUA_NUMBER_INTEGRAL
 
 #define LUA_OPTRAM

--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -196,11 +196,10 @@ static int file_fsinfo( lua_State* L )
 // g_read()
 static int file_g_read( lua_State* L, int n, int16_t end_char )
 {
-  if(n< 0 || n>LUAL_BUFFERSIZE) 
+  if(n <= 0 || n > LUAL_BUFFERSIZE)
     n = LUAL_BUFFERSIZE;
   if(end_char < 0 || end_char >255)
     end_char = EOF;
-  int ec = (int)end_char;
   
   luaL_Buffer b;
   if((FS_OPEN_OK - 1)==file_fd)
@@ -208,27 +207,22 @@ static int file_g_read( lua_State* L, int n, int16_t end_char )
 
   luaL_buffinit(L, &b);
   char *p = luaL_prepbuffer(&b);
-  int c = EOF;
-  int i = 0;
+  int i;
 
-  do{
-    c = fs_getc(file_fd);
-    if(c==EOF){
+  n = fs_read(file_fd, p, n);
+  for (i = 0; i < n; ++i)
+    if (p[i] == end_char)
+    {
+      ++i;
       break;
     }
-    p[i++] = (char)(0xFF & c);
-  }while((c!=EOF) && (c!=ec) && (i<n) );
 
-#if 0
-  if(i>0 && p[i-1] == '\n')
-    i--;    /* do not include `eol' */
-#endif
-    
   if(i==0){
     luaL_pushresult(&b);  /* close buffer */
     return (lua_objlen(L, -1) > 0);  /* check whether read something */
   }
 
+  fs_seek(file_fd, -(n - i), SEEK_CUR);
   luaL_addsize(&b, i);
   luaL_pushresult(&b);  /* close buffer */
   return 1;  /* read at least an `eol' */ 

--- a/app/platform/common.c
+++ b/app/platform/common.c
@@ -220,7 +220,7 @@ uint32_t platform_flash_read( void *to, uint32_t fromaddr, uint32_t size )
 #else // #ifindef INTERNAL_FLASH_READ_UNIT_SIZE
   uint32_t temp, rest, ssize = size;
   unsigned i;
-  char tmpdata[ INTERNAL_FLASH_READ_UNIT_SIZE ];
+  char tmpdata[ INTERNAL_FLASH_READ_UNIT_SIZE ] __attribute__ ((aligned(INTERNAL_FLASH_READ_UNIT_SIZE)));
   uint8_t *pto = ( uint8_t* )to;
   const uint32_t blksize = INTERNAL_FLASH_READ_UNIT_SIZE;
   const uint32_t blkmask = INTERNAL_FLASH_READ_UNIT_SIZE - 1;

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -460,6 +460,11 @@ spi_data_type platform_spi_send_recv( unsigned id, spi_data_type data )
 // ****************************************************************************
 // Flash access functions
 
+/*
+ * Assumptions:
+ * > toaddr is INTERNAL_FLASH_WRITE_UNIT_SIZE aligned
+ * > size is a multiple of INTERNAL_FLASH_WRITE_UNIT_SIZE
+ */
 uint32_t platform_s_flash_write( const void *from, uint32_t toaddr, uint32_t size )
 {
   toaddr -= INTERNAL_FLASH_START_ADDRESS;
@@ -484,12 +489,37 @@ uint32_t platform_s_flash_write( const void *from, uint32_t toaddr, uint32_t siz
   }
 }
 
+/*
+ * Assumptions:
+ * > fromaddr is INTERNAL_FLASH_READ_UNIT_SIZE aligned
+ * > size is a multiple of INTERNAL_FLASH_READ_UNIT_SIZE
+ */
 uint32_t platform_s_flash_read( void *to, uint32_t fromaddr, uint32_t size )
 {
+  if (size==0)
+    return 0;
+
   fromaddr -= INTERNAL_FLASH_START_ADDRESS;
   SpiFlashOpResult r;
   WRITE_PERI_REG(0x60000914, 0x73);
-  r = flash_read(fromaddr, (uint32 *)to, size);
+
+  const uint32_t blkmask = (INTERNAL_FLASH_READ_UNIT_SIZE - 1);
+  if( ((uint32_t)to) & blkmask )
+  {
+    uint32_t size2=size-INTERNAL_FLASH_READ_UNIT_SIZE;
+    uint32* to2=(uint32*)((((uint32_t)to)&(~blkmask))+INTERNAL_FLASH_READ_UNIT_SIZE);
+    r = flash_read(fromaddr, to2, size2);
+    if(SPI_FLASH_RESULT_OK == r)
+    {
+      os_memmove(to,to2,size2);
+      char back[ INTERNAL_FLASH_READ_UNIT_SIZE ] __attribute__ ((aligned(INTERNAL_FLASH_READ_UNIT_SIZE)));
+      r=flash_read(fromaddr+size2,(uint32*)back,INTERNAL_FLASH_READ_UNIT_SIZE);
+      os_memcpy((uint8_t*)to+size2,back,INTERNAL_FLASH_READ_UNIT_SIZE);
+    }
+  }
+  else
+    r = flash_read(fromaddr, (uint32 *)to, size);
+
   if(SPI_FLASH_RESULT_OK == r)
     return size;
   else{

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -471,7 +471,8 @@ uint32_t platform_s_flash_write( const void *from, uint32_t toaddr, uint32_t siz
   SpiFlashOpResult r;
   const uint32_t blkmask = INTERNAL_FLASH_WRITE_UNIT_SIZE - 1;
   uint32_t *apbuf = NULL;
-  if( ((uint32_t)from) & blkmask ){
+  uint32_t fromaddr = (uint32_t)from;
+  if( (fromaddr & blkmask ) || (fromaddr >= INTERNAL_FLASH_START_ADDRESS)) {
     apbuf = (uint32_t *)c_malloc(size);
     if(!apbuf)
       return 0;

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -8,7 +8,9 @@ spiffs fs;
   
 static u8_t spiffs_work_buf[LOG_PAGE_SIZE*2];
 static u8_t spiffs_fds[32*4];
-static u8_t spiffs_cache[(LOG_PAGE_SIZE+32)*4];
+#if SPIFFS_CACHE
+static u8_t spiffs_cache[(LOG_PAGE_SIZE+32)*2];
+#endif
 
 static s32_t my_spiffs_read(u32_t addr, u32_t size, u8_t *dst) {
   platform_flash_read(dst, addr, size);
@@ -62,8 +64,12 @@ void myspiffs_mount() {
     spiffs_work_buf,
     spiffs_fds,
     sizeof(spiffs_fds),
+#if SPIFFS_CACHE
     spiffs_cache,
     sizeof(spiffs_cache),
+#else
+    0, 0,
+#endif
     // myspiffs_check_callback);
     0);
   NODE_DBG("mount res: %i\n", res);

--- a/app/spiffs/spiffs_config.h
+++ b/app/spiffs/spiffs_config.h
@@ -8,16 +8,10 @@
 #ifndef SPIFFS_CONFIG_H_
 #define SPIFFS_CONFIG_H_
 
-// ----------- 8< ------------
-// Following includes are for the linux test build of spiffs
-// These may/should/must be removed/altered/replaced in your target
-// #include "params_test.h"
+#include "user_config.h"
 #include "c_stdio.h"
-#include "c_stdlib.h"
+#include "c_stdint.h"
 #include "c_string.h"
-#include "c_stddef.h"
-#include "c_types.h"
-// ----------- >8 ------------
 
 typedef sint32_t s32_t;
 typedef uint32_t u32_t;
@@ -67,6 +61,8 @@ typedef uint8_t u8_t;
 #ifndef  SPIFFS_CACHE_STATS
 #define SPIFFS_CACHE_STATS              0
 #endif
+#else
+#define SPIFFS_CACHE_WR                 0
 #endif
 
 // Always check header of each accessed page to ensure consistent state.

--- a/app/spiffs/spiffs_nucleus.h
+++ b/app/spiffs/spiffs_nucleus.h
@@ -405,7 +405,7 @@ typedef struct {
 // page header, part of each page except object lookup pages
 // NB: this is always aligned when the data page is an object index,
 // as in this case struct spiffs_page_object_ix is used
-typedef struct __attribute(( packed )) {
+typedef struct __attribute(( packed, aligned(4) )) {
   // object id
   spiffs_obj_id obj_id;
   // object span index

--- a/app/spiffs/spiffs_nucleus.h
+++ b/app/spiffs/spiffs_nucleus.h
@@ -405,7 +405,7 @@ typedef struct {
 // page header, part of each page except object lookup pages
 // NB: this is always aligned when the data page is an object index,
 // as in this case struct spiffs_page_object_ix is used
-typedef struct __attribute(( packed, aligned(4) )) {
+typedef struct __attribute(( packed )) {
   // object id
   spiffs_obj_id obj_id;
   // object span index
@@ -415,7 +415,7 @@ typedef struct __attribute(( packed, aligned(4) )) {
 } spiffs_page_header;
 
 // object index header page header
-typedef struct __attribute(( packed, aligned(4) ))
+typedef struct __attribute(( packed ))
 {
   // common page header
   spiffs_page_header p_hdr;
@@ -428,7 +428,7 @@ typedef struct __attribute(( packed, aligned(4) ))
 } spiffs_page_object_ix_header;
 
 // object index page header
-typedef struct __attribute(( packed, aligned(4) )) {
+typedef struct __attribute(( packed )) {
  spiffs_page_header p_hdr;
 } spiffs_page_object_ix;
 


### PR DESCRIPTION
Here are a couple of things that might be of interest:

  1. I tuned the SPIFFS cache down a bit, freeing up half a K of RAM in the process. I also resolved the issue preventing the cache from being disabled, and made disabling the cache optional (as requested in #579). Disabling the SPIFFS cache is really only for those of us who have a read-only scenario and need as much RAM as we can get. This patch leaves the cache *enabled*.
  1. I switched the DNS table over to use dynamically allocated storage for the dns names. These buffers were taking up a whopping 1k of RAM, most of it which would never be used.

Both of these items have only received a basic level of testing here so far, but we're hoping the community might hammer this and point out any issues :)