### PR TITLE
Add functions: wifi.sta.sethostname and wifi.sta.gethostname

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -83,6 +83,17 @@
 
 #define ENDUSER_SETUP_AP_SSID "SetupGadget"
 
+/*
+ * A valid hostname only contains alphanumeric and hyphen(-) characters, with no hyphens at first or last char
+ * if WIFI_STA_HOSTNAME not defined: hostname will default to NODE-xxxxxx (xxxxxx being last 3 octets of MAC address)
+ * if WIFI_STA_HOSTNAME defined: hostname must only contain alphanumeric characters
+ * if WIFI_STA_HOSTNAME_APPEND_MAC not defined: Hostname MUST be 32 chars or less
+ * if WIFI_STA_HOSTNAME_APPEND_MAC defined: Hostname MUST be 26 chars or less, since last 3 octets of MAC address will be appended
+ * if defined hostname is invalid: hostname will default to NODE-xxxxxx (xxxxxx being last 3 octets of MAC address)
+*/
+//#define WIFI_STA_HOSTNAME "NodeMCU"
+//#define WIFI_STA_HOSTNAME_APPEND_MAC
+
 #define STRBUF_DEFAULT_INCREMENT 32
 
 #endif	/* __USER_CONFIG_H__ */

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -920,7 +920,6 @@ static int wifi_station_listap( lua_State* L )
   }
 }
 
-
 // Lua: wifi.sta.gethostname()
 static int wifi_sta_gethostname( lua_State* L )
 {
@@ -931,28 +930,25 @@ static int wifi_sta_gethostname( lua_State* L )
 
 static uint8 wifi_sta_sethostname(const char *hostname, size_t len)
 {
-  const char* charset="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-";
-  size_t span = strspn(hostname, charset);
-  if(hostname[span] == '\0' && hostname[span - 1] != '-' && hostname[0] != '-' && (len >= 1 && len <= 32))
+  uint8 status;
+  if(hostname[0]!='-' && hostname[len-1]!='-' && (len >= 1 && len <= 32))
   {
-	NODE_DBG("\n\tstring is: \"%s\"\n\tlength is: %d\n", hostname, len );
-	if(wifi_station_set_hostname((char*)hostname))
+    uint8 i=0;
+	while(hostname[i])
 	{
-	  NODE_DBG("\n\twifi_sta_sethostname returned: true\n");
-	  return 1; //pass
-	}
-	else
-	{
-	  NODE_DBG("\n\twifi_sta_sethostname returned: false\n");
-	  return 0; //fail
-	}
+      if(!(isalnum(hostname[i])||hostname[i]=='-'))
+      {
+	    return 2;
+      }
+      i++;
+    }
+    status=wifi_station_set_hostname((char*)hostname);
   }
   else
   {
-    NODE_DBG("\n\tInvalid hostname!\n");
-    return 2; //Invalid hostname
-	}
-
+    return 2;
+  }
+  return status;
 }
 
 // Lua: wifi.sta.sethostname()
@@ -961,7 +957,7 @@ static int wifi_sta_sethostname_lua( lua_State* L )
   size_t len;
   const char *hostname = luaL_checklstring(L, 1, &len);
   uint8 retval = wifi_sta_sethostname(hostname, len);
-  NODE_DBG("\n\twifi_sta_sethostname returned: %d\n", retval);
+  NODE_DBG("\n\tstring is: \"%s\"\n\tlength is: %u\t wifi_sta_sethostname returned: %u\n", hostname, len, retval);
   if(retval==0)
   {
 	lua_pushboolean(L, 0);

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -920,6 +920,65 @@ static int wifi_station_listap( lua_State* L )
   }
 }
 
