### PR TITLE
Update flash_api due to flash size map is redefined by espressif.

### DIFF
--- a/app/platform/flash_api.c
+++ b/app/platform/flash_api.c
@@ -132,13 +132,13 @@ uint32_t flash_rom_get_size_byte(void)
             // 32Mbit, 4MByte
             flash_size = 4 * 1024 * 1024;
             break;
-        case SIZE_64MBIT:
-            // 64Mbit, 8MByte
-            flash_size = 8 * 1024 * 1024;
+        case SIZE_16MBIT_8M_8M:
+            // 16Mbit, 2MByte
+            flash_size = 2 * 1024 * 1024;
             break;
-        case SIZE_128MBIT:
-            // 128Mbit, 16MByte
-            flash_size = 16 * 1024 * 1024;
+        case SIZE_32MBIT_8M_8M:
+            // 32Mbit, 4MByte
+            flash_size = 4 * 1024 * 1024;
             break;
         default:
             // Unknown flash size, fall back mode.
@@ -206,16 +206,18 @@ bool flash_rom_set_size_byte(uint32_t size)
         flash_size = SIZE_32MBIT;
         flash_rom_set_size_type(flash_size);
         break;
+        /*
     case 8 * 1024 * 1024:
         // 64Mbit, 8MByte
-        flash_size = SIZE_64MBIT;
+        flash_size = SIZE_16MBIT_8M_8M;
         flash_rom_set_size_type(flash_size);
         break;
     case 16 * 1024 * 1024:
         // 128Mbit, 16MByte
-        flash_size = SIZE_128MBIT;
+        flash_size = SIZE_32MBIT_8M_8M;
         flash_rom_set_size_type(flash_size);
         break;
+        */
     default:
         // Unknown flash size.
         result = false;

--- a/app/platform/flash_api.h
+++ b/app/platform/flash_api.h
@@ -78,12 +78,12 @@ typedef struct
         SIZE_8MBIT = 2,
         SIZE_16MBIT = 3,
         SIZE_32MBIT = 4,
-        SIZE_64MBIT = 5,
-        SIZE_128MBIT = 6,
+        SIZE_16MBIT_8M_8M = 5,
+        SIZE_32MBIT_8M_8M = 6,
     } size : 4;
     uint32_t entry_point;
     uint32_t memory_offset;
-    uint32_t segment_size; 
+    uint32_t segment_size;
 } ICACHE_STORE_TYPEDEF_ATTR SPIFlashInfo;
 
 uint32_t flash_detect_size_byte(void);


### PR DESCRIPTION
SIZE_64MBIT and SIZE_128MBIT is not supported by espressif.