### PR TITLE
Fix for node.dsleep to increase maximum sleep time

### DIFF
--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -39,7 +39,8 @@ static int node_restart( lua_State* L )
 // Lua: dsleep( us, option )
 static int node_deepsleep( lua_State* L )
 {
-  s32 us, option;
+  uint32 us;
+  uint8 option;
   //us = luaL_checkinteger( L, 1 );
   // Set deleep option, skip if nil
   if ( lua_isnumber(L, 2) )
@@ -53,7 +54,7 @@ static int node_deepsleep( lua_State* L )
   // Set deleep time, skip if nil
   if ( lua_isnumber(L, 1) )
   {
-    us = lua_tointeger(L, 1);
+    us = luaL_checknumber(L, 1);
     // if ( us <= 0 )
     if ( us < 0 )
       return luaL_error( L, "wrong arg range" );


### PR DESCRIPTION
`node.dsleep()` is currently using the type sint32 for the variable `us` to hold the sleep time, which limits maximum sleep time to 2,147,483,647 us(~35min).
This PR changes that variable's type to uint32 to match the type used in the SDK function `void system_deep_sleep(uint32 time_in_us)` increasing maximum sleep time to 4,294,967,295 us(~71 min)
