### PR TITLE
Add the exccause parameter into the bootreason block

### DIFF
--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -477,12 +477,13 @@ static int node_bootreason (lua_State *L)
   lua_pushnumber (L, ri->reason);
   if (ri->reason == REASON_EXCEPTION_RST)
   {
+    lua_pushnumber (L, ri->exccause);
     lua_pushnumber (L, ri->epc1);
     lua_pushnumber (L, ri->epc2);
     lua_pushnumber (L, ri->epc3);
     lua_pushnumber (L, ri->excvaddr);
     lua_pushnumber (L, ri->depc);
-    return 7;
+    return 8;
   }
   else
     return 2;


### PR DESCRIPTION
It turns out that the exccause parameter was missing from the returned set of values from node.bootreason(). This adds that parameter in. [This is the parameter that tells you which type of exception it was. There is a good table in the xtensa documentation]