### PR TITLE
Implement SDK function wifi_status_led_install

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -455,6 +455,51 @@ static int wifi_sleeptype( lua_State* L )
   return 1;  
 }
 
+// lua: wifi.installstatusled(pin)
+static int wifi_statusledinstall( lua_State* L ){
+	if (lua_isnil(L, 1)) {
+		wifi_status_led_uninstall();
+		return 0;
+	}
+	else{
+		unsigned pin = luaL_checkinteger( L, 1 );
+
+		uint32 muxname;
+		uint8 pinfunc;
+		switch (pin){
+		case 0:
+			muxname = PERIPHS_IO_MUX_GPIO0_U;
+			pinfunc = FUNC_GPIO0;
+			break;
+		case 4:
+			muxname = PERIPHS_IO_MUX_GPIO4_U;
+			pinfunc = FUNC_GPIO4;
+			break;
+		case 5:
+			muxname = PERIPHS_IO_MUX_GPIO5_U;
+			pinfunc = FUNC_GPIO5;
+			break;
+		case 12:
+			muxname = PERIPHS_IO_MUX_MTDI_U;
+			pinfunc = FUNC_GPIO12;
+			break;
+		case 13:
+			muxname = PERIPHS_IO_MUX_MTCK_U;
+			pinfunc = FUNC_GPIO13;
+			break;
+		case 14:
+			muxname = PERIPHS_IO_MUX_MTMS_U;
+			pinfunc = FUNC_GPIO14;
+			break;
+
+		default:
+			return luaL_error (L, "only supports GPIO pins 0,4,5 and 12-14");
+		}
+		wifi_status_led_install(pin,muxname,pinfunc );
+		return 0;
+	}
+}
+
 // Lua: wifi.sta.getmac()
 static int wifi_station_getmac( lua_State* L ){
   return wifi_getmac(L, STATION_IF);
@@ -1332,6 +1377,7 @@ const LUA_REG_TYPE wifi_map[] =
   { LSTRKEY( "startsmart" ), LFUNCVAL( wifi_start_smart ) },
   { LSTRKEY( "stopsmart" ), LFUNCVAL( wifi_exit_smart ) },
   { LSTRKEY( "sleeptype" ), LFUNCVAL( wifi_sleeptype ) },
+  { LSTRKEY( "setstatusled" ), LFUNCVAL( wifi_statusledinstall ) },
 #if LUA_OPTIMIZE_MEMORY > 0
   { LSTRKEY( "sta" ), LROVAL( wifi_station_map ) },
   { LSTRKEY( "ap" ), LROVAL( wifi_ap_map ) },


### PR DESCRIPTION
This PR implements the new SDK functions wifi_status_led_install(pin,muxname,pinfunc ) and wifi_status_led_uninstall(). I've only tested some of these pins, can't test them all, but they should work. In all honesty it's quite lackluster (but energy efficient) at the moment, just blinks while trying to connect, then stays off. Might get upgraded in newer SDKs though

Thanks to @eku for spotting some flaws in the previous PR #699 

## wifi.setstatusled()
### Description
Enables/disables output of wifi status to an LED connected to the specified pin
### Syntax
wifi.setstatusled(pin)

### Parameters
pin: Pin number (only allows 0,4,5,12,13 and 14). Use nil to remove the LED

### Returns
nil

### Example

```lua
    wifi.setstatusled(4) -- Connect LED to GPIO4, it should flash when trying to connect

    wifi.setstatusled(nil) -- disables status output
```
