### PR TITLE
Remove left-over cruft regarding Lua mem opt.

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -57,13 +57,6 @@
 
 // #define LUA_NUMBER_INTEGRAL
 
-#define LUA_OPTRAM
-#ifdef LUA_OPTRAM
-#define LUA_OPTIMIZE_MEMORY			2
-#else
-#define LUA_OPTIMIZE_MEMORY         0
-#endif	/* LUA_OPTRAM */
-
 #define READLINE_INTERVAL 80
 #define LUA_TASK_PRIO USER_TASK_PRIO_0
 #define LUA_PROCESS_LINE_SIG 2


### PR DESCRIPTION
I must've overlooked this when we moved LUA_OPTIMIZE_MEMORY=2 into the app/Makefile.