### PR TITLE
implement architecture dependent delay functions for u8glib

### DIFF
--- a/app/modules/u8g.c
+++ b/app/modules/u8g.c
@@ -820,6 +820,28 @@ static void lu8g_digital_write( u8g_t *u8g, uint8_t pin_index, uint8_t value )
         platform_gpio_write( pin, value );
 }
 
+void u8g_Delay(uint16_t msec)
+{
+    const uint16_t chunk = 50;
+
+    while (msec > chunk)
+    {
+        os_delay_us( chunk*1000 );
+        msec -= chunk;
+    }
+    if (msec > 0)
+        os_delay_us( msec*1000 );
+}
+void u8g_MicroDelay(void)
+{
+    os_delay_us( 1 );
+}
+void u8g_10MicroDelay(void)
+{
+    os_delay_us( 10 );
+}
+
+
 uint8_t u8g_com_esp8266_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
 {
     switch(msg)

--- a/app/modules/u8g.c
+++ b/app/modules/u8g.c
@@ -820,9 +820,12 @@ static void lu8g_digital_write( u8g_t *u8g, uint8_t pin_index, uint8_t value )
         platform_gpio_write( pin, value );
 }
 
-void u8g_Delay(uint16_t msec)
+void u8g_Delay(u8g_t *u8g, uint16_t msec)
 {
     const uint16_t chunk = 50;
+
+    if (u8g->use_delay == 0)
+        return;
 
     while (msec > chunk)
     {
@@ -994,6 +997,7 @@ static int lu8g_close_display( lua_State *L )
     static int lu8g_ ## device( lua_State *L )                          \
     {                                                                   \
         unsigned addr = luaL_checkinteger( L, 1 );                      \
+        unsigned del  = luaL_optinteger( L, 2, 0 );                     \
                                                                         \
         if (addr == 0)                                                  \
             return luaL_error( L, "i2c address required" );             \
@@ -1001,6 +1005,7 @@ static int lu8g_close_display( lua_State *L )
         lu8g_userdata_t *lud = (lu8g_userdata_t *) lua_newuserdata( L, sizeof( lu8g_userdata_t ) ); \
                                                                         \
         lud->u8g.i2c_addr = (uint8_t)addr;                              \
+        lud->u8g.use_delay = del > 0 ? 1 : 0;                           \
                                                                         \
         u8g_InitI2C( LU8G, &u8g_dev_ ## device, U8G_I2C_OPT_NONE);      \
                                                                         \
@@ -1028,8 +1033,11 @@ U8G_DISPLAY_TABLE_I2C
         if (dc == 0)                                                    \
             return luaL_error( L, "D/C pin required" );                 \
         unsigned res = luaL_optinteger( L, 3, U8G_PIN_NONE );           \
+        unsigned del = luaL_optinteger( L, 4, 0 );                      \
                                                                         \
         lu8g_userdata_t *lud = (lu8g_userdata_t *) lua_newuserdata( L, sizeof( lu8g_userdata_t ) ); \
+                                                                        \
+        lud->u8g.use_delay = del > 0 ? 1 : 0;                           \
                                                                         \
         u8g_InitHWSPI( LU8G, &u8g_dev_ ## device, cs, dc, res );        \
                                                                         \

--- a/app/u8glib/u8g.h
+++ b/app/u8glib/u8g.h
@@ -1163,6 +1163,7 @@ struct _u8g_t
   u8g_box_t current_page;		/* current box of the visible page */
 
   uint8_t i2c_addr;
+  uint8_t use_delay;
 };
 
 #define u8g_GetFontAscent(u8g) ((u8g)->font_ref_ascent)
@@ -1523,7 +1524,7 @@ const char *u8g_u16toa(uint16_t v, uint8_t d);
 /* u8g_delay.c */
 
 /* delay by the specified number of milliseconds */
-void u8g_Delay(uint16_t val);
+void u8g_Delay(u8g_t *u8g, uint16_t val);
 
 /* delay by one microsecond */
 void u8g_MicroDelay(void);

--- a/app/u8glib/u8g_com_api.c
+++ b/app/u8glib/u8g_com_api.c
@@ -151,9 +151,9 @@ uint8_t u8g_WriteEscSeqP(u8g_t *u8g, u8g_dev_t *dev, const uint8_t *esc_seq)
         value &= 0x0f;
         value <<= 4;
         value+=2;
-        u8g_Delay(value);
+        u8g_Delay(u8g, value);
         u8g_SetResetHigh(u8g, dev);
-        u8g_Delay(value);
+        u8g_Delay(u8g, value);
       }
       else if ( value >= 0xbe )
       {
@@ -162,7 +162,7 @@ uint8_t u8g_WriteEscSeqP(u8g_t *u8g, u8g_dev_t *dev, const uint8_t *esc_seq)
       }
       else if ( value <= 127 )
       {
-        u8g_Delay(value);
+        u8g_Delay(u8g, value);
       }
       is_escape = 0;
     }

--- a/app/u8glib/u8g_delay.c
+++ b/app/u8glib/u8g_delay.c
@@ -71,7 +71,7 @@
 #  define USE_AVR_DELAY
 #elif defined(__18CXX)
 #  define USE_PIC18_DELAY
-#elif defined(__arm__)
+#elif defined(__arm__) || defined(__XTENSA__)
 /* do not define anything, all procedures are expected to be defined outside u8glib */
 
 /*

--- a/app/u8glib/u8g_dev_a2_micro_printer.c
+++ b/app/u8glib/u8g_dev_a2_micro_printer.c
@@ -78,7 +78,7 @@ uint8_t u8g_dev_a2_micro_printer_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
 	    u8g_WriteByte(u8g, dev, *ptr);
 	    ptr++;
 	  }
-	  u8g_Delay(LINE_DELAY);
+	  u8g_Delay(u8g, LINE_DELAY);
           y++;
         }
 
@@ -160,7 +160,7 @@ uint8_t u8g_dev_a2_micro_printer_double_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
 	    u8g_WriteByte(u8g, dev, u8g_dev_expand4(*p2 & 15));
 	    p2++;
 	  }
-	  u8g_Delay(LINE_DELAY);
+	  u8g_Delay(u8g, LINE_DELAY);
 	  p2 = ptr;
 	  for( j = 0; j < pb->width/8; j++ )
 	  {
@@ -168,7 +168,7 @@ uint8_t u8g_dev_a2_micro_printer_double_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
 	    u8g_WriteByte(u8g, dev, u8g_dev_expand4(*p2 & 15));
 	    p2++;
 	  }
-	  u8g_Delay(LINE_DELAY);
+	  u8g_Delay(u8g, LINE_DELAY);
 	  ptr += pb->width/8;
           y++;
         }

--- a/docs/en/modules/u8g.md
+++ b/docs/en/modules/u8g.md
@@ -100,6 +100,8 @@ In contrast to the source code based inclusion of XBMs into u8glib, it's require
 ## I²C Display Drivers
 Initialize a display via I²C.
 
+The init sequence would insert delays to match the display specs. These can destabilize the overall system if wifi service is blocked for too long. It is therefore advisable to disable such delays unless the specific use case can exclude wifi traffic while initializing the display driver.
+
 - `u8g.sh1106_128x64_i2c()`
 - `u8g.ssd1306_128x64_i2c()`
 - `u8g.ssd1306_64x48_i2c()`
@@ -109,10 +111,11 @@ Initialize a display via I²C.
 - `u8g.uc1611_dogxl240_i2c()`
 
 ####Syntax
-`u8g.ssd1306_128x64_i2c(address)`
+`u8g.ssd1306_128x64_i2c(address[, use_delay])`
 
 ####Parameters
-`address` I²C slave address of display
+- `address` I²C slave address of display
+- `use_delay` '1': use delays in init sequence, '0' if omitted
 
 ####Returns
 u8g display object
@@ -132,6 +135,8 @@ disp = u8g.ssd1306_128x64_i2c(sla)
 
 ## SPI Display Drivers
 Initialize a display via Hardware SPI.
+
+The init sequence would insert delays to match the display specs. These can destabilize the overall system if wifi service is blocked for too long. It is therefore advisable to disable such delays unless the specific use case can exclude wifi traffic while initializing the display driver.
 
 - `u8g.ld7032_60x32_hw_spi()`
 - `u8g.pcd8544_84x48_hw_spi()`
@@ -169,12 +174,13 @@ Initialize a display via Hardware SPI.
 - `u8g.uc1701_mini12864_hw_spi()`
 
 #### Syntax
-`u8g.ssd1306_128x64_spi(cs, dc[, res])`
+`u8g.ssd1306_128x64_spi(cs, dc[, res[, use_delay]])`
 
 #### Parameters
 - `cs` GPIO pin for /CS
 - `dc` GPIO pin for DC
-- `res` GPIO pin for /RES (optional)
+- `res` GPIO pin for /RES, none if omitted
+- `use_delay` '1': use delays in init sequence, '0' if omitted
 
 #### Returns
 u8g display object


### PR DESCRIPTION
The u8glib integration was missing the arch dependent delay functions. They're added now and should improve the stability of display initialization sequences.