### PR TITLE
SPI: cpol=high is not implemented due to insufficient hw docs

### DIFF
--- a/app/modules/spi.c
+++ b/app/modules/spi.c
@@ -33,6 +33,10 @@ static int spi_setup( lua_State *L )
   if (cpol != PLATFORM_SPI_CPOL_LOW && cpol != PLATFORM_SPI_CPOL_HIGH) {
     return luaL_error( L, "wrong arg type" );
   }
+  // CPOL_HIGH is not implemented, see app/driver/spi.c spi_master_init()
+  if (cpol == PLATFORM_SPI_CPOL_HIGH) {
+    return luaL_error( L, "cpol=high is not implemented" );
+  }
 
   if (cpha != PLATFORM_SPI_CPHA_LOW && cpha != PLATFORM_SPI_CPHA_HIGH) {
     return luaL_error( L, "wrong arg type" );


### PR DESCRIPTION
#451 raised the issue that SPI MODE3 is not working - as stated there, the respective code is commented out as TODO. Until now there's still no public documentation available on how to enable cpol=1 mode for the (H)SPI interface.
PR simply informs the user about this shortcoming via an error message when he tries to select cpol=1.
The missing mode can be added once we know how to flip the bits.