### PR TITLE
Update full-duplex for SPI module

### DIFF
--- a/app/driver/spi.c
+++ b/app/driver/spi.c
@@ -64,7 +64,7 @@ void spi_lcd_9bit_write(uint8 spi_no,uint8 high_bit,uint8 low_8bit)
  * Description  : SPI master initial function for common byte units transmission
  * Parameters   : uint8 spi_no - SPI module number, Only "SPI" and "HSPI" are valid
 *******************************************************************************/
-void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_div, uint8 full_duplex)
+void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_div)
 {
 	uint32 regvalue; 
 
@@ -85,7 +85,7 @@ void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_
 		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, 2);//configure io to spi mode	
 	}
 
-	SET_PERI_REG_MASK(SPI_USER(spi_no), SPI_CS_SETUP|SPI_CS_HOLD|SPI_RD_BYTE_ORDER|SPI_WR_BYTE_ORDER);
+	SET_PERI_REG_MASK(SPI_USER(spi_no), SPI_CS_SETUP|SPI_CS_HOLD|SPI_RD_BYTE_ORDER|SPI_WR_BYTE_ORDER|SPI_DOUTDIN);
 
 	//set clock polarity
 	// TODO: This doesn't work
@@ -103,8 +103,7 @@ void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_
     		CLEAR_PERI_REG_MASK(SPI_USER(spi_no), SPI_CK_OUT_EDGE|SPI_CK_I_EDGE);
 	}
 
-	CLEAR_PERI_REG_MASK(SPI_USER(spi_no), SPI_FLASH_MODE|SPI_USR_MISO|
-			    SPI_USR_ADDR|SPI_USR_COMMAND|SPI_USR_DUMMY|SPI_DOUTDIN);
+	CLEAR_PERI_REG_MASK(SPI_USER(spi_no), SPI_FLASH_MODE|SPI_USR_MISO|SPI_USR_ADDR|SPI_USR_COMMAND|SPI_USR_DUMMY);
 
 	//clear Dual or Quad lines transmission mode
 	CLEAR_PERI_REG_MASK(SPI_CTRL(spi_no), SPI_QIO_MODE|SPI_DIO_MODE|SPI_DOUT_MODE|SPI_QOUT_MODE);
@@ -124,11 +123,6 @@ void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_
 					((1&SPI_CLKCNT_N)<<SPI_CLKCNT_N_S)|
 					((0&SPI_CLKCNT_H)<<SPI_CLKCNT_H_S)|
 					((1&SPI_CLKCNT_L)<<SPI_CLKCNT_L_S)); //clear bit 31,set SPI clock div
-
-        if (full_duplex > 0)
-        {
-            SET_PERI_REG_MASK(SPI_USER(spi_no), SPI_DOUTDIN);
-        }
 }
 
 /******************************************************************************
@@ -250,20 +244,21 @@ uint32 spi_mast_get_miso(uint8 spi_no, uint8 offset, uint8 bitlen)
  *                  uint16 cmd_data     - Command data.
  *                  uint8  addr_bitlen  - Valid number of bits in addr_data.
  *                  uint32 addr_data    - Address data.
- *                  uint8  mosi_bitlen  - Valid number of bits in MOSI buffer.
+ *                  uint16 mosi_bitlen  - Valid number of bits in MOSI buffer.
  *                  uint8  dummy_bitlen - Number of dummy cycles.
- *                  uint8  miso_bitlen  - number of bits to be captured in MISO buffer.
+ *                  sint16 miso_bitlen  - number of bits to be captured in MISO buffer.
+ *                                        negative value activates full-duplex mode.
 *******************************************************************************/
 void spi_mast_transaction(uint8 spi_no, uint8 cmd_bitlen, uint16 cmd_data, uint8 addr_bitlen, uint32 addr_data,
-                          uint8 mosi_bitlen, uint8 dummy_bitlen, uint8 miso_bitlen)
+                          uint16 mosi_bitlen, uint8 dummy_bitlen, sint16 miso_bitlen)
 {
     if (spi_no > 1)
         return; // handle invalid input number
 
     while(READ_PERI_REG(SPI_CMD(spi_no)) & SPI_USR);
 
-    // default disable COMMAND, ADDR, MOSI, DUMMY, MISO
-    CLEAR_PERI_REG_MASK(SPI_USER(spi_no), SPI_USR_COMMAND|SPI_USR_ADDR|SPI_USR_MOSI|SPI_USR_DUMMY|SPI_USR_MISO);
+    // default disable COMMAND, ADDR, MOSI, DUMMY, MISO, and DOUTDIN (aka full-duplex)
+    CLEAR_PERI_REG_MASK(SPI_USER(spi_no), SPI_USR_COMMAND|SPI_USR_ADDR|SPI_USR_MOSI|SPI_USR_DUMMY|SPI_USR_MISO|SPI_DOUTDIN);
     // default set bit lengths
     WRITE_PERI_REG(SPI_USER1(spi_no),
                    ((addr_bitlen - 1)  & SPI_USR_ADDR_BITLEN)    << SPI_USR_ADDR_BITLEN_S    |
@@ -297,6 +292,10 @@ void spi_mast_transaction(uint8 spi_no, uint8 cmd_bitlen, uint16 cmd_data, uint8
     if (miso_bitlen > 0)
     {
         SET_PERI_REG_MASK(SPI_USER(spi_no), SPI_USR_MISO);
+    }
+    else if (miso_bitlen < 0)
+    {
+        SET_PERI_REG_MASK(SPI_USER(spi_no), SPI_DOUTDIN);
     }
 
     // start transaction

--- a/app/include/driver/spi.h
+++ b/app/include/driver/spi.h
@@ -18,14 +18,14 @@ void spi_lcd_mode_init(uint8 spi_no);
 void spi_lcd_9bit_write(uint8 spi_no,uint8 high_bit,uint8 low_8bit);
 
 //spi master init funtion
-void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_div, uint8 full_duplex);
+void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_div);
 // fill MOSI buffer
 void spi_set_mosi(uint8 spi_no, uint8 offset, uint8 bitlen, uint32 data);
 // retrieve data from MISO buffer
 uint32 spi_get_miso(uint8 spi_no, uint8 offset, uint8 bitlen);
 // initiate SPI transaction
 void spi_mast_transaction(uint8 spi_no, uint8 cmd_bitlen, uint16 cmd_data, uint8 addr_bitlen, uint32 addr_data,
-                          uint8 mosi_bitlen, uint8 dummy_bitlen, uint8 miso_bitlen);
+                          uint16 mosi_bitlen, uint8 dummy_bitlen, sint16 miso_bitlen);
 
 //transmit data to esp8266 slave buffer,which needs 16bit transmission ,
 //first byte is master command 0x04, second byte is master data

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -435,15 +435,11 @@ int platform_i2c_recv_byte( unsigned id, int ack ){
   return r;
 }
 
