### PR TITLE
Add minimum debug library providing traceback() and getregistry() functions

### DIFF
--- a/app/include/user_modules.h
+++ b/app/include/user_modules.h
@@ -8,7 +8,8 @@
 // #define LUA_USE_BUILTIN_IO 			// for io.xxx(), partially work
 
 // #define LUA_USE_BUILTIN_OS			// for os.xxx(), not work
-// #define LUA_USE_BUILTIN_DEBUG		// for debug.xxx(), not work
+// #define LUA_USE_BUILTIN_DEBUG
+#define LUA_USE_BUILTIN_DEBUG_MINIMAL // for debug.getregistry() and debug.traceback()
 
 #define LUA_USE_MODULES
 

--- a/app/lua/ldblib.c
+++ b/app/lua/ldblib.c
@@ -17,6 +17,7 @@
 #include "lauxlib.h"
 #include "lualib.h"
 #include "lrotable.h"
+#include "user_modules.h"
 
 
 
@@ -25,6 +26,7 @@ static int db_getregistry (lua_State *L) {
   return 1;
 }
 
+#ifndef LUA_USE_BUILTIN_DEBUG_MINIMAL
 
 static int db_getmetatable (lua_State *L) {
   luaL_checkany(L, 1);
@@ -73,7 +75,7 @@ static void settabsi (lua_State *L, const char *i, int v) {
   lua_setfield(L, -2, i);
 }
 
-
+#endif
 static lua_State *getthread (lua_State *L, int *arg) {
   if (lua_isthread(L, 1)) {
     *arg = 1;
@@ -84,7 +86,7 @@ static lua_State *getthread (lua_State *L, int *arg) {
     return L;
   }
 }
-
+#ifndef LUA_USE_BUILTIN_DEBUG_MINIMAL
 
 static void treatstackoption (lua_State *L, lua_State *L1, const char *fname) {
   if (L == L1) {
@@ -324,7 +326,7 @@ static int db_debug (lua_State *L) {
     lua_settop(L, 0);  /* remove eventual returns */
   }
 }
-
+#endif
 
 #define LEVELS1	12	/* size of the first part of the stack */
 #define LEVELS2	10	/* size of the second part of the stack */
@@ -384,12 +386,15 @@ static int db_errorfb (lua_State *L) {
 #define MIN_OPT_LEVEL 1
 #include "lrodefs.h"
 const LUA_REG_TYPE dblib[] = {
+#ifndef LUA_USE_BUILTIN_DEBUG_MINIMAL
   {LSTRKEY("debug"), LFUNCVAL(db_debug)},
   {LSTRKEY("getfenv"), LFUNCVAL(db_getfenv)},
   {LSTRKEY("gethook"), LFUNCVAL(db_gethook)},
   {LSTRKEY("getinfo"), LFUNCVAL(db_getinfo)},
   {LSTRKEY("getlocal"), LFUNCVAL(db_getlocal)},
+#endif
   {LSTRKEY("getregistry"), LFUNCVAL(db_getregistry)},
+#ifndef LUA_USE_BUILTIN_DEBUG_MINIMAL
   {LSTRKEY("getmetatable"), LFUNCVAL(db_getmetatable)},
   {LSTRKEY("getupvalue"), LFUNCVAL(db_getupvalue)},
   {LSTRKEY("setfenv"), LFUNCVAL(db_setfenv)},
@@ -397,6 +402,7 @@ const LUA_REG_TYPE dblib[] = {
   {LSTRKEY("setlocal"), LFUNCVAL(db_setlocal)},
   {LSTRKEY("setmetatable"), LFUNCVAL(db_setmetatable)},
   {LSTRKEY("setupvalue"), LFUNCVAL(db_setupvalue)},
+#endif
   {LSTRKEY("traceback"), LFUNCVAL(db_errorfb)},
   {LNILKEY, LNILVAL}
 };

--- a/app/modules/linit.c
+++ b/app/modules/linit.c
@@ -47,7 +47,7 @@ static const luaL_Reg lualibs[] = {
   {LUA_TABLIBNAME, luaopen_table},  
   #endif
 
-  #if defined(LUA_USE_BUILTIN_DEBUG)
+  #if defined(LUA_USE_BUILTIN_DEBUG) || defined(LUA_USE_BUILTIN_DEBUG_MINIMAL)
   {LUA_DBLIBNAME, luaopen_debug},
   #endif 
 #endif
@@ -71,7 +71,7 @@ extern const luaR_entry syslib[];
 extern const luaR_entry tab_funcs[];
 #endif
 
-#if defined(LUA_USE_BUILTIN_DEBUG)
+#if defined(LUA_USE_BUILTIN_DEBUG) || defined(LUA_USE_BUILTIN_DEBUG_MINIMAL)
 extern const luaR_entry dblib[];
 #endif
 
@@ -99,7 +99,7 @@ const luaR_table lua_rotable[] =
   {LUA_TABLIBNAME, tab_funcs},
   #endif
 
-  #if defined(LUA_USE_BUILTIN_DEBUG)
+  #if defined(LUA_USE_BUILTIN_DEBUG) || defined(LUA_USE_BUILTIN_DEBUG_MINIMAL)
   {LUA_DBLIBNAME, dblib},
   #endif
 


### PR DESCRIPTION
As discussed in nodemcu/nodemcu-firmware#624, this patch implements a minimal debug library to provide correct trace back error messages and also the getregistry() function. 