### PR TITLE
Also support DS18S20

### DIFF
--- a/lua_examples/onewire-ds18b20.lua
+++ b/lua_examples/onewire-ds18b20.lua
@@ -40,7 +40,13 @@ else
           crc = ow.crc8(string.sub(data,1,8))
           print("CRC="..crc)
           if (crc == data:byte(9)) then
-             t = (data:byte(1) + data:byte(2) * 256) * 625
+             t = (data:byte(1) + data:byte(2) * 256)
+
+             -- handle negative temperatures
+             if (t > 0x7fff) then
+                t = t - 0x10000
+             end
+
              if (addr:byte(1) == 0x28) then
                 t = t * 625  -- DS18B20, 4 fractional bits
              else

--- a/lua_examples/onewire-ds18b20.lua
+++ b/lua_examples/onewire-ds18b20.lua
@@ -41,6 +41,11 @@ else
           print("CRC="..crc)
           if (crc == data:byte(9)) then
              t = (data:byte(1) + data:byte(2) * 256) * 625
+             if (addr:byte(1) == 0x28) then
+                t = t * 625  -- DS18B20, 4 fractional bits
+             else
+                t = t * 5000 -- DS18S20, 1 fractional bit
+             end
              t1 = t / 10000
              t2 = t % 10000
              print("Temperature= "..t1.."."..t2.." Centigrade")

--- a/lua_modules/ds18b20/ds18b20.lua
+++ b/lua_modules/ds18b20/ds18b20.lua
@@ -101,12 +101,19 @@ function readNumber(addr, unit)
         if (t > 32767) then
           t = t - 65536
         end
-        if(unit == nil or unit == C) then
-          t = t * 625
-        elseif(unit == F) then
-          t = t * 1125 + 320000
-        elseif(unit == K) then
-          t = t * 625 + 2731500
+
+		if (addr:byte(1) == 0x28) then
+		  t = t * 625  -- DS18B20, 4 fractional bits
+		else
+		  t = t * 5000 -- DS18S20, 1 fractional bit
+		end
+
+        if(unit == nil or unit == 'C') then
+          -- do nothing
+        elseif(unit == 'F') then
+          t = t * 1.8 + 320000
+        elseif(unit == 'K') then
+          t = t + 2731500
         else
           return nil
         end


### PR DESCRIPTION
The DS18S20 has only 1 fractional bit whereas DS18B20 has 4, and their
temperature register alignment differs. Check the family code to choose
the correct multiplier for both devices.

Closes #610

Signed-off-by: Nick Andrew <nick@nick-andrew.net>