### PR TITLE
Remove adc.readvdd33() limitation.

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -11,11 +11,13 @@
 // #define FLASH_16M
 #define FLASH_AUTOSIZE
 #define FLASH_SAFE_API
+
+// Byte 107 of esp_init_data_default, only one of these 3 can be picked
+#define ESP_INIT_DATA_ENABLE_READVDD33
+//#define ESP_INIT_DATA_ENABLE_READADC
+//#define ESP_INIT_DATA_FIXED_VDD33_VALUE 33
+
 // #define DEVELOP_VERSION
-#define FULL_VERSION_FOR_USER
-
-#define USE_OPTIMIZE_PRINTF
-
 #ifdef DEVELOP_VERSION
 #define NODE_DEBUG
 #define COAP_DEBUG

--- a/app/modules/adc.c
+++ b/app/modules/adc.c
@@ -23,25 +23,7 @@ static int adc_sample( lua_State* L )
 // Lua: readvdd33()
 static int adc_readvdd33( lua_State* L )
 {
-  uint32_t vdd33 = 0;
-
-  if(STATION_MODE == wifi_get_opmode())
-  {
-    // Bug fix
-	  if (wifi_station_get_connect_status()!=0)
-	  {
-        return luaL_error( L, "Can't read vdd33 while station is connected" );
-	  }
-	  else
-	  {
-		  vdd33 = system_get_vdd33();
-	  }
-  }
-  else
-  {
-    vdd33 = system_get_vdd33();
-  }
-  lua_pushinteger(L, vdd33);
+  lua_pushinteger(L, system_get_vdd33 ());
   return 1;
 }
 

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -30,7 +30,14 @@
 #define SIG_LUA 0
 #define SIG_UARTINPUT 1
 #define TASK_QUEUE_LEN 4
-os_event_t *taskQueue;
+
+static os_event_t *taskQueue;
+
+/* Important: no_init_data CAN NOT be left as zero initialised, as that
+ * initialisation will happen after user_start_trampoline, but before
+ * the user_init, thus clobbering our state!
+ */
+static uint8_t no_init_data = 0xff;
 
 
 /* Note: the trampoline *must* be explicitly put into the .text segment, since
@@ -47,6 +54,30 @@ void TEXT_SECTION_ATTR user_start_trampoline (void)
   // is where the cpu clock actually gets bumped to 80MHz.
   rtctime_early_startup ();
 #endif
+
+
+  /* Minimal early detection of missing esp_init_data.
+   * If it is missing, the SDK will write its own and thus we'd end up
+   * using that unless the flash size field is incorrect. This then leads
+   * to different esp_init_data being used depending on whether the user
+   * flashed with the right flash size or not (and the better option would
+   * be to flash with an *incorrect* flash size, counter-intuitively).
+   * To avoid that mess, we read out the flash size and do a test for
+   * esp_init_data based on that size. If it's missing, flag for later.
+   * If the flash size was incorrect, we'll end up fixing it all up
+   * anyway, so this ends up solving the conundrum. Only remaining issue
+   * is lack of spare code bytes in iram, so this is deliberately quite
+   * terse and not as readable as one might like.
+   */
+  SPIFlashInfo sfi;
+  SPIRead (0, &sfi, sizeof (sfi)); // Cache read not enabled yet, safe to use
+  if (sfi.size < 2) // Compensate for out-of-order 4mbit vs 2mbit values
+    sfi.size ^= 1;
+  uint32_t flash_end_addr = (256 * 1024) << sfi.size;
+  uint32_t init_data_hdr = 0xffffffff;
+  SPIRead (flash_end_addr - 4 * SPI_FLASH_SEC_SIZE, &init_data_hdr, sizeof (init_data_hdr));
+  no_init_data = (init_data_hdr == 0xffffffff);
+
   call_user_start ();
 }
 
@@ -96,10 +127,9 @@ void nodemcu_init(void)
         NODE_ERR("Self adjust flash size.\n");
         // Fit hardware real flash size.
         flash_rom_set_size_byte(flash_safe_get_size_byte());
-        // Flash init data at FLASHSIZE - 0x04000 Byte.
-        flash_init_data_default();
-        // Flash blank data at FLASHSIZE - 0x02000 Byte.
-        flash_init_data_blank();
+        // Write out init data at real location.
+        no_init_data = true;
+
         if( !fs_format() )
         {
             NODE_ERR( "\ni*** ERROR ***: unable to format. FS might be compromised.\n" );
@@ -112,12 +142,15 @@ void nodemcu_init(void)
     }
 #endif // defined(FLASH_SAFE_API)
 
-    if( !flash_init_data_written() ){
+    if (no_init_data)
+    {
         NODE_ERR("Restore init data.\n");
         // Flash init data at FLASHSIZE - 0x04000 Byte.
         flash_init_data_default();
         // Flash blank data at FLASHSIZE - 0x02000 Byte.
         flash_init_data_blank();
+        // Reboot to make the new data come into effect
+        system_restart ();
     }
 
 #if defined( BUILD_WOFS )


### PR DESCRIPTION
With the change to use the new system_get_vdd33() function for reading vdd33, it became possible to read it while connected to WiFi. As such, the explicit prevention of doing so is no longer needed nor wanted. Getting vdd33 is now possible regardless of whether the WiFi is connected (since system_get_vdd33 internally suspends WiFi while reading the vdd).

Note that system_get_vdd33() checks byte 107 of esp_init_data_default.bin, so this byte MUST be changed to 0xFF to get actual ADC readings (otherwise you'll only see 65535 returned). For whatever reason the SDK-provided esp_init_data_default.bin does not have this set.

This should thoroughly close #433, btw.