+
+// Lua: wifi.sta.gethostname()
+static int wifi_sta_gethostname( lua_State* L )
+{
+	char* hostname = wifi_station_get_hostname();
+	lua_pushstring(L, hostname);
+  return 1;
+}
+
+static uint8 wifi_sta_sethostname(const char *hostname, size_t len)
+{
+  const char* charset="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-";
+  size_t span = strspn(hostname, charset);
+  if(hostname[span] == '\0' && hostname[span - 1] != '-' && hostname[0] != '-' && (len >= 1 && len <= 32))
+  {
+	NODE_DBG("\n\tstring is: \"%s\"\n\tlength is: %d\n", hostname, len );
+	if(wifi_station_set_hostname((char*)hostname))
+	{
+	  NODE_DBG("\n\twifi_sta_sethostname returned: true\n");
+	  return 1; //pass
+	}
+	else
+	{
+	  NODE_DBG("\n\twifi_sta_sethostname returned: false\n");
+	  return 0; //fail
+	}
+  }
+  else
+  {
+    NODE_DBG("\n\tInvalid hostname!\n");
+    return 2; //Invalid hostname
+	}
+
+}
+
+// Lua: wifi.sta.sethostname()
+static int wifi_sta_sethostname_lua( lua_State* L )
+{
+  size_t len;
+  const char *hostname = luaL_checklstring(L, 1, &len);
+  uint8 retval = wifi_sta_sethostname(hostname, len);
+  NODE_DBG("\n\twifi_sta_sethostname returned: %d\n", retval);
+  if(retval==0)
+  {
+	lua_pushboolean(L, 0);
+	return 1;
+  }
+  else if (retval==1)
+  {
+    lua_pushboolean(L, 1);
+    return 1;
+  }
+  else if (retval==2)
+  {
+    return luaL_error(L, "Invalid hostname!");
+  }
+}
+
+
 // Lua: wifi.sta.status()
 static int wifi_station_status( lua_State* L )
 {
@@ -1349,6 +1408,8 @@ static const LUA_REG_TYPE wifi_station_map[] = {
   { LSTRKEY( "getmac" ),        LFUNCVAL( wifi_station_getmac ) },
   { LSTRKEY( "setmac" ),        LFUNCVAL( wifi_station_setmac ) },
   { LSTRKEY( "getap" ),         LFUNCVAL( wifi_station_listap ) },
+  { LSTRKEY( "sethostname" ),   LFUNCVAL( wifi_sta_sethostname_lua ) },
+  { LSTRKEY( "gethostname" ),   LFUNCVAL( wifi_sta_gethostname ) },
   { LSTRKEY( "status" ),        LFUNCVAL( wifi_station_status ) },
   { LSTRKEY( "eventMonReg" ),   LFUNCVAL( wifi_station_event_mon_reg ) },
   { LSTRKEY( "eventMonStart" ), LFUNCVAL( wifi_station_event_mon_start ) },
@@ -1421,4 +1482,40 @@ static const LUA_REG_TYPE wifi_map[] =  {
   { LNILKEY, LNILVAL }
 };
 
-NODEMCU_MODULE(WIFI, "wifi", wifi_map, NULL);
+int luaopen_wifi( lua_State *L )
+{
+#ifndef WIFI_STA_HOSTNAME
+  char temp[32];
+  uint8_t mac[6];
+  wifi_get_macaddr(STATION_IF, mac);
+  c_sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
+  wifi_sta_sethostname((const char*)temp, strlen(temp));
+
+ #elif defined(WIFI_STA_HOSTNAME) && !defined(WIFI_STA_HOSTNAME_APPEND_MAC)
+  const char* hostname=WIFI_STA_HOSTNAME;
+  uint8 retval=wifi_sta_sethostname(hostname, strlen(hostname));
+  if(retval!=1)
+  {
+    char temp[32];
+    uint8_t mac[6];
+    wifi_get_macaddr(STATION_IF, mac);
+    c_sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
+    wifi_sta_sethostname((const char*)temp, strlen(temp));
+  }
+
+#elif defined(WIFI_STA_HOSTNAME) && defined(WIFI_STA_HOSTNAME_APPEND_MAC)
+  char temp[32];
+  uint8_t mac[6];
+  wifi_get_macaddr(STATION_IF, mac);
+  c_sprintf(temp, "%s%X%X%X", WIFI_STA_HOSTNAME, (mac)[3], (mac)[4], (mac)[5]);
+  uint8 retval=wifi_sta_sethostname(temp, strlen(temp));
+  if(retval!=1)
+  {
+	c_sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
+    wifi_sta_sethostname((const char*)temp, strlen(temp));
+  }
+#endif
+return 0;
+}
+
+NODEMCU_MODULE(WIFI, "wifi", wifi_map, luaopen_wifi);


### PR DESCRIPTION
This PR exposes SDK functions `wifi_station_set_hostname` and `wifi_station_get_hostname` referred to in issue #875.

I also implemented the option to set hostname at boot by adding `luaopen_wifi` and have it set the hostname according to `user_config.h` and defaults to `NODE-xxxxxx`(xxxxxx being the last digits of mac address) if a hostname is not specified.

## wifi.sta.sethostname()
#### Description
Set station hostname.

#### Syntax
wifi.sta.sethostname(hostname)

#### Parameters
 - `hostname`: Hostname must only contain letters, numbers and hyphens(`-`) and be 32 characters or less with first and last character being alphanumeric.

#### Returns
 - `true`: hostname was successfully set
 - `false`: hostname was not successfully set

#### Example
   
```lua
  if (wifi.sta.sethostname("NodeMCU")==true) then
    print("hostname was successfully changed")
  else
    print("hostname was not changed")
  end

```

## wifi.sta.gethostname()
#### Description
Get current station hostname.

#### Syntax
wifi.sta.gethostname()

#### Parameters
 - `nil`

#### Returns
 - `hostname`: Currently configured hostname.

#### Example
   
```lua
  print("Current hostname is: \""..wifi.sta.gethostname().."\"")
```