### PR TITLE
Do not allow execution to continue after a PANIC

### DIFF
--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -816,6 +816,7 @@ static int panic (lua_State *L) {
   luai_writestringerror("PANIC: unprotected error in call to Lua API (%s)\n",
                    lua_tostring(L, -1));
 #endif
+  while (1) {}
   return 0;
 }
 


### PR DESCRIPTION
As discussed in #801, I thought I'd already pushed this.