### PR TITLE
Onewire search bug fix

### DIFF
--- a/app/driver/onewire.c
+++ b/app/driver/onewire.c
@@ -403,9 +403,10 @@ uint8_t onewire_search(uint8_t pin, uint8_t *newAddr)
       LastDeviceFlag[pin] = FALSE;
       LastFamilyDiscrepancy[pin] = 0;
       search_result = FALSE;
-   }
-   int i;
-   for (i = 0; i < 8; i++) newAddr[i] = ROM_NO[pin][i];
+   } else {
+	  int i;
+      for (i = 0; i < 8; i++) newAddr[i] = ROM_NO[pin][i];
+   }   
    return search_result;
   }
 


### PR DESCRIPTION
Current version tries copying device address even when no device is found.
Merged from
https://github.com/PaulStoffregen/OneWire/commit/c6564f22321d9bc6c89cc5d26e64a109fc6e80bf