### PR TITLE
Merge Onewire changes from Master into Dev

### DIFF
--- a/app/driver/onewire.c
+++ b/app/driver/onewire.c
@@ -407,10 +407,15 @@ uint8_t onewire_search(uint8_t pin, uint8_t *newAddr)
       LastFamilyDiscrepancy[pin] = 0;
       search_result = FALSE;
    }
-   int i;
-   for (i = 0; i < 8; i++) newAddr[i] = ROM_NO[pin][i];
+   else
+   {
+      for (rom_byte_number = 0; rom_byte_number < 8; rom_byte_number++)
+      {
+         newAddr[rom_byte_number] = ROM_NO[pin][rom_byte_number];
+      }
+   }
    return search_result;
-  }
+}
 
 #endif
 


### PR DESCRIPTION
Master contained two OW changes one of which was already reimplemented in dev using the
correct macros.  The second was from hazarkarabay (f6d0c0c) that onewire_search()
returns a device address vector even when no device is found.  I've reimplemented this
but using the correct index, rom_byte_number, rather than declaring a new temp index i.