### PR TITLE
Add divider for arbitrary HSPI clock frequencies, resolves #674

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ All other pins can be assigned to any available GPIO:
 
 Also refer to the initialization sequence eg in [u8g_graphics_test.lua](lua_examples/u8glib/u8g_graphics_test.lua):
 ```lua
-spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 0)
+spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 8)
 ```
 
 
@@ -488,7 +488,7 @@ All other pins can be assigned to any available GPIO:
 
 Also refer to the initialization sequence eg in [GraphicsTest.lua](lua_examples/ucglib/GraphicsRest.lua):
 ```lua
-spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 0)
+spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 8)
 ```
 
 #####Library usage

--- a/app/driver/spi.c
+++ b/app/driver/spi.c
@@ -112,10 +112,13 @@ void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, unsigned databi
 	// SPI clock = CPU clock / clock_div
 	// the divider needs to be a multiple of 2 to get a proper waveform shape
 	if ((clock_div & 0x01) != 0) {
-		// bump the divider to the nextN*2
+		// bump the divider to the next N*2
 		clock_div += 0x02;
 	}
 	clock_div >>= 1;
+	// clip to maximum possible CLKDIV_PRE
+	clock_div = clock_div > SPI_CLKDIV_PRE ? SPI_CLKDIV_PRE : clock_div - 1;
+
 	WRITE_PERI_REG(SPI_CLOCK(spi_no), 
 					((clock_div&SPI_CLKDIV_PRE)<<SPI_CLKDIV_PRE_S)|
 					((1&SPI_CLKCNT_N)<<SPI_CLKCNT_N_S)|

--- a/app/driver/spi.c
+++ b/app/driver/spi.c
@@ -64,7 +64,7 @@ void spi_lcd_9bit_write(uint8 spi_no,uint8 high_bit,uint8 low_8bit)
  * Description  : SPI master initial function for common byte units transmission
  * Parameters   : uint8 spi_no - SPI module number, Only "SPI" and "HSPI" are valid
 *******************************************************************************/
-void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, unsigned databits, uint32_t clock)
+void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, unsigned databits, uint32_t clock_div)
 {
 	uint32 regvalue; 
 
@@ -109,12 +109,18 @@ void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, unsigned databi
 	//clear Daul or Quad lines transmission mode
 	CLEAR_PERI_REG_MASK(SPI_CTRL(spi_no), SPI_QIO_MODE|SPI_DIO_MODE|SPI_DOUT_MODE|SPI_QOUT_MODE);
 
-	// SPI clock=CPU clock/8
+	// SPI clock = CPU clock / clock_div
+	// the divider needs to be a multiple of 2 to get a proper waveform shape
+	if ((clock_div & 0x01) != 0) {
+		// bump the divider to the nextN*2
+		clock_div += 0x02;
+	}
+	clock_div >>= 1;
 	WRITE_PERI_REG(SPI_CLOCK(spi_no), 
-					((1&SPI_CLKDIV_PRE)<<SPI_CLKDIV_PRE_S)|
-					((3&SPI_CLKCNT_N)<<SPI_CLKCNT_N_S)|
-					((1&SPI_CLKCNT_H)<<SPI_CLKCNT_H_S)|
-					((3&SPI_CLKCNT_L)<<SPI_CLKCNT_L_S)); //clear bit 31,set SPI clock div
+					((clock_div&SPI_CLKDIV_PRE)<<SPI_CLKDIV_PRE_S)|
+					((1&SPI_CLKCNT_N)<<SPI_CLKCNT_N_S)|
+					((0&SPI_CLKCNT_H)<<SPI_CLKCNT_H_S)|
+					((1&SPI_CLKCNT_L)<<SPI_CLKCNT_L_S)); //clear bit 31,set SPI clock div
 
 	//set 8bit output buffer length, the buffer is the low 8bit of register"SPI_FLASH_C0"
 	WRITE_PERI_REG(SPI_USER1(spi_no), 

--- a/app/include/driver/spi.h
+++ b/app/include/driver/spi.h
@@ -18,7 +18,7 @@ void spi_lcd_mode_init(uint8 spi_no);
 void spi_lcd_9bit_write(uint8 spi_no,uint8 high_bit,uint8 low_8bit);
 
 //spi master init funtion
-void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, unsigned databits, uint32_t clock);
+void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, unsigned databits, uint32_t clock_div);
 //use spi send 8bit data
 void spi_mast_byte_write(uint8 spi_no,uint8 *data);
 

--- a/app/modules/spi.c
+++ b/app/modules/spi.c
@@ -7,7 +7,7 @@
 #include "auxmods.h"
 #include "lrotable.h"
 
-// Lua: = spi.setup( id, mode, cpol, cpha, databits, clock )
+// Lua: = spi.setup( id, mode, cpol, cpha, databits, clock_div )
 static int spi_setup( lua_State *L )
 {
   unsigned id = luaL_checkinteger( L, 1 );
@@ -15,7 +15,7 @@ static int spi_setup( lua_State *L )
   unsigned cpol = luaL_checkinteger( L, 3 );
   unsigned cpha = luaL_checkinteger( L, 4 );
   unsigned databits = luaL_checkinteger( L, 5 );
-  uint32_t clock = luaL_checkinteger( L, 6 );
+  uint32_t clock_div = luaL_checkinteger( L, 6 );
 
   MOD_CHECK_ID( spi, id );
 
@@ -35,7 +35,11 @@ static int spi_setup( lua_State *L )
     return luaL_error( L, "wrong arg type" );
   }
 
