### PR TITLE
Fix problem in wifi.sta.getap where invidual result is lost.

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -97,7 +97,6 @@ static void wifi_scan_done(void *arg, STATUS status)
   if (status == OK)
   {
     struct bss_info *bss_link = (struct bss_info *)arg;
-    bss_link = bss_link->next.stqe_next;//ignore first
     lua_newtable( gL );
 
     while (bss_link != NULL)


### PR DESCRIPTION
In my project, I use `wifi.sta.getap()` to search for a specific access point and check it against a list before connecting. 
Recently, with a firmware upgrade, it stopped returning the ap's info.
I determined that somewhere along the line with one of the SDK upgrades, the first entry in bss_link, which is supposed to be blank, was dropped and the now commented-out line was dropping the individual result returned causing a blank table to be returned to the lua CB.
This PR is the fix for the issue.

Lua code to reproduce issue:
```lua
wifi.sta.getap({ssid="Known_SSID"}, function(T) print("\r") for k,v in pairs(T) do print(k.." : "..v) end end)
```