### PR TITLE
Rework the README file considerably

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,44 +34,6 @@ Tencent QQ group: 309957875<br />
 - add coap module (done)
 - cross compiler (done)
 
-# Change log
-2015-06-27<br />
-fixed ap/station-ap cannot connect to the device.<br />
-added wifi.ap.getconfig().<br />
-fixed net.dns.getdnsserver().<br />
-added new base64 lua example.<br />
-added node.bootreason() to inspect boot cause.<br />
-optimization of u8g.<br />
-
-# Change log
-2015-06-25<br />
-move constants to ROM. Frees up 16k+ of RAM.<br />
-add dhtlib for DHT11/21/22/33/44, port from Arduino.<br />
-add 433MHz transmission.<br />
-add crypto library.<br />
-re-add ws2812.write().<br />
-add wifi.getchannel.<br />
-changed wifi_setip() to allow setting SoftAP gateway to 0.0.0.0.<br />
-added net.dns.setdnsserver and net.dns.getdnsserver.<br />
-add support for lm92 temperature sensor.<br />
-implement getStrWidth() and setFontLineSpacingFactor().<br />
-add -Os flag to release and debug builds.<br />
-changed output format of table that is output by wifi_scan_done.<br />
-added ability to set scan configuration to wifi.sta.getap.<br />
-added function wifi.sta.getconfig().<br />
-allow connecting to unsecured WiFi networks.<br />
-add setphymode and getphymode to wifi module.<br />
-add multicastJoin and multicastLeave to net module.<br />
-add Yeelink Modules.<br />
-
-2015-03-31<br />
-polish mqtt module, add queue for mqtt module.<br />
-add reconnect option to mqtt.connect api, :connect( host, port, secure, auto_reconnect, function(client) )<br />
-move node.readvdd33 to adc.readvdd33.<br />
-tools/esptool.py supported NodeMCU devkit automatic flash.
-
-[more change log](https://github.com/nodemcu/nodemcu-firmware/wiki)<br />
-
 ##GPIO NEW TABLE ( Build 20141219 and later)
 
 <a id="new_gpio_map"></a>

--- a/README.md
+++ b/README.md
@@ -260,20 +260,9 @@ out can cause a system panic.
 
 ## Edit app/include/user_modules.h
 
-Comment-out the #define statement for unused modules.
+Comment-out the #define statement for unused modules. Example:
 
 ```c
-#define LUA_USE_BUILTIN_STRING    // for string.xxx()
-#define LUA_USE_BUILTIN_TABLE   // for table.xxx()
-#define LUA_USE_BUILTIN_COROUTINE // for coroutine.xxx()
-#define LUA_USE_BUILTIN_MATH    // for math.xxx(), partially work
-// #define LUA_USE_BUILTIN_IO       // for io.xxx(), partially work
-
-// #define LUA_USE_BUILTIN_OS     // for os.xxx(), not work
-// #define LUA_USE_BUILTIN_DEBUG    // for debug.xxx(), not work
-
-#define LUA_USE_MODULES
-
 #ifdef LUA_USE_MODULES
 #define LUA_USE_MODULES_NODE
 #define LUA_USE_MODULES_FILE
@@ -290,11 +279,35 @@ Comment-out the #define statement for unused modules.
 #define LUA_USE_MODULES_BIT
 #define LUA_USE_MODULES_MQTT
 // #define LUA_USE_MODULES_COAP
-#define LUA_USE_MODULES_U8G
-#define LUA_USE_MODULES_WS2812
-#define LUA_USE_MODULES_CJSON
+// #define LUA_USE_MODULES_U8G
+// #define LUA_USE_MODULES_WS2801
+// #define LUA_USE_MODULES_WS2812
+// #define LUA_USE_MODULES_CJSON
+#define LUA_USE_MODULES_CRYPTO
+#define LUA_USE_MODULES_RC
+#define LUA_USE_MODULES_DHT
+#define LUA_USE_MODULES_RTCMEM
+#define LUA_USE_MODULES_RTCTIME
+#define LUA_USE_MODULES_RTCFIFO
+#define LUA_USE_MODULES_SNTP
+// #define LUA_USE_MODULES_BMP085
+#define LUA_USE_MODULES_TSL2561
+// #define LUA_USE_MODULES_HX711
+
 #endif /* LUA_USE_MODULES */
 ```
+
+## Tagging your build
+
+Identify your firmware builds by editing `app/include/user_version.h`
+
+```c
+#define NODE_VERSION    "NodeMCU 1.4.0+myname"
+#ifndef BUILD_DATE
+#define BUILD_DATE        "YYYYMMDD"
+#endif
+```
+
 
 
 # GPIO NEW TABLE (Build 20141219 and later)

--- a/README.md
+++ b/README.md
@@ -366,12 +366,21 @@ NodeMCU serial interface uses 9600 baud at boot time. To increase the speed afte
 
 If the device panics and resets, errors will be written to the serial interface at 115200 bps.
 
-#Write Lua script to filesystem
-####Esplorer
-Victor Brutskiy's [Esplorer](https://github.com/4refr0nt/ESPlorer) support most platforms such as Linux, Windows, Mac OS, etc. This software is opensource and can write lua/lc files to filesystem.
+# User Interface tools
 
-####NodeMCU Studio
-[NodeMCU Studio](https://github.com/nodemcu/nodemcu-studio-csharp) is written in C# and support Windows. This software is opensource and can write lua files to filesystem.
+## Esplorer
+
+Victor Brutskiy's [ESPlorer](https://github.com/4refr0nt/ESPlorer) is written in Java, is open source and runs on most platforms such as Linux, Windows, Mac OS, etc.
+
+#### Features
+
+  - Edit Lua scripts and run on the ESP8266 and save to its flash
+  - Serial console log
+  - Also supports original AT firmware (reading and setting WiFi modes, etc)
+
+## NodeMCU Studio
+
+[NodeMCU Studio](https://github.com/nodemcu/nodemcu-studio-csharp) is written in C# and supports Windows. This software is open source and can write lua files to filesystem.
 
 # OPTIONAL MODULES
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
-# **NodeMCU** #
-version 0.9.5
+# **NodeMCU 1.4.0** #
 
 [![Join the chat at https://gitter.im/nodemcu/nodemcu-firmware](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodemcu/nodemcu-firmware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/nodemcu/nodemcu-firmware.svg)](https://travis-ci.org/nodemcu/nodemcu-firmware)  [![Download](https://img.shields.io/badge/download-~400k-orange.svg)](https://github.com/nodemcu/nodemcu-firmware/releases/latest)
 
 ###A lua based firmware for wifi-soc esp8266
-Build on [ESP8266 sdk 0.9.5](http://bbs.espressif.com/viewtopic.php?f=5&t=154)<br />
+Build on [ESP8266 sdk 1.4.0](http://bbs.espressif.com/viewtopic.php?f=46&t=1124)<br />
 Lua core based on [eLua project](http://www.eluaproject.net/)<br />
 cjson based on [lua-cjson](https://github.com/mpx/lua-cjson)<br />
 File system based on [spiffs](https://github.com/pellepl/spiffs)<br />

--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ File system based on [spiffs](https://github.com/pellepl/spiffs)<br />
 Open source development kit for NodeMCU [nodemcu-devkit](https://github.com/nodemcu/nodemcu-devkit)<br />
 Flash tool for NodeMCU [nodemcu-flasher](https://github.com/nodemcu/nodemcu-flasher)<br />
 
-wiki: [NodeMCU wiki](https://github.com/nodemcu/nodemcu-firmware/wiki)<br />
+Developer Wiki: (https://github.com/nodemcu/nodemcu-firmware/wiki)<br />
 api: [NodeMCU api](https://github.com/nodemcu/nodemcu-firmware/wiki/nodemcu_api_en)<br />
 home: [nodemcu.com](http://www.nodemcu.com)<br />
-bbs: [Chinese bbs](http://bbs.nodemcu.com)<br />
+bbs: [Chinese BBS](http://bbs.nodemcu.com)<br />
 docs: [NodeMCU docs](http://www.nodemcu.com/docs/)<br />
 Tencent QQ group: 309957875<br />
 
 # Summary
 - Easy to access wireless router
 - Based on Lua 5.1.4 (without *debug, os* module.)
-- Event-Drive programming preferred.
-- Build-in json, file, timer, pwm, i2c, spi, 1-wire, net, mqtt, coap, gpio, wifi, adc, uart and system api.
-- GPIO pin re-mapped, use the index to access gpio, i2c, pwm.
-- Both Integer(less memory usage) and Float version firmware provided.
+- Event-driven programming preferred
+- Built-in modules: json, file, timer, pwm, i2c, spi, 1-wire, net, mqtt, coap, gpio, wifi, adc, uart and system api.
+- GPIO pins re-mapped: use the index to access gpio, i2c, pwm.
+- Both Integer (less memory usage) and Float version firmware provided.
 
-# To Do List (pull requests are very welcomed)
+# To Do List (pull requests are very welcome)
 - loadable c module
 - fix wifi smart connect
 - add spi module (done)

--- a/README.md
+++ b/README.md
@@ -19,14 +19,16 @@ docs: [NodeMCU docs](http://www.nodemcu.com/docs/)<br />
 Tencent QQ group: 309957875<br />
 
 # Summary
-- Easy to access wireless router
+
+- Easy to program wireless node and/or Access Point
 - Based on Lua 5.1.4 (without *debug, os* module.)
-- Event-driven programming preferred
-- Built-in modules: json, file, timer, pwm, i2c, spi, 1-wire, net, mqtt, coap, gpio, wifi, adc, uart and system api.
+- Event-driven programming model preferred
+- Built-in modules: node, json, file, timer, pwm, i2c, spi, onewire, net, mqtt, coap, gpio, wifi, adc, uart, bit, u8g, ucg, ws2801, ws2812, crypto, dht, rtc, sntp, bmp085, tls2561, hx711 and system api.
 - GPIO pins re-mapped: use the index to access gpio, i2c, pwm.
 - Both Integer (less memory usage) and Float version firmware provided.
 
 # To Do List (pull requests are very welcome)
+
 - loadable c module
 - fix wifi smart connect
 - add spi module (done)

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ See BUILD OPTIONS below, to configure the firmware before building.
   - GNU flex, bison, gawk, sed
   - python, python-serial, libexpat-dev
   - srecord
-  - The esp-open-sdk from https://github.com/pfalcon/esp-open-sdk.git
+  - The esp-open-sdk from https://github.com/pfalcon/esp-open-sdk
 
 ### Build instructions:
 
@@ -309,16 +309,40 @@ Identify your firmware builds by editing `app/include/user_version.h`
 #endif
 ```
 
-#Flash the firmware
-nodemcu_latest.bin: 0x00000<br />
-for most esp8266 modules, just pull GPIO0 down and restart.<br />
+# Flash the firmware
+
+## Flash tools for Windows
+
 You can use the [nodemcu-flasher](https://github.com/nodemcu/nodemcu-flasher) to burn the firmware.
 
-Or, if you build your own bin from source code.<br />
-0x00000.bin: 0x00000<br />
-0x10000.bin: 0x10000<br />
+## Flash tools for Linux
 
-*Better run file.format() after flash*
+Esptool is a python utility which can read and write the flash in an ESP8266 device. See https://github.com/themadinventor/esptool
+
+## Preparing the hardware for firmware upgrade
+
+To enable ESP8266 firmware flashing, the GPIO0 pin must be pulled low before
+the device is reset. Conversely, for a normal boot, GPIO0 must be pulled high
+or floating.
+
+If you have a [NodeMCU Development Kit](http://www.nodemcu.com/index_en.html) then
+you don't need to do anything, as the USB connection can pull GPIO0
+low by asserting DTR, and reset your board by asserting RTS.
+
+If you have an ESP-01 or other device without inbuilt USB, you will need to
+enable flashing yourself by pulling GPIO0 low or pressing a "flash" switch.
+
+## Files to burn to the flash
+
+If you got your firmware from [NodeMCU custom builds](http://frightanic.com/nodemcu-custom-build) then you can flash that file directly to address 0x00000.
+
+Otherwise, if you built your own firmware from source code:
+  - bin/0x00000.bin to 0x00000
+  - bin/0x10000.bin to 0x10000
+
+Also, in some special circumstances, you may need to flash `blank.bin` or `esp_init_data_default.bin` to various addresses on the flash.
+
+If upgrading from `spiffs` version 0.3.2 to 0.3.3 or later, or after flashing any new firmware, you should run `file.format()` to re-format your flash filesystem.
 
 #Connect the hardware in serial
 baudrate:9600

--- a/README.md
+++ b/README.md
@@ -316,6 +316,15 @@ Identify your firmware builds by editing `app/include/user_version.h`
 #endif
 ```
 
+## Setting the boot time serial interface rate
+
+The initial baud rate at boot time is 9600 bps, but you can change this by
+editing `app/include/user_config.h` and change BIT_RATE_DEFAULT, e.g.:
+
+```c
+#define BIT_RATE_DEFAULT BIT_RATE_115200
+```
+
 # Flash the firmware
 
 ## Flash tools for Windows

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # **NodeMCU 1.4.0** #
 
 [![Join the chat at https://gitter.im/nodemcu/nodemcu-firmware](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/nodemcu/nodemcu-firmware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Build Status](https://travis-ci.org/nodemcu/nodemcu-firmware.svg)](https://travis-ci.org/nodemcu/nodemcu-firmware)  [![Download](https://img.shields.io/badge/download-~400k-orange.svg)](https://github.com/nodemcu/nodemcu-firmware/releases/latest)
+[![Build Status](https://travis-ci.org/nodemcu/nodemcu-firmware.svg)](https://travis-ci.org/nodemcu/nodemcu-firmware)
 
 ###A lua based firmware for wifi-soc esp8266
 Build on [ESP8266 sdk 1.4.0](http://bbs.espressif.com/viewtopic.php?f=46&t=1124)<br />

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ See BUILD OPTIONS below, to configure the firmware before building.
 
 ### Build instructions:
 
-Assuming NodeMCU firmware is checked-out to /opt/nodemcu-firmware:
+Assuming NodeMCU firmware is checked-out to `/opt/nodemcu-firmware`:
 
 ```sh
 git clone --recursive https://github.com/pfalcon/esp-open-sdk.git /opt/esp-open-sdk
@@ -259,7 +259,7 @@ Disable modules you won't be using, to reduce firmware size on flash and
 free more RAM. The ESP8266 is quite limited in available RAM, and running
 out can cause a system panic.
 
-## Edit app/include/user_modules.h
+## Edit `app/include/user_modules.h`
 
 Comment-out the #define statement for unused modules. Example:
 
@@ -340,12 +340,15 @@ Otherwise, if you built your own firmware from source code:
   - bin/0x00000.bin to 0x00000
   - bin/0x10000.bin to 0x10000
 
-Also, in some special circumstances, you may need to flash `blank.bin` or `esp_init_data_default.bin` to various addresses on the flash.
+Also, in some special circumstances, you may need to flash `blank.bin` or `esp_init_data_default.bin` to various addresses on the flash (depending on flash size and type).
 
 If upgrading from `spiffs` version 0.3.2 to 0.3.3 or later, or after flashing any new firmware, you should run `file.format()` to re-format your flash filesystem.
 
-#Connect the hardware in serial
-baudrate:9600
+# Connecting to your NodeMCU device
+
+NodeMCU serial interface uses 9600 baud at boot time. To increase the speed after booting, issue `uart.setup(0, 115200, 8, 0, 1, 1 )` (ESPlorer will do this automatically when changing the speed in the dropdown list).
+
+If the device panics and resets, errors will be written to the serial interface at 115200 bps.
 
 #Write Lua script to filesystem
 ####Esplorer

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Because Lua is a high level language and several modules are built into the firm
     print(ip)
     --nil
     wifi.setmode(wifi.STATION)
-    wifi.sta.config("SSID","password")
+    wifi.sta.config("SSID", "password")
     ip = wifi.sta.getip()
     print(ip)
     --192.168.18.110
@@ -57,8 +57,8 @@ Because Lua is a high level language and several modules are built into the firm
 
 ```lua
     pin = 1
-    gpio.mode(pin,gpio.OUTPUT)
-    gpio.write(pin,gpio.HIGH)
+    gpio.mode(pin, gpio.OUTPUT)
+    gpio.write(pin, gpio.HIGH)
     print(gpio.read(pin))
 ```
 
@@ -67,10 +67,10 @@ Because Lua is a high level language and several modules are built into the firm
 ```lua
     -- A simple http client
     conn=net.createConnection(net.TCP, 0)
-    conn:on("receive", function(conn, payload) print(payload) end )
-    conn:connect(80,"115.239.210.27")
+    conn:on("receive", function(conn, payload) print(payload) end)
+    conn:connect(80, "115.239.210.27")
     conn:send("GET / HTTP/1.1\r\nHost: www.baidu.com\r\n"
-        .."Connection: keep-alive\r\nAccept: */*\r\n\r\n")
+        .. "Connection: keep-alive\r\nAccept: */*\r\n\r\n")
 ```
 
 ## Or a simple HTTP server
@@ -78,12 +78,12 @@ Because Lua is a high level language and several modules are built into the firm
 ```lua
     -- A simple http server
     srv=net.createServer(net.TCP)
-    srv:listen(80,function(conn)
-      conn:on("receive",function(conn,payload)
+    srv:listen(80, function(conn)
+      conn:on("receive", function(conn,payload)
         print(payload)
-        conn:send("<h1> Hello, NodeMcu.</h1>")
+        conn:send("<h1> Hello, NodeMCU.</h1>")
       end)
-      conn:on("sent",function(conn) conn:close() end)
+      conn:on("sent", function(conn) conn:close() end)
     end)
 ```
 
@@ -95,33 +95,33 @@ m = mqtt.Client("clientid", 120, "user", "password")
 
 -- setup Last Will and Testament (optional)
 -- Broker will publish a message with qos = 0, retain = 0, data = "offline"
--- to topic "/lwt" if client don't send keepalive packet
+-- to topic "/lwt" if client doesn't send keepalive packet
 m:lwt("/lwt", "offline", 0, 0)
 
-m:on("connect", function(con) print ("connected") end)
-m:on("offline", function(con) print ("offline") end)
+m:on("connect", function(con) print("connected") end)
+m:on("offline", function(con) print("offline") end)
 
 -- on publish message receive event
 m:on("message", function(conn, topic, data)
-  print(topic .. ":" )
+  print(topic .. ":")
   if data ~= nil then
     print(data)
   end
 end)
 
--- m:connect( host, port, secure, auto_reconnect, function(client) )
+-- m:connect(host, port, secure, auto_reconnect, function(client) end)
 -- for secure: m:connect("192.168.11.118", 1880, 1, 0)
 -- for auto-reconnect: m:connect("192.168.11.118", 1880, 0, 1)
 m:connect("192.168.11.118", 1880, 0, 0, function(conn) print("connected") end)
 
--- subscribe topic with qos = 0
-m:subscribe("/topic",0, function(conn) print("subscribe success") end)
--- or subscribe multiple topic (topic/0, qos = 0; topic/1, qos = 1; topic2 , qos = 2)
+-- subscribe to topic with qos = 0
+m:subscribe("/topic", 0, function(conn) print("subscribe success") end)
+-- or subscribe multiple topics (topic/0, qos = 0; topic/1, qos = 1; topic2, qos = 2)
 -- m:subscribe({["topic/0"]=0,["topic/1"]=1,topic2=2}, function(conn) print("subscribe success") end)
 -- publish a message with data = hello, QoS = 0, retain = 0
-m:publish("/topic","hello",0,0, function(conn) print("sent") end)
+m:publish("/topic", "hello", 0, 0, function(conn) print("sent") end)
 
-m:close();  -- if auto-reconnect == 1, will disable auto-reconnect and then disconnect from host.
+m:close();  -- if auto-reconnect == 1, it will disable auto-reconnect and then disconnect from host.
 -- you can call m:connect again
 
 ```
@@ -131,45 +131,45 @@ m:close();  -- if auto-reconnect == 1, will disable auto-reconnect and then disc
 ```lua
 -- a udp server
 s=net.createServer(net.UDP)
-s:on("receive",function(s,c) print(c) end)
+s:on("receive", function(s, c) print(c) end)
 s:listen(5683)
 
 -- a udp client
 cu=net.createConnection(net.UDP)
-cu:on("receive",function(cu,c) print(c) end)
-cu:connect(5683,"192.168.18.101")
+cu:on("receive", function(cu, c) print(c) end)
+cu:connect(5683, "192.168.18.101")
 cu:send("hello")
 ```
 
 ## Do something shiny with an RGB LED
 
 ```lua
-  function led(r,g,b)
-    pwm.setduty(1,r)
-    pwm.setduty(2,g)
-    pwm.setduty(3,b)
+  function led(r, g, b)
+    pwm.setduty(1, r)
+    pwm.setduty(2, g)
+    pwm.setduty(3, b)
   end
-  pwm.setup(1,500,512)
-  pwm.setup(2,500,512)
-  pwm.setup(3,500,512)
+  pwm.setup(1, 500, 512)
+  pwm.setup(2, 500, 512)
+  pwm.setup(3, 500, 512)
   pwm.start(1)
   pwm.start(2)
   pwm.start(3)
-  led(512,0,0) -- red
-  led(0,0,512) -- blue
+  led(512, 0, 0) -- red
+  led(0, 0, 512) -- blue
 ```
 
 ## And blink it
 
 ```lua
   lighton=0
-  tmr.alarm(1,1000,1,function()
+  tmr.alarm(1, 1000, 1, function()
     if lighton==0 then
       lighton=1
-      led(512,512,512)
+      led(512, 512, 512)
     else
       lighton=0
-      led(0,0,0)
+      led(0, 0, 0)
     end
   end)
 ```
@@ -177,8 +177,8 @@ cu:send("hello")
 ## If you want to run something when the system boots
 
 ```lua
-  --init.lua will be excuted
-  file.open("init.lua","w")
+  --init.lua will be executed
+  file.open("init.lua", "w")
   file.writeline([[print("Hello, do this at the beginning.")]])
   file.close()
   node.restart()  -- this will restart the module.
@@ -188,21 +188,21 @@ cu:send("hello")
 
 ```lua
     -- a simple telnet server
-    s=net.createServer(net.TCP,180)
-    s:listen(2323,function(c)
+    s=net.createServer(net.TCP, 180)
+    s:listen(2323, function(c)
        function s_output(str)
           if(c~=nil)
              then c:send(str)
           end
        end
        node.output(s_output, 0)   -- re-direct output to function s_ouput.
-       c:on("receive",function(c,l)
-          node.input(l)           -- works like pcall(loadstring(l)) but support multiple separate line
+       c:on("receive", function(c, l)
+          node.input(l)           -- works like pcall(loadstring(l)) but support multiples separate lines
        end)
-       c:on("disconnection",function(c)
-          node.output(nil)        -- un-regist the redirect output function, output goes to serial
+       c:on("disconnection", function(c)
+          node.output(nil)        -- un-register the redirect output function, output goes to serial
        end)
-       print("Welcome to NodeMcu world.")
+       print("Welcome to NodeMCU world.")
     end)
 ```
 

--- a/README.md
+++ b/README.md
@@ -362,9 +362,9 @@ If upgrading from `spiffs` version 0.3.2 to 0.3.3 or later, or after flashing an
 
 # Connecting to your NodeMCU device
 
-NodeMCU serial interface uses 9600 baud at boot time. To increase the speed after booting, issue `uart.setup(0, 115200, 8, 0, 1, 1 )` (ESPlorer will do this automatically when changing the speed in the dropdown list).
+NodeMCU serial interface uses 9600 baud at boot time. To increase the speed after booting, issue `uart.setup(0,115200,8,0,1,1)` (ESPlorer will do this automatically when changing the speed in the dropdown list).
 
-If the device panics and resets, errors will be written to the serial interface at 115200 bps.
+If the device panics and resets at any time, errors will be written to the serial interface at 115200 bps.
 
 # User Interface tools
 

--- a/README.md
+++ b/README.md
@@ -4,19 +4,23 @@
 [![Build Status](https://travis-ci.org/nodemcu/nodemcu-firmware.svg)](https://travis-ci.org/nodemcu/nodemcu-firmware)
 
 ###A lua based firmware for wifi-soc esp8266
-Build on [ESP8266 sdk 1.4.0](http://bbs.espressif.com/viewtopic.php?f=46&t=1124)<br />
-Lua core based on [eLua project](http://www.eluaproject.net/)<br />
-cjson based on [lua-cjson](https://github.com/mpx/lua-cjson)<br />
-File system based on [spiffs](https://github.com/pellepl/spiffs)<br />
-Open source development kit for NodeMCU [nodemcu-devkit](https://github.com/nodemcu/nodemcu-devkit)<br />
-Flash tool for NodeMCU [nodemcu-flasher](https://github.com/nodemcu/nodemcu-flasher)<br />
+  - Build on [ESP8266 sdk 1.4.0](http://bbs.espressif.com/viewtopic.php?f=46&t=1124)
+  - Lua core based on [eLua project](http://www.eluaproject.net/)
+  - cjson based on [lua-cjson](https://github.com/mpx/lua-cjson)
+  - File system based on [spiffs](https://github.com/pellepl/spiffs)
+  - Open source development kit for NodeMCU [nodemcu-devkit](https://github.com/nodemcu/nodemcu-devkit)
+  - Flash tool for NodeMCU [nodemcu-flasher](https://github.com/nodemcu/nodemcu-flasher)
 
-Developer Wiki: (https://github.com/nodemcu/nodemcu-firmware/wiki)<br />
-api: [NodeMCU api](https://github.com/nodemcu/nodemcu-firmware/wiki/nodemcu_api_en)<br />
-home: [nodemcu.com](http://www.nodemcu.com)<br />
-bbs: [Chinese BBS](http://bbs.nodemcu.com)<br />
-docs: [NodeMCU docs](http://www.nodemcu.com/docs/)<br />
-Tencent QQ group: 309957875<br />
+### Resources
+
+| Resource | Location |
+| -------------- | -------------- |
+| Developer Wiki | https://github.com/nodemcu/nodemcu-firmware/wiki |
+| api | [NodeMCU api](https://github.com/nodemcu/nodemcu-firmware/wiki/nodemcu_api_en) |
+| home | [nodemcu.com](http://www.nodemcu.com) |
+| bbs | [Chinese BBS](http://bbs.nodemcu.com) |
+| docs | [NodeMCU docs](http://www.nodemcu.com/docs/) |
+| Tencent QQ group | 309957875 |
 
 # Summary
 
@@ -211,7 +215,7 @@ There are several options for building the NodeMCU firmware.
 
 ## Online firmware custom build
 
-Please try Marcel's [NodeMCU custom builds](http://frightanic.com/nodemcu-custom-build) cloud service and you can choose only the modules you need, and download the firmware once built.<br />
+Please try Marcel's [NodeMCU custom builds](http://frightanic.com/nodemcu-custom-build) cloud service and you can choose only the modules you need, and download the firmware once built.
 
 NodeMCU custom builds can build from the master branch (0.9.6; deprecated) and dev
 branch (1.4.0).

--- a/README.md
+++ b/README.md
@@ -9,18 +9,6 @@
   - cjson based on [lua-cjson](https://github.com/mpx/lua-cjson)
   - File system based on [spiffs](https://github.com/pellepl/spiffs)
   - Open source development kit for NodeMCU [nodemcu-devkit](https://github.com/nodemcu/nodemcu-devkit)
-  - Flash tool for NodeMCU [nodemcu-flasher](https://github.com/nodemcu/nodemcu-flasher)
-
-### Resources
-
-| Resource | Location |
-| -------------- | -------------- |
-| Developer Wiki | https://github.com/nodemcu/nodemcu-firmware/wiki |
-| api | [NodeMCU api](https://github.com/nodemcu/nodemcu-firmware/wiki/nodemcu_api_en) |
-| home | [nodemcu.com](http://www.nodemcu.com) |
-| bbs | [Chinese BBS](http://bbs.nodemcu.com) |
-| docs | [NodeMCU docs](http://www.nodemcu.com/docs/) |
-| Tencent QQ group | 309957875 |
 
 # Summary
 
@@ -29,6 +17,21 @@
 - Event-driven programming model preferred
 - Built-in modules: node, json, file, timer, pwm, i2c, spi, onewire, net, mqtt, coap, gpio, wifi, adc, uart, bit, u8g, ucg, ws2801, ws2812, crypto, dht, rtc, sntp, bmp085, tls2561, hx711 and system api.
 - Both Integer (less memory usage) and Float version firmware provided.
+
+## Useful links
+
+| Resource | Location |
+| -------------- | -------------- |
+| Developer Wiki       | https://github.com/nodemcu/nodemcu-firmware/wiki |
+| API docs             | [NodeMCU api](https://github.com/nodemcu/nodemcu-firmware/wiki/nodemcu_api_en) |
+| Home                 | [nodemcu.com](http://www.nodemcu.com) |
+| BBS                  | [Chinese BBS](http://bbs.nodemcu.com) |
+| Docs                 | [NodeMCU docs](http://www.nodemcu.com/docs/) |
+| Tencent QQ group     | 309957875 |
+| Windows flash tool   | [nodemcu-flasher](https://github.com/nodemcu/nodemcu-flasher) |
+| Linux flash tool     | [Esptool](https://github.com/themadinventor/esptool) |
+| ESPlorer GUI         | https://github.com/4refr0nt/ESPlorer |
+| NodeMCU Studio GUI   | https://github.com/nodemcu/nodemcu-studio-csharp |
 
 # To Do List (pull requests are very welcome)
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,99 @@ cu:send("hello")
     end)
 ```
 
+# Building the firmware
+
+There are several options for building the NodeMCU firmware.
+
+## Online firmware custom build
+
+Please try Marcel's [NodeMCU custom builds](http://frightanic.com/nodemcu-custom-build) cloud service and you can choose only the modules you need, and download the firmware once built.<br />
+
+NodeMCU custom builds can build from the master branch (0.9.6; deprecated) and dev
+branch (1.4.0).
+
+## Docker containerised build
+
+See https://hub.docker.com/r/asmaps/nodemcu-builder/
+
+This docker image includes the build toolchain and SDK. You just run the docker
+image with your checked-out NodeMCU firmware repository (this one). The docker
+image can also flash the firmware to your device.
+
+You will need to see BUILD OPTIONS below, to configure the firmware before building.
+
+## Build it yourself
+
+See BUILD OPTIONS below, to configure the firmware before building.
+
+### Minimum requirements:
+
+  - unrar
+  - GNU autoconf, automake, libtool
+  - GNU gcc, g++, make
+  - GNU flex, bison, gawk, sed
+  - python, python-serial, libexpat-dev
+  - srecord
+  - The esp-open-sdk from https://github.com/pfalcon/esp-open-sdk.git
+
+### Build instructions:
+
+Assuming NodeMCU firmware is checked-out to /opt/nodemcu-firmware:
+
+```sh
+git clone --recursive https://github.com/pfalcon/esp-open-sdk.git /opt/esp-open-sdk
+cd /opt/esp-open-sdk
+make STANDALONE=y
+PATH=/opt/esp-open-sdk/xtensa-lx106-elf/bin:$PATH
+cd /opt/nodemcu-firmware
+make
+```
+
+# BUILD OPTIONS
+
+Disable modules you won't be using, to reduce firmware size on flash and
+free more RAM. The ESP8266 is quite limited in available RAM, and running
+out can cause a system panic.
+
+## Edit app/include/user_modules.h
+
+Comment-out the #define statement for unused modules.
+
+```c
+#define LUA_USE_BUILTIN_STRING    // for string.xxx()
+#define LUA_USE_BUILTIN_TABLE   // for table.xxx()
+#define LUA_USE_BUILTIN_COROUTINE // for coroutine.xxx()
+#define LUA_USE_BUILTIN_MATH    // for math.xxx(), partially work
+// #define LUA_USE_BUILTIN_IO       // for io.xxx(), partially work
+
+// #define LUA_USE_BUILTIN_OS     // for os.xxx(), not work
+// #define LUA_USE_BUILTIN_DEBUG    // for debug.xxx(), not work
+
+#define LUA_USE_MODULES
+
+#ifdef LUA_USE_MODULES
+#define LUA_USE_MODULES_NODE
+#define LUA_USE_MODULES_FILE
+#define LUA_USE_MODULES_GPIO
+#define LUA_USE_MODULES_WIFI
+#define LUA_USE_MODULES_NET
+#define LUA_USE_MODULES_PWM
+#define LUA_USE_MODULES_I2C
+#define LUA_USE_MODULES_SPI
+#define LUA_USE_MODULES_TMR
+#define LUA_USE_MODULES_ADC
+#define LUA_USE_MODULES_UART
+#define LUA_USE_MODULES_OW
+#define LUA_USE_MODULES_BIT
+#define LUA_USE_MODULES_MQTT
+// #define LUA_USE_MODULES_COAP
+#define LUA_USE_MODULES_U8G
+#define LUA_USE_MODULES_WS2812
+#define LUA_USE_MODULES_CJSON
+#endif /* LUA_USE_MODULES */
+```
+
+
 # GPIO NEW TABLE (Build 20141219 and later)
 
 <a id="new_gpio_map"></a>
@@ -238,46 +331,6 @@ cu:send("hello")
 </table>
 #### [*] D0(GPIO16) can only be used as gpio read/write. no interrupt supported. no pwm/i2c/ow supported.
 
-#Build option
-####file ./app/include/user_modules.h
-```c
-#define LUA_USE_BUILTIN_STRING    // for string.xxx()
-#define LUA_USE_BUILTIN_TABLE   // for table.xxx()
-#define LUA_USE_BUILTIN_COROUTINE // for coroutine.xxx()
-#define LUA_USE_BUILTIN_MATH    // for math.xxx(), partially work
-// #define LUA_USE_BUILTIN_IO       // for io.xxx(), partially work
-
-// #define LUA_USE_BUILTIN_OS     // for os.xxx(), not work
-// #define LUA_USE_BUILTIN_DEBUG    // for debug.xxx(), not work
-
-#define LUA_USE_MODULES
-
-#ifdef LUA_USE_MODULES
-#define LUA_USE_MODULES_NODE
-#define LUA_USE_MODULES_FILE
-#define LUA_USE_MODULES_GPIO
-#define LUA_USE_MODULES_WIFI
-#define LUA_USE_MODULES_NET
-#define LUA_USE_MODULES_PWM
-#define LUA_USE_MODULES_I2C
-#define LUA_USE_MODULES_SPI
-#define LUA_USE_MODULES_TMR
-#define LUA_USE_MODULES_ADC
-#define LUA_USE_MODULES_UART
-#define LUA_USE_MODULES_OW
-#define LUA_USE_MODULES_BIT
-#define LUA_USE_MODULES_MQTT
-// #define LUA_USE_MODULES_COAP
-#define LUA_USE_MODULES_U8G
-#define LUA_USE_MODULES_WS2812
-#define LUA_USE_MODULES_CJSON
-#endif /* LUA_USE_MODULES */
-```
-#Online firmware custom build
-
-For many application, some modules are not used, remove them can free many memory.<br />
-
-Please try Marcel's [NodeMCU custom builds](http://frightanic.com/nodemcu-custom-build) cloud service and you can get your own firmware.<br />
 
 #Flash the firmware
 nodemcu_latest.bin: 0x00000<br />
@@ -300,6 +353,7 @@ Victor Brutskiy's [Esplorer](https://github.com/4refr0nt/ESPlorer) support most 
 ####NodeMCU Studio
 [NodeMCU Studio](https://github.com/nodemcu/nodemcu-studio-csharp) is written in C# and support Windows. This software is opensource and can write lua files to filesystem.
 
+# OPTIONAL MODULES
 
 ####Use DS18B20 module extends your esp8266
 ```lua

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Tencent QQ group: 309957875<br />
 - Based on Lua 5.1.4 (without *debug, os* module.)
 - Event-driven programming model preferred
 - Built-in modules: node, json, file, timer, pwm, i2c, spi, onewire, net, mqtt, coap, gpio, wifi, adc, uart, bit, u8g, ucg, ws2801, ws2812, crypto, dht, rtc, sntp, bmp085, tls2561, hx711 and system api.
-- GPIO pins re-mapped: use the index to access gpio, i2c, pwm.
 - Both Integer (less memory usage) and Float version firmware provided.
 
 # To Do List (pull requests are very welcome)
@@ -309,43 +308,6 @@ Identify your firmware builds by editing `app/include/user_version.h`
 #define BUILD_DATE        "YYYYMMDD"
 #endif
 ```
-
-
-
-# GPIO NEW TABLE (Build 20141219 and later)
-
-<a id="new_gpio_map"></a>
-<table>
-  <tr>
-    <th scope="col">IO index</th><th scope="col">ESP8266 pin</th><th scope="col">IO index</th><th scope="col">ESP8266 pin</th>
-  </tr>
-  <tr>
-    <td>0 [*]</td><td>GPIO16</td><td>8</td><td>GPIO15 (SPI CS)</td>
-  </tr>
-  <tr>
-    <td>1</td><td>GPIO5</td><td>9</td><td>GPIO3 (UART RX)</td>
-   </tr>
-   <tr>
-    <td>2</td><td>GPIO4</td><td>10</td><td>GPIO1 (UART TX)</td>
-  </tr>
-  <tr>
-    <td>3</td><td>GPIO0</td><td>11</td><td>GPIO9</td>
-   </tr>
-   <tr>
-    <td>4</td><td>GPIO2</td><td>12</td><td>GPIO10</td>
-  </tr>
-  <tr>
-    <td>5</td><td>GPIO14 (SPI CLK)</td><td></td><td></td>
-   </tr>
-   <tr>
-    <td>6</td><td>GPIO12 (SPI MISO)</td><td></td><td></td>
-  </tr>
-  <tr>
-    <td>7</td><td>GPIO13 (SPI MOSI)</td><td></td><td></td>
-   </tr>
-</table>
-#### [*] D0(GPIO16) can only be used as gpio read/write. no interrupt supported. no pwm/i2c/ow supported.
-
 
 #Flash the firmware
 nodemcu_latest.bin: 0x00000<br />


### PR DESCRIPTION
Nobody had updated the README file from 0.9.5 to 1.4.0 and so that was my starting point.

Looking at the README from the point of a new user, information you need to know wasn't there or was presented in the wrong order.

- Restructured to remove a lot of irrelevant information (e.g changelog)
- Reordered to show general features first, then show off the platform capabilities, then explain how to build it, how to configure it, how to flash it and then how to run it after flashing
- Added info about esptool (the lack of doco confused me initially as a Linux user, as I couldn't use nodemcu-flasher and there was no note in the README to say it was for Windows only)
- Updated info about Marcel's cloud build server (you *do* need to tell people to build the dev branch or they will build from master)
- Added a link to the docker containerised build, which is the easiest way to build a firmware with your own patches
- Added sufficient detailed build instructions for anybody who really wants to install the toolchain
- Updated the list of optional modules in user_modules.h
- Added instructions on tagging your own builds
- Added instructions on changing the boot time serial interface rate
- Described the GPIO0 conditions for normal boot and for flash upgrade
- Gave more detailed instructions on what needs to be flashed
- And how to connect the device
- And the least interesting code snippets went down the bottom of the document where they can be cleaned up later.

After merging this pull request into dev I'd suggest also merging it into master, or probably nobody will see it until dev itself becomes master.