### PR TITLE
Expose extended reset info via node.bootreason().

### DIFF
--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -472,8 +472,20 @@ static int node_setcpufreq(lua_State* L)
 // Lua: code = bootreason()
 static int node_bootreason (lua_State *L)
 {
+  struct rst_info *ri = system_get_rst_info ();
   lua_pushnumber (L, rtc_get_reset_reason ());
-  return 1;
+  lua_pushnumber (L, ri->reason);
+  if (ri->reason == REASON_EXCEPTION_RST)
+  {
+    lua_pushnumber (L, ri->epc1);
+    lua_pushnumber (L, ri->epc2);
+    lua_pushnumber (L, ri->epc3);
+    lua_pushnumber (L, ri->excvaddr);
+    lua_pushnumber (L, ri->depc);
+    return 7;
+  }
+  else
+    return 2;
 }
 
 // Lua: restore()


### PR DESCRIPTION
I opted against providing constants for all the various reset reasons, as this is a bit of a niche function and the space overhead did not seem appropriate. I'll update `newdocs` if/when merged.