-static uint8_t platform_spi_fdplx[NUM_SPI] = {0, 0};
-
 // *****************************************************************************
 // SPI platform interface
-uint32_t platform_spi_setup( uint8_t id, int mode, unsigned cpol, unsigned cpha,
-                             uint32_t clock_div, uint8 full_duplex )
+uint32_t platform_spi_setup( uint8_t id, int mode, unsigned cpol, unsigned cpha, uint32_t clock_div)
 {
-  platform_spi_fdplx[id] = full_duplex;
-  spi_master_init( id, cpol, cpha, clock_div, full_duplex );
+  spi_master_init( id, cpol, cpha, clock_div );
   return 1;
 }
 
@@ -462,7 +458,7 @@ spi_data_type platform_spi_send_recv( uint8_t id, uint8_t bitlen, spi_data_type 
     return 0;
 
   spi_mast_set_mosi( id, 0, bitlen, data );
-  spi_mast_transaction( id, 0, 0, 0, 0, bitlen, 0, platform_spi_fdplx[id] > 0 ? 0 : bitlen );
+  spi_mast_transaction( id, 0, 0, 0, 0, bitlen, 0, -1 );
   return spi_mast_get_miso( id, 0, bitlen );
 }
 
@@ -486,7 +482,7 @@ spi_data_type platform_spi_get_miso( uint8_t id, uint8_t offset, uint8_t bitlen 
 
 int platform_spi_transaction( uint8_t id, uint8_t cmd_bitlen, spi_data_type cmd_data,
                               uint8_t addr_bitlen, spi_data_type addr_data,
-                              uint8_t mosi_bitlen, uint8_t dummy_bitlen, uint8_t miso_bitlen )
+                              uint16_t mosi_bitlen, uint8_t dummy_bitlen, int16_t miso_bitlen )
 {
   if ((cmd_bitlen   >  16) ||
       (addr_bitlen  >  32) ||

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -96,7 +96,7 @@ typedef uint32_t spi_data_type;
 
 // The platform SPI functions
 int platform_spi_exists( unsigned id );
-uint32_t platform_spi_setup( uint8_t id, int mode, unsigned cpol, unsigned cpha, uint32_t clock_div, uint8_t full_duplex);
+uint32_t platform_spi_setup( uint8_t id, int mode, unsigned cpol, unsigned cpha, uint32_t clock_div);
 int platform_spi_send( uint8_t id, uint8_t bitlen, spi_data_type data );
 spi_data_type platform_spi_send_recv( uint8_t id, uint8_t bitlen, spi_data_type data );
 void platform_spi_select( unsigned id, int is_select );
@@ -105,7 +105,7 @@ int platform_spi_set_mosi( uint8_t id, uint8_t offset, uint8_t bitlen, spi_data_
 spi_data_type platform_spi_get_miso( uint8_t id, uint8_t offset, uint8_t bitlen );
 int platform_spi_transaction( uint8_t id, uint8_t cmd_bitlen, spi_data_type cmd_data,
                               uint8_t addr_bitlen, spi_data_type addr_data,
-                              uint8_t mosi_bitlen, uint8_t dummy_bitlen, uint8_t miso_bitlen );
+                              uint16_t mosi_bitlen, uint8_t dummy_bitlen, int16_t miso_bitlen );
 
 
 // *****************************************************************************


### PR DESCRIPTION
This PR refines previous #702 to consolidate the API.
* `spi.send_recv()` finally replaced by `spi.send()`.<br />
  * spi.FULLDUPLEX mode:<br />
    `wrote, rdata1[, ... [, rdatan]] = spi.send(id, data1[, ...[, datan]])`
  * spi.HALFDUPLEX mode (default):<br />
    `wrote = spi.send(id, data1[, ...[, datan]])`
* miso_bitlen for `spi.transaction()` accepts negative values to enable full-duplex MOSI&MISO operation on demand.
* Correction of mosi_bitlen parameter ranges.
