### PR TITLE
Add full-duplex support to SPI module

### DIFF
--- a/app/include/driver/spi.h
+++ b/app/include/driver/spi.h
@@ -18,7 +18,7 @@ void spi_lcd_mode_init(uint8 spi_no);
 void spi_lcd_9bit_write(uint8 spi_no,uint8 high_bit,uint8 low_8bit);
 
 //spi master init funtion
-void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_div);
+void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_div, uint8 full_duplex);
 // fill MOSI buffer
 void spi_set_mosi(uint8 spi_no, uint8 offset, uint8 bitlen, uint32 data);
 // retrieve data from MISO buffer

--- a/app/modules/spi.c
+++ b/app/modules/spi.c
@@ -110,7 +110,7 @@ static int spi_generic_send_recv( lua_State *L, u8 recv )
         lua_pop( L, 1 );
         if (recv > 0) {
           lua_pushinteger( L, platform_spi_send_recv( id, spi_databits[id], numdata ) );
-          lua_rawseti( L, -1, i + 1 );
+          lua_rawseti( L, -2, i + 1 );
         }
         else
         {

--- a/app/modules/spi.c
+++ b/app/modules/spi.c
@@ -173,11 +173,12 @@ static int spi_send_recv( lua_State *L )
   return spi_generic_send_recv( L, 1 );
 }
 
-// Lua: read = spi.recv( id, size )
+// Lua: read = spi.recv( id, size, [default data] )
 static int spi_recv( lua_State *L )
 {
   int id   = luaL_checkinteger( L, 1 );
   int size = luaL_checkinteger( L, 2 ), i;
+  int def  = luaL_optinteger( L, 3, 0xffffffff );
 
   luaL_Buffer b;
 
@@ -189,10 +190,7 @@ static int spi_recv( lua_State *L )
   luaL_buffinit( L, &b );
   for (i=0; i<size; i++)
   {
-    if (PLATFORM_OK != platform_spi_transaction( id, 0, 0, 0, 0, 0, 0, spi_databits[id] )) {
-      return luaL_error( L, "failed" );
-    }
-    luaL_addchar( &b, ( char )platform_spi_get_miso( id, 0, spi_databits[id] ) );
+    luaL_addchar( &b, ( char )platform_spi_send_recv( id, spi_databits[id], def ) );
   }
 
   luaL_pushresult( &b );

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -96,8 +96,9 @@ typedef uint32_t spi_data_type;
 
 // The platform SPI functions
 int platform_spi_exists( unsigned id );
-uint32_t platform_spi_setup( uint8_t id, int mode, unsigned cpol, unsigned cpha, uint32_t clock_div);
+uint32_t platform_spi_setup( uint8_t id, int mode, unsigned cpol, unsigned cpha, uint32_t clock_div, uint8_t full_duplex);
 int platform_spi_send( uint8_t id, uint8_t bitlen, spi_data_type data );
+spi_data_type platform_spi_send_recv( uint8_t id, uint8_t bitlen, spi_data_type data );
 void platform_spi_select( unsigned id, int is_select );
 
 int platform_spi_set_mosi( uint8_t id, uint8_t offset, uint8_t bitlen, spi_data_type data );


### PR DESCRIPTION
This PR is supposed to add true full- and half-duplex support based on the learnings of #693 and the associated discussion.
* Add optional parameter 'full_duplex' to `spi.setup()` for full-duplex vs half-duplex configuration of the HW.<br />
  Constants `spi.FULLDUPLEX` and `spi.HALFDUPLEX` select the respective operation mode. Defaults to `spi.FULLDUPLEX` if omitted.
* Add new function `wrote, rdata1[, ... [, rdatan]] = spi.send_recv(id, data1[, ...[, datan]])` to enable concurrent sending and receiving of data.<br />
  The parameter layout follows the established definition of `spi.send()` in the way that integers, arrays and strings can be arbitrarily specified as data items. The returned data items dynamically adapt to the input pattern. I.e. rdataX is returned as integer in case dataX was provided as integer, rdataY as array when dataY is an array, rdataZ as string when dataZ is a string.
* Add optional parameter 'default_data' to `spi.recv()` which specifies the data that is being sent for each receive transaction. Defaults to 'all-1' if omitted.

Theoretically, `spi.send()` and `spi.recv()` could both be collapsed into `spi.send_recv()` with an appropriate parameter pattern. There are a couple of thoughts why I still see a use for them:

1. Half-duplex operation requires pure send-only functionality. This can't be achieved with `spi.send_recv()` alone since it would generate an extra cycle for each receive: N clocks for data sending and another N clocks for data reception. Therefore I kept `spi.send()`.
2. Pushing a larger number of returned items onto the stack unnecessarily degrades the performance in case these items aren't of any interest to the user. This can be avoided with `spi.send()`.
3. `spi.recv()` was kept out of convenience considerations. Although it's always been asymmetrical with its return data being fixed to string type. I'd favour a similar approach like in `spi.send_recv()` where the user is free to choose between 3 data types.<br />
  On top of that, a string can handle data items with 8 bits at maximum - quite a restriction now that these functions support 1-32 bits.
4. After all I'm not feeling comfortable to break the existing API at the moment.

IMO this part of the API contains now a certain degree of redundancy and I'm a hesitating to merge this right away. Nevertheless, this proposal is intended to show my current status and I'd be glad to get feedback for any of its components. Maybe someone finds an elegant solution to resolve the points above.