### PR TITLE
Request rebase instead of merge for contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,4 +4,7 @@ Thank you everyone for contributing to this project.
 
 Pull requests for new features and major fixes should be opened against the `dev` branch.
 
+Avoid intermediate merge commits. Rebase your feature branch onto `dev` to pull updates and
+verify your local changes against them before placing the pull request.
+
 *Note that the `pre_build` bin in the dev branch is never up-to-date.*


### PR DESCRIPTION
There were PRs in the past (including some of mine) that contained intermediate merge commits. IMO this should be avoided to maintain a clean commit history.

See https://www.atlassian.com/git/tutorials/merging-vs-rebasing for a conceptual discussion.