### PR TITLE
Provide GIT_HASH as version information

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ install:
 - tar -zxvf tools/esp-open-sdk.tar.gz
 - export PATH=$PATH:$PWD/esp-open-sdk/xtensa-lx106-elf/bin
 script:
+- export GIT_HASH=$(git log --pretty=format:%h -n 1)
 - export BUILD_DATE=$(date +%Y%m%d)
-- make EXTRA_CCFLAGS="-DBUILD_DATE='\"'$BUILD_DATE'\"'" all
+- make EXTRA_CCFLAGS="-DBUILD_DATE='\"'$BUILD_DATE'\"' -DGIT_HASH='\"'$GIT_HASH'\"'" all
 - cd bin/
 - file_name_float="nodemcu_float_${TRAVIS_TAG}.bin"
 - srec_cat -output ${file_name_float} -binary 0x00000.bin -binary -fill 0xff 0x00000 0x10000 0x10000.bin -binary -offset 0x10000

--- a/app/Makefile
+++ b/app/Makefile
@@ -126,9 +126,7 @@ DEPENDS_eagle.app.v6 = 				\
 #   for a subtree within the makefile rooted therein
 #
 
-BUILD_DATE=$(shell git log --pretty=format:%h -n 1)
-UNIVERSAL_TARGET_DEFINES = 			\
-	-DBUILD_DATE='"$(BUILD_DATE)"'
+#UNIVERSAL_TARGET_DEFINES = 			\
 
 # Other potential configuration flags include:
 #	-DTXRX_TXBUF_DEBUG

--- a/app/Makefile
+++ b/app/Makefile
@@ -126,7 +126,9 @@ DEPENDS_eagle.app.v6 = 				\
 #   for a subtree within the makefile rooted therein
 #
 
-#UNIVERSAL_TARGET_DEFINES = 			\
+BUILD_DATE=$(shell git log --pretty=format:%h -n 1)
+UNIVERSAL_TARGET_DEFINES = 			\
+	-DBUILD_DATE='"$(BUILD_DATE)"'
 
 # Other potential configuration flags include:
 #	-DTXRX_TXBUF_DEBUG

--- a/app/include/user_version.h
+++ b/app/include/user_version.h
@@ -8,7 +8,11 @@
 
 #define NODE_VERSION	"NodeMCU 1.4.0"
 #ifndef BUILD_DATE
-#define BUILD_DATE	  "20151006"
+#define BUILD_DATE	"20151006"
+#endif
+
+#ifndef GIT_HASH
+#define GIT_HASH	"unknown"
 #endif
 
 extern char SDK_VERSION[];

--- a/app/lua/lua.c
+++ b/app/lua/lua.c
@@ -126,7 +126,7 @@ static int docall (lua_State *L, int narg, int clear) {
 
 
 static void print_version (lua_State *L) {
-  lua_pushliteral (L, "\n" NODE_VERSION " build " BUILD_DATE " powered by " LUA_RELEASE " on SDK ");
+  lua_pushliteral (L, "\n" NODE_VERSION " (" GIT_HASH ") build " BUILD_DATE " powered by " LUA_RELEASE " on SDK ");
   lua_pushstring (L, SDK_VERSION);
   lua_concat (L, 2);
   const char *msg = lua_tostring (L, -1);


### PR DESCRIPTION
Not having any particular version information when your are searching for bugs in a module that has been flashed months ago. The git hash helps to identify the version in use.