### PR TITLE
Cleanup/minor correction: Flash addr cleanup

### DIFF
--- a/app/platform/common.c
+++ b/app/platform/common.c
@@ -149,7 +149,7 @@ uint32_t platform_flash_get_first_free_block_address( uint32_t *psect )
   uint32_t start, end, sect;
   NODE_DBG("_flash_used_end:%08x\n", (uint32_t)_flash_used_end);
   if(_flash_used_end>0){ // find the used sector
-    sect = flashh_find_sector( ( uint32_t )_flash_used_end - INTERNAL_FLASH_MAPPED_ADDRESS - 1, NULL, &end );
+    sect = flashh_find_sector( platform_flash_mapped2phys ( (uint32_t)_flash_used_end - 1), NULL, &end );
     if( psect )
       *psect = sect + 1;    
     return end + 1;

--- a/app/platform/common.c
+++ b/app/platform/common.c
@@ -102,15 +102,14 @@ extern char _flash_used_end[];
 // Return the sector number, as well as the start and end address of the sector
 static uint32_t flashh_find_sector( uint32_t address, uint32_t *pstart, uint32_t *pend )
 {
-  address -= INTERNAL_FLASH_START_ADDRESS;
 #ifdef INTERNAL_FLASH_SECTOR_SIZE
   // All the sectors in the flash have the same size, so just align the address
   uint32_t sect_id = address / INTERNAL_FLASH_SECTOR_SIZE;
 
   if( pstart )
-    *pstart = sect_id * INTERNAL_FLASH_SECTOR_SIZE + INTERNAL_FLASH_START_ADDRESS;
+    *pstart = sect_id * INTERNAL_FLASH_SECTOR_SIZE ;
   if( pend )
-    *pend = ( sect_id + 1 ) * INTERNAL_FLASH_SECTOR_SIZE + INTERNAL_FLASH_START_ADDRESS - 1;
+    *pend = ( sect_id + 1 ) * INTERNAL_FLASH_SECTOR_SIZE - 1;
   return sect_id;
 #else // #ifdef INTERNAL_FLASH_SECTOR_SIZE
   // The flash has blocks of different size
@@ -121,9 +120,9 @@ static uint32_t flashh_find_sector( uint32_t address, uint32_t *pstart, uint32_t
   while( ( total <= address ) && ( i < sizeof( flash_sect_size ) / sizeof( uint32_t ) ) )
     total += flash_sect_size[ i ++ ];
   if( pstart )
-    *pstart = ( total - flash_sect_size[ i - 1 ] ) + INTERNAL_FLASH_START_ADDRESS;
+    *pstart = ( total - flash_sect_size[ i - 1 ] );
   if( pend )
-    *pend = total + INTERNAL_FLASH_START_ADDRESS - 1;
+    *pend = total - 1;
   return i - 1;
 #endif // #ifdef INTERNAL_FLASH_SECTOR_SIZE
 }
@@ -150,13 +149,12 @@ uint32_t platform_flash_get_first_free_block_address( uint32_t *psect )
   uint32_t start, end, sect;
   NODE_DBG("_flash_used_end:%08x\n", (uint32_t)_flash_used_end);
   if(_flash_used_end>0){ // find the used sector
-    // sect = flashh_find_sector( ( uint32_t )flash_used_size + INTERNAL_FLASH_START_ADDRESS - 1, NULL, &end );
-    sect = flashh_find_sector( ( uint32_t )_flash_used_end - 1, NULL, &end );
+    sect = flashh_find_sector( ( uint32_t )_flash_used_end - INTERNAL_FLASH_MAPPED_ADDRESS - 1, NULL, &end );
     if( psect )
       *psect = sect + 1;    
     return end + 1;
   }else{
-    sect = flashh_find_sector( INTERNAL_FLASH_START_ADDRESS, &start, NULL ); // find the first free sector
+    sect = flashh_find_sector( 0, &start, NULL ); // find the first free sector
     if( psect )
       *psect = sect;   
     return start;

--- a/app/platform/cpu_esp8266.h
+++ b/app/platform/cpu_esp8266.h
@@ -53,7 +53,7 @@
 #define INTERNAL_FLASH_READ_UNIT_SIZE	4
 
 #define INTERNAL_FLASH_SIZE             ( (SYS_PARAM_SEC_START) * INTERNAL_FLASH_SECTOR_SIZE )
-#define INTERNAL_FLASH_START_ADDRESS    0x40200000
+#define INTERNAL_FLASH_MAPPED_ADDRESS    0x40200000
 
 // SpiFlashOpResult spi_flash_erase_sector(uint16 sec);
 // SpiFlashOpResult spi_flash_write(uint32 des_addr, uint32 *src_addr, uint32 size);

--- a/app/platform/cpu_esp8266.h
+++ b/app/platform/cpu_esp8266.h
@@ -68,4 +68,9 @@
 #define flash_read spi_flash_read
 #endif // defined(FLASH_SAFE_API)
 
+#define CACHE_FLASH_CTRL_REG         0x3ff0000c
+#define CACHE_FLASH_ACTIVE           0x00000100
+#define CACHE_FLASH_MAPPED0          0x02000000
+#define CACHE_FLASH_MAPPED1          0x00010000
+
 #endif // #ifndef __CPU_ESP8266_H__

--- a/app/platform/flash_api.c
+++ b/app/platform/flash_api.c
@@ -96,11 +96,6 @@ SpiFlashOpResult flash_safe_erase_sector(uint16 sec)
 SPIFlashInfo flash_rom_getinfo(void)
 {
     volatile SPIFlashInfo spi_flash_info ICACHE_STORE_ATTR;
-    // Don't use it before cache read disabled
-    // FLASH_DISABLE_CACHE();
-    // spi_flash_info = *((SPIFlashInfo *)(FLASH_ADDRESS_START_MAP));
-    // FLASH_ENABLE_CACHE();
-    // Needn't safe mode.
     spi_flash_read(0, (uint32 *)(& spi_flash_info), sizeof(spi_flash_info));
     return spi_flash_info;
 }

--- a/app/platform/flash_api.h
+++ b/app/platform/flash_api.h
@@ -4,8 +4,6 @@
 #include "user_config.h"
 #include "cpu_esp8266.h"
 
-#define FLASH_ADDRESS_START_MAP (INTERNAL_FLASH_START_ADDRESS)
-
 #define FLASH_SIZE_2MBIT    (2   * 1024 * 1024)
 #define FLASH_SIZE_4MBIT    (4   * 1024 * 1024)
 #define FLASH_SIZE_8MBIT    (8   * 1024 * 1024)

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -514,12 +514,11 @@ int platform_spi_transaction( uint8_t id, uint8_t cmd_bitlen, spi_data_type cmd_
  */
 uint32_t platform_s_flash_write( const void *from, uint32_t toaddr, uint32_t size )
 {
-  toaddr -= INTERNAL_FLASH_START_ADDRESS;
   SpiFlashOpResult r;
   const uint32_t blkmask = INTERNAL_FLASH_WRITE_UNIT_SIZE - 1;
   uint32_t *apbuf = NULL;
   uint32_t fromaddr = (uint32_t)from;
-  if( (fromaddr & blkmask ) || (fromaddr >= INTERNAL_FLASH_START_ADDRESS)) {
+  if( (fromaddr & blkmask ) || (fromaddr >= INTERNAL_FLASH_MAPPED_ADDRESS)) {
     apbuf = (uint32_t *)c_malloc(size);
     if(!apbuf)
       return 0;
@@ -532,7 +531,7 @@ uint32_t platform_s_flash_write( const void *from, uint32_t toaddr, uint32_t siz
   if(SPI_FLASH_RESULT_OK == r)
     return size;
   else{
-    NODE_ERR( "ERROR in flash_write: r=%d at %08X\n", ( int )r, ( unsigned )toaddr+INTERNAL_FLASH_START_ADDRESS );
+    NODE_ERR( "ERROR in flash_write: r=%d at %08X\n", ( int )r, ( unsigned )toaddr);
     return 0;
   }
 }
@@ -547,7 +546,6 @@ uint32_t platform_s_flash_read( void *to, uint32_t fromaddr, uint32_t size )
   if (size==0)
     return 0;
 
-  fromaddr -= INTERNAL_FLASH_START_ADDRESS;
   SpiFlashOpResult r;
   system_soft_wdt_feed ();
 
@@ -571,7 +569,7 @@ uint32_t platform_s_flash_read( void *to, uint32_t fromaddr, uint32_t size )
   if(SPI_FLASH_RESULT_OK == r)
     return size;
   else{
-    NODE_ERR( "ERROR in flash_read: r=%d at %08X\n", ( int )r, ( unsigned )fromaddr+INTERNAL_FLASH_START_ADDRESS );
+    NODE_ERR( "ERROR in flash_read: r=%d at %08X\n", ( int )r, ( unsigned )fromaddr);
     return 0;
   }
 }

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -579,3 +579,14 @@ int platform_flash_erase_sector( uint32_t sector_id )
   system_soft_wdt_feed ();
   return flash_erase( sector_id ) == SPI_FLASH_RESULT_OK ? PLATFORM_OK : PLATFORM_ERR;
 }
+
+uint32_t platform_flash_mapped2phys (uint32_t mapped_addr)
+{
+  uint32_t cache_ctrl = READ_PERI_REG(CACHE_FLASH_CTRL_REG);
+  if (!(cache_ctrl & CACHE_FLASH_ACTIVE))
+    return -1;
+  bool b0 = (cache_ctrl & CACHE_FLASH_MAPPED0) ? 1 : 0;
+  bool b1 = (cache_ctrl & CACHE_FLASH_MAPPED1) ? 1 : 0;
+  uint32_t meg = (b1 << 1) | b0;
+  return mapped_addr - INTERNAL_FLASH_MAPPED_ADDRESS + meg * 0x100000;
+}

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -237,6 +237,16 @@ uint32_t platform_s_flash_read( void *to, uint32_t fromaddr, uint32_t size );
 uint32_t platform_flash_get_num_sectors(void);
 int platform_flash_erase_sector( uint32_t sector_id );
 
+/**
+ * Translated a mapped address to a physical flash address, based on the
+ * current flash cache mapping.
+ * @param mapped_addr Address to translate (>= INTERNAL_FLASH_MAPPED_ADDRESS)
+ * @return the corresponding physical flash address, or -1 if flash cache is
+ *  not currently active.
+ * @see Cache_Read_Enable.
+ */
+uint32_t platform_flash_mapped2phys (uint32_t mapped_addr);
+
 // *****************************************************************************
 // Allocator support
 

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -53,7 +53,7 @@ void myspiffs_mount() {
 #endif
   cfg.phys_addr += 0x3000;
   cfg.phys_addr &= 0xFFFFC000;  // align to 4 sector.
-  cfg.phys_size = INTERNAL_FLASH_SIZE - ( ( u32_t )cfg.phys_addr - INTERNAL_FLASH_START_ADDRESS );
+  cfg.phys_size = INTERNAL_FLASH_SIZE - ( ( u32_t )cfg.phys_addr );
   cfg.phys_erase_block = INTERNAL_FLASH_SECTOR_SIZE; // according to datasheet
   cfg.log_block_size = INTERNAL_FLASH_SECTOR_SIZE; // let us not complicate things
   cfg.log_page_size = LOG_PAGE_SIZE; // as we said
@@ -97,7 +97,7 @@ int myspiffs_format( void )
   sect_first += 0x3000;
   sect_first &= 0xFFFFC000;  // align to 4 sector.
   sect_first = platform_flash_get_sector_of_address(sect_first);
-  sect_last = INTERNAL_FLASH_SIZE + INTERNAL_FLASH_START_ADDRESS - 4;
+  sect_last = INTERNAL_FLASH_SIZE - SYS_PARAM_SEC_NUM;
   sect_last = platform_flash_get_sector_of_address(sect_last);
   NODE_DBG("sect_first: %x, sect_last: %x\n", sect_first, sect_last);
   while( sect_first <= sect_last )

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -51,7 +51,7 @@ void myspiffs_mount() {
 #else
   cfg.phys_addr = ( u32_t )platform_flash_get_first_free_block_address( NULL ); 
 #endif
-  cfg.phys_addr += 0x3000;
+  cfg.phys_addr += 0x3FFF;
   cfg.phys_addr &= 0xFFFFC000;  // align to 4 sector.
   cfg.phys_size = INTERNAL_FLASH_SIZE - ( ( u32_t )cfg.phys_addr );
   cfg.phys_erase_block = INTERNAL_FLASH_SECTOR_SIZE; // according to datasheet
@@ -94,7 +94,7 @@ int myspiffs_format( void )
 #else
   sect_first = ( u32_t )platform_flash_get_first_free_block_address( NULL ); 
 #endif
-  sect_first += 0x3000;
+  sect_first += 0x3FFF;
   sect_first &= 0xFFFFC000;  // align to 4 sector.
   sect_first = platform_flash_get_sector_of_address(sect_first);
   sect_last = INTERNAL_FLASH_SIZE - SYS_PARAM_SEC_NUM;

--- a/app/wofs/romfs.c
+++ b/app/wofs/romfs.c
@@ -521,7 +521,7 @@ int romfs_init( void )
 #if defined( BUILD_WOFS ) 
   // Get the start address and size of WOFS and register it
   wofs_fsdata.pbase = ( uint8_t* )platform_flash_get_first_free_block_address( NULL );
-  wofs_fsdata.max_size = INTERNAL_FLASH_SIZE - ( ( uint32_t )wofs_fsdata.pbase - INTERNAL_FLASH_START_ADDRESS );
+  wofs_fsdata.max_size = INTERNAL_FLASH_SIZE - ( ( uint32_t )wofs_fsdata.pbase );
   NODE_DBG("wofs.pbase:%x,max:%x\n",wofs_fsdata.pbase,wofs_fsdata.max_size);
 #endif // ifdef BUILD_WOFS
   return 0;


### PR DESCRIPTION
The platform flash API has been somewhat confused as to what offsets it should be using, and making some unsafe assumptions around the mapped portion of the flash. The first commit fixes the offset part and should make the API considerable more portable (esp32, perhaps?) and less confusing to use.

After some digging around in the flash cache control register I also managed to find a way to resolve the unsafe assumptions part too. The flash API now correctly deduces the mapped portion and adjusts accordingly.