### PR TITLE
Integrate an extra build step for PRs to build a special firmware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ script:
 - cd bin/
 - file_name_integer="nodemcu_integer_${TRAVIS_TAG}.bin"
 - srec_cat -output ${file_name_integer} -binary 0x00000.bin -binary -fill 0xff 0x00000 0x10000 0x10000.bin -binary -offset 0x10000
+# http://docs.travis-ci.com/user/environment-variables/#Convenience-Variables
+- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash "$TRAVIS_BUILD_DIR"/tools/pr-build.sh; fi
 deploy:
   provider: releases
   api_key:

--- a/tools/pr-build.sh
+++ b/tools/pr-build.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+echo "Running PR build (all modules, SSL disabled)"
+(
+cd "$TRAVIS_BUILD_DIR"/app/include || exit
+# uncomment disabled modules e.g. '//#define LUA_USE_MODULES_UCG' -> '#define LUA_USE_MODULES_UCG'
+sed -E -i.bak 's@(//.*)(#define *LUA_USE_MODULES_.*)@\2@g' user_modules.h
+cat user_modules.h
+
+# disable SSL
+sed -i.bak 's@#define CLIENT_SSL_ENABLE@//#define CLIENT_SSL_ENABLE@' user_config.h
+cat user_config.h
+
+# change to "root" directory no matter where the script was started from
+cd "$TRAVIS_BUILD_DIR" || exit
+make clean
+make
+)


### PR DESCRIPTION
If the build is triggered for a PR:
- run a script at the very end that
 - enables all modules in `user_modules.h`
 - disables SSL in `user_config.h`
 - runs `make` again with the new parameters

I opted to directly change the configuration values in the `.h` files rather than trying to pass parameters to `make`. It's easier to debug IMO because I can simply dump the content of the files _after_ manipulation to the "console" and analyze it if necessary. Also, it allows for more complex manipulations should the need for that ever arise.
Any additional PR sanity checks can be added to `pr-build.sh` in the future.

Fixes #756