### PR TITLE
Added mqtt clean session support.

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -548,7 +548,7 @@ void mqtt_socket_timer(void *arg)
   NODE_DBG("leave mqtt_socket_timer.\n");
 }
 
-// Lua: mqtt.Client(clientid, keepalive, user, pass)
+// Lua: mqtt.Client(clientid, keepalive, user, pass, clean_session)
 static int mqtt_socket_client( lua_State* L )
 {
   NODE_DBG("enter mqtt_socket_client.\n");

--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -565,6 +565,7 @@ static int mqtt_socket_client( lua_State* L )
   int keepalive = 0;
   int stack = 1;
   unsigned secure = 0;
+  int clean_session = 1;
   int top = lua_gettop(L);
 
   // create a object
@@ -626,6 +627,16 @@ static int mqtt_socket_client( lua_State* L )
   if(password == NULL)
     pwl = 0;
   NODE_DBG("lengh password: %d\r\n", pwl);
+  
+  if(lua_isnumber( L, stack ))
+  {   
+    clean_session = luaL_checkinteger( L, stack);
+    stack++;
+  }
+
+  if(clean_session > 1){
+    clean_session = 1;
+  }
 
   // TODO: check the zalloc result.
   mud->connect_info.client_id = (uint8_t *)c_zalloc(idl+1);
@@ -656,7 +667,7 @@ static int mqtt_socket_client( lua_State* L )
   
   NODE_DBG("MQTT: Init info: %s, %s, %s\r\n", mud->connect_info.client_id, mud->connect_info.username, mud->connect_info.password);
 
-  mud->connect_info.clean_session = 1;
+  mud->connect_info.clean_session = clean_session;
   mud->connect_info.will_qos = 0;
   mud->connect_info.will_retain = 0;
   mud->connect_info.keepalive = keepalive;


### PR DESCRIPTION
Adds clean session support to mqtt.client function. Addresses issue #151 
```
mq = .Client("clientid", 120, "user", "password", 0)
```
```
mq = .Client("clientid", 120, "user", "password", 1)
```