-  u32 res = platform_spi_setup(id, mode, cpol, cpha, databits, clock);
+  if (clock_div < 4) {
+    return luaL_error( L, "invalid clock divider" );
+  }
+
+  u32 res = platform_spi_setup(id, mode, cpol, cpha, databits, clock_div);
   lua_pushinteger( L, res );
   return 1;
 }

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -445,9 +445,9 @@ int platform_i2c_recv_byte( unsigned id, int ack ){
 
 // *****************************************************************************
 // SPI platform interface
-uint32_t platform_spi_setup( unsigned id, int mode, unsigned cpol, unsigned cpha, unsigned databits, uint32_t clock)
+uint32_t platform_spi_setup( unsigned id, int mode, unsigned cpol, unsigned cpha, unsigned databits, uint32_t clock_div)
 {
-  spi_master_init(id, cpol, cpha, databits, clock);
+  spi_master_init(id, cpol, cpha, databits, clock_div);
   return 1;
 }
 

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -100,7 +100,7 @@ typedef uint32_t spi_data_type;
 
 // The platform SPI functions
 int platform_spi_exists( unsigned id );
-uint32_t platform_spi_setup( unsigned id, int mode, unsigned cpol, unsigned cpha, unsigned databits, uint32_t clock);
+uint32_t platform_spi_setup( unsigned id, int mode, unsigned cpol, unsigned cpha, unsigned databits, uint32_t clock_div);
 spi_data_type platform_spi_send_recv( unsigned id, spi_data_type data );
 void platform_spi_select( unsigned id, int is_select );
 

--- a/lua_examples/u8glib/u8g_bitmaps.lua
+++ b/lua_examples/u8glib/u8g_bitmaps.lua
@@ -30,7 +30,7 @@ function init_spi_display()
      local dc  = 4 -- GPIO2
      local res = 0 -- GPIO16
 
-     spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 0)
+     spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 8)
      disp = u8g.ssd1306_128x64_hw_spi(cs, dc, res)
 end
 

--- a/lua_examples/u8glib/u8g_graphics_test.lua
+++ b/lua_examples/u8glib/u8g_graphics_test.lua
@@ -29,7 +29,7 @@ function init_spi_display()
     local dc  = 4 -- GPIO2
     local res = 0 -- GPIO16
 
-    spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 0)
+    spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 8)
     disp = u8g.ssd1306_128x64_hw_spi(cs, dc, res)
 end
 

--- a/lua_examples/u8glib/u8g_rotation.lua
+++ b/lua_examples/u8glib/u8g_rotation.lua
@@ -30,7 +30,7 @@ function init_spi_display()
      local dc  = 4 -- GPIO2
      local res = 0 -- GPIO16
 
-     spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 0)
+     spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 8)
      disp = u8g.ssd1306_128x64_hw_spi(cs, dc, res)
 end
 

--- a/lua_examples/ucglib/GraphicsTest.lua
+++ b/lua_examples/ucglib/GraphicsTest.lua
@@ -8,7 +8,7 @@ function init_spi_display()
     local dc  = 4 -- GPIO2
     local res = 0 -- GPIO16
 
-    spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 0)
+    spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 8)
 
     -- initialize the matching driver for your display
     -- see app/include/ucg_config.h

--- a/lua_examples/ucglib/HelloWorld.lua
+++ b/lua_examples/ucglib/HelloWorld.lua
@@ -8,7 +8,7 @@ function init_spi_display()
    local dc  = 4 -- GPIO2
    local res = 0 -- GPIO16
 
-   spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 0)
+   spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 8)
    disp = ucg.ili9341_18x240x320_hw_spi(cs, dc, res)
 end
 

--- a/lua_examples/ucglib/UcgLogo.lua
+++ b/lua_examples/ucglib/UcgLogo.lua
@@ -8,7 +8,7 @@ function init_spi_display()
     local dc  = 4 -- GPIO2
     local res = 0 -- GPIO16
 
-    spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 0)
+    spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, spi.DATABITS_8, 8)
     disp = ucg.ili9341_18x240x320_hw_spi(cs, dc, res)
 end
 


### PR DESCRIPTION
The yet-unused `clock` parameter for `spi.setup()` is now used to specify the clock divider:
```lua
spi.setup( id, mode, cpol, cpha, databits, clock_div )
```
Where `f_HSPI = f_CPU / clock_div`.
I refrained from asking the user for an absolute frequency here, since the CPU clock can be different. It's WYSIWYG this way. API extension will be documented once merged to `dev` branch.

Details of the (H)SPI clock generation can be found at
http://d.av.id.au/blog/hardware-spi-clock-registers/