### PR TITLE
Add uart.alt function to swap to using RTS and CTS as RX and TX (pins…

### DIFF
--- a/app/driver/uart.c
+++ b/app/driver/uart.c
@@ -66,6 +66,39 @@ uart_config(uint8 uart_no)
     SET_PERI_REG_MASK(UART_INT_ENA(uart_no), UART_RXFIFO_FULL_INT_ENA);
 }
 
+
+
+/******************************************************************************
+ * FunctionName : uart0_alt
+ * Description  : Internal used function
+ *                UART0 pins changed to 13,15 if 'on' is set, else set to normal pins
+ * Parameters   : on - 1 = use alternate pins, 0 = use normal pins
+ * Returns      : NONE
+*******************************************************************************/
+void ICACHE_FLASH_ATTR
+uart0_alt(uint8 on)
+{
+    if (on)
+    {
+        PIN_PULLUP_DIS(PERIPHS_IO_MUX_MTDO_U);
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, FUNC_U0RTS);
+        PIN_PULLUP_EN(PERIPHS_IO_MUX_MTCK_U);
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTCK_U, FUNC_U0CTS);
+        // now make RTS/CTS behave as TX/RX
+        IOSWAP |= (1 << IOSWAPU0);
+    }
+    else
+    {
+        PIN_PULLUP_DIS(PERIPHS_IO_MUX_U0TXD_U);
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD);
+        PIN_PULLUP_EN(PERIPHS_IO_MUX_U0RXD_U);
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0RXD_U, FUNC_U0RXD);
+        // now make RX/TX behave as TX/RX
+        IOSWAP &= ~(1 << IOSWAPU0);
+    }
+}
+
+
 /******************************************************************************
  * FunctionName : uart_tx_one_char
  * Description  : Internal used function

--- a/app/include/driver/uart.h
+++ b/app/include/driver/uart.h
@@ -101,6 +101,7 @@ typedef struct {
 } UartDevice;
 
 void uart_init(UartBautRate uart0_br, UartBautRate uart1_br);
+void uart0_alt(uint8 on);
 void uart0_sendStr(const char *str);
 void uart0_putc(const char c);
 void uart0_tx_buffer(uint8 *buf, uint16 len);

--- a/app/include/driver/uart_register.h
+++ b/app/include/driver/uart_register.h
@@ -125,4 +125,17 @@
 
 #define UART_DATE( i )                          (REG_UART_BASE( i ) + 0x78)
 #define UART_ID( i )                            (REG_UART_BASE( i ) + 0x7C)
+
+#define ESP8266_DREG(addr) *((volatile uint32_t *)(0x3FF00000+(addr)))
+
+//IO SWAP Register
+#define IOSWAP    ESP8266_DREG(0x28)
+#define IOSWAPU   0 //Swaps UART
+#define IOSWAPS   1 //Swaps SPI
+#define IOSWAPU0  2 //Swaps UART 0 pins (u0rxd <-> u0cts), (u0txd <-> u0rts)
+#define IOSWAPU1  3 //Swaps UART 1 pins (u1rxd <-> u1cts), (u1txd <-> u1rts)
+#define IOSWAPHS  5 //Sets HSPI with higher prio
+#define IOSWAP2HS 6 //Sets Two SPI Masters on HSPI
+#define IOSWAP2CS 7 //Sets Two SPI Masters on CSPI
+
 #endif // UART_REGISTER_H_INCLUDED

--- a/app/modules/uart.c
+++ b/app/modules/uart.c
@@ -116,6 +116,17 @@ static int uart_setup( lua_State* L )
   return 1;
 }
 
+// Lua: alt( set )
+static int uart_alt( lua_State* L )
+{
+  unsigned set;
+  
+  set = luaL_checkinteger( L, 1 );
+
+  platform_uart_alt( set );
+  return 0;
+}
+
 // Lua: write( id, string1, [string2], ..., [stringn] )
 static int uart_write( lua_State* L )
 {
@@ -154,6 +165,8 @@ const LUA_REG_TYPE uart_map[] =
   { LSTRKEY( "setup" ),  LFUNCVAL( uart_setup ) },
   { LSTRKEY( "write" ), LFUNCVAL( uart_write ) },
   { LSTRKEY( "on" ), LFUNCVAL( uart_on ) },
+  { LSTRKEY( "alt" ), LFUNCVAL( uart_alt ) },
+
 #if LUA_OPTIMIZE_MEMORY > 0
 
 #endif

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -259,6 +259,14 @@ uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int pari
   return baud;
 }
 
+// if set=1, then alternate serial output pins are used. (15=rx, 13=tx)
+void platform_uart_alt( int set )
+{
+    uart0_alt( set );
+    return;
+}
+
+
 // Send: version with and without mux
 void platform_uart_send( unsigned id, u8 data ) 
 {

--- a/include/eagle_soc.h
+++ b/include/eagle_soc.h
@@ -197,6 +197,7 @@
 #define FUNC_GPIO12                     3
 #define PERIPHS_IO_MUX_MTCK_U           (PERIPHS_IO_MUX + 0x08)
 #define FUNC_GPIO13                     3
+#define FUNC_U0CTS                      4
 #define PERIPHS_IO_MUX_MTMS_U           (PERIPHS_IO_MUX + 0x0C)
 #define FUNC_GPIO14                     3
 #define PERIPHS_IO_MUX_MTDO_U           (PERIPHS_IO_MUX + 0x10)

--- a/lua_modules/dht_lib/dht_lib.lua
+++ b/lua_modules/dht_lib/dht_lib.lua
@@ -103,7 +103,7 @@ function M.read(pin)
 
   for i = 1, 8, 1 do -- Byte[3]
     if (bitStream[i+24] > 3) then
-      byte_2 = byte_2 + 2 ^ (8 - i)
+      byte_3 = byte_2 + 2 ^ (8 - i)
     end
   end
 

--- a/lua_modules/dht_lib/dht_lib.lua
+++ b/lua_modules/dht_lib/dht_lib.lua
@@ -103,7 +103,7 @@ function M.read(pin)
 
   for i = 1, 8, 1 do -- Byte[3]
     if (bitStream[i+24] > 3) then
-      byte_3 = byte_2 + 2 ^ (8 - i)
+      byte_3 = byte_3 + 2 ^ (8 - i)
     end
   end
 


### PR DESCRIPTION
I wanted to use the alternate serial pins (GPIO13 & GPIO15) on the ESP03, but the code did not seem to be there.
I've added some defines for the IOSWAP register in uart_register.h, and then used them in a new function uart0_alt(), plus implemented calling through to the function from Lua.
With these changes, the 'normal' serial can remain in place for flash, diagnostics, etc. while serial peripherals don't get hassled with bootup output.
I've tested that the serial no longer comes out of the normal pins, but not wired to the new pins yet!

ignore the config changes..... did not know how to exclude them from the pull request