### PR TITLE
Fix compiler warning in tmr.c

### DIFF
--- a/app/modules/tmr.c
+++ b/app/modules/tmr.c
@@ -76,6 +76,7 @@ extern uint32_t platform_tmr_exists(uint32_t t);
 extern uint32_t system_rtc_clock_cali_proc();
 extern uint32_t system_get_rtc_time();
 extern void system_restart();
+extern void system_soft_wdt_feed();
 
 //in fact lua_State is constant, it's pointless to pass it around
 //but hey, whatever, I'll just pass it, still we waste 28B here


### PR DESCRIPTION
I noticed this compiler warning when I was compiling a local build: [implicit declaration of function 'system_soft_wdt_feed'](https://travis-ci.org/nodemcu/nodemcu-firmware/builds/87594740#L2409)