### PR TITLE
Remove the lobject.c:88 assertion failures

### DIFF
--- a/app/lua/lobject.c
+++ b/app/lua/lobject.c
@@ -83,9 +83,11 @@ int luaO_rawequalObj (const TValue *t1, const TValue *t2) {
     case LUA_TBOOLEAN:
       return bvalue(t1) == bvalue(t2);  /* boolean true must be 1 !! */
     case LUA_TLIGHTUSERDATA:
-    case LUA_TROTABLE:
-    case LUA_TLIGHTFUNCTION:
       return pvalue(t1) == pvalue(t2);
+    case LUA_TROTABLE:
+      return rvalue(t1) == rvalue(t2);
+    case LUA_TLIGHTFUNCTION:
+      return fvalue(t1) == fvalue(t2);
     default:
       lua_assert(iscollectable(t1));
       return gcvalue(t1) == gcvalue(t2);


### PR DESCRIPTION
When lua assertions are enabled, normal operation results in many:

```
lobject.c:88: (((t1)->tt) == 4)
lobject.c:88: (((t2)->tt) == 4)
lobject.c:88: (((t1)->tt) == 4)
lobject.c:88: (((t2)->tt) == 4)
lobject.c:88: (((t1)->tt) == 4)
lobject.c:88: (((t2)->tt) == 4)
```

It comes from using the pvalue() macro for 3 pointer types, where pvalue() also checks the type of pointer and complains through the assertion where the type == 4 (TLIGHTUSERDATA).

Use the correct macro according to the type of data being compared to eliminate this assertion error.

Signed-off-by: Nick Andrew <nick@nick-andrew.net>