### PR TITLE
Handle CR corner case

### DIFF
--- a/app/lua/lua.c
+++ b/app/lua/lua.c
@@ -555,6 +555,8 @@ static bool readline(lua_Load *load){
         char next;
         if (uart_getc(&next))
           ch = next;
+        else
+          continue; // bail out
       }
       /* backspace key */
       else if (ch == 0x7f || ch == 0x08)


### PR DESCRIPTION
Ever since #687 my debugging setup with ESPlorer started to show extra new lines. I could track it down to the CR processing in `lua.c` which is ineffective when no further data can be retrieved from the UART.
This corner case now gets handled by falling back to the outer while loop in case `uart_getc()` was drained.