### PR TITLE
support airkiss and esptouch at the same time

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -202,7 +202,7 @@ static int wifi_start_smart( lua_State* L )
     wifi_smart_succeed = luaL_ref(L, LUA_REGISTRYINDEX);
   }
 
-  if ( smart_type > 1 )
+  if ( smart_type > 2 )
     return luaL_error( L, "wrong arg range" );
 
   smartconfig_set_type(smart_type);


### PR DESCRIPTION
in /app/modules/wifi.c
change if ( smart_type > 1 ) return luaL_error( L, "wrong arg range" );
to if ( smart_type > 2 ) return luaL_error( L, "wrong arg range" );