### PR TITLE
Better timings for WS2812 (measured 345ns/695ns, instead of 340ns/600ns)

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -31,8 +31,8 @@ static void ICACHE_RAM_ATTR ws2812_write(uint8_t pin, uint8_t *pixels, uint32_t 
   pixel = *p++;
   mask = 0x80;
   start_time = 0;
-  t0h  = (1000 * system_get_cpu_freq()) / 3333;  // 0.30us (spec=0.35 +- 0.15)
-  t1h  = (1000 * system_get_cpu_freq()) / 1666;  // 0.60us (spec=0.70 +- 0.15)
+  t0h  = (1000 * system_get_cpu_freq()) / 3526;  // 0.35us (spec=0.35 +- 0.15)
+  t1h  = (1000 * system_get_cpu_freq()) / 1591;  // 0.70us (spec=0.70 +- 0.15)
   ttot = (1000 * system_get_cpu_freq()) /  800;  // 1.25us (MUST be >= 1.25)
 
   while (true) {

--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -31,8 +31,8 @@ static void ICACHE_RAM_ATTR ws2812_write(uint8_t pin, uint8_t *pixels, uint32_t 
   pixel = *p++;
   mask = 0x80;
   start_time = 0;
-  t0h  = (1000 * system_get_cpu_freq()) / 3526;  // 0.35us (spec=0.35 +- 0.15)
-  t1h  = (1000 * system_get_cpu_freq()) / 1591;  // 0.70us (spec=0.70 +- 0.15)
+  t0h  = (1000 * system_get_cpu_freq()) / 3022;  // 0.35us (spec=0.35 +- 0.15)
+  t1h  = (1000 * system_get_cpu_freq()) / 1477;  // 0.70us (spec=0.70 +- 0.15)
   ttot = (1000 * system_get_cpu_freq()) /  800;  // 1.25us (MUST be >= 1.25)
 
   while (true) {


### PR DESCRIPTION
Timings for t1h are a little too fast for ws2812 leds.
Values measured with an oscilloscope and more close to specs.