### PR TITLE
Update mqtt.c fix for #679

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -1334,7 +1334,7 @@ static int mqtt_socket_lwt( lua_State* L )
   {
     return luaL_error( L, "need lwt message");
   }
-
+  stack++;
   if(mud->connect_info.will_topic){    // free the previous one if there is any
     c_free(mud->connect_info.will_topic);
     mud->connect_info.will_topic = NULL;


### PR DESCRIPTION
Patch for  "mqtt LWT qos and retain parameters are parsed incorrectly #679". Rebased PR #697 on `dev` branch.