### PR TITLE
Fixed compilation error when the enduser_setup module is disabled

### DIFF
--- a/app/modules/enduser_setup.c
+++ b/app/modules/enduser_setup.c
@@ -640,6 +640,10 @@ static void enduser_setup_ap_start(void)
   struct softap_config cnf;
   c_memset(&(cnf), 0, sizeof(struct softap_config));
 
+#ifndef ENDUSER_SETUP_AP_SSID
+  #define ENDUSER_SETUP_AP_SSID "SetupGadget"
+#endif
+
   char ssid[] = ENDUSER_SETUP_AP_SSID;
   int ssid_name_len = c_strlen(ENDUSER_SETUP_AP_SSID);
   c_memcpy(&(cnf.ssid), ssid, ssid_name_len);


### PR DESCRIPTION
Fixed compilation error when the enduser_setup module is disabled yet requires ENDUSER_SETUP_AP_SSID to be defined.

As discussed in #863.