### PR TITLE
Enable -std=gnu11 for crypto, http, mqtt, and lua dir

### DIFF
--- a/app/crypto/Makefile
+++ b/app/crypto/Makefile
@@ -15,6 +15,8 @@ ifndef PDIR
 GEN_LIBS = libcrypto.a
 endif
 
+STD_CFLAGS=-std=gnu11 -Wimplicit
+
 #############################################################
 # Configuration i.e. compile options etc.
 # Target specific stuff (defines etc.) goes in here!

--- a/app/http/Makefile
+++ b/app/http/Makefile
@@ -15,6 +15,7 @@ ifndef PDIR
 GEN_LIBS = libhttp.a
 endif
 
+STD_CFLAGS=-std=gnu11 -Wimplicit
 
 #############################################################
 # Configuration i.e. compile options etc.

--- a/app/include/driver/readline.h
+++ b/app/include/driver/readline.h
@@ -1,0 +1,6 @@
+#ifndef READLINE_APP_H
+#define READLINE_APP_H
+
+bool uart_getc(char *c);
+
+#endif /* READLINE_APP_H */

--- a/app/include/rom.h
+++ b/app/include/rom.h
@@ -122,6 +122,7 @@ char *ets_strcpy (char *dst, const char *src);
 size_t ets_strlen (const char *s);
 int ets_strcmp (const char *s1, const char *s2);
 int ets_strncmp (const char *s1, const char *s2, size_t n);
+char *ets_strstr(const char *haystack, const char *needle);
 
 void ets_delay_us (uint32_t us);
 

--- a/app/include/rom.h
+++ b/app/include/rom.h
@@ -122,6 +122,7 @@ char *ets_strcpy (char *dst, const char *src);
 size_t ets_strlen (const char *s);
 int ets_strcmp (const char *s1, const char *s2);
 int ets_strncmp (const char *s1, const char *s2, size_t n);
+char *ets_strncpy(char *dest, const char *src, size_t n);
 char *ets_strstr(const char *haystack, const char *needle);
 
 void ets_delay_us (uint32_t us);
@@ -142,6 +143,10 @@ void ets_intr_lock(void);
 void ets_intr_unlock(void);
 
 void ets_install_putc1(void *routine);
+
+int rand(void);
+void srand(unsigned int);
+
 void uart_div_modify(int no, unsigned int freq);
 
 #endif

--- a/app/libc/c_stdlib.h
+++ b/app/libc/c_stdlib.h
@@ -10,6 +10,8 @@
 #include "c_stddef.h"
 #include "mem.h"
 
+#include <stdlib.h>
+
 #define EXIT_FAILURE 1
 #define EXIT_SUCCESS 0
 

--- a/app/lua/Makefile
+++ b/app/lua/Makefile
@@ -15,6 +15,8 @@ ifndef PDIR
 GEN_LIBS = liblua.a
 endif
 
+STD_CFLAGS=-std=gnu11 -Wimplicit
+
 #############################################################
 # Configuration i.e. compile options etc.
 # Target specific stuff (defines etc.) goes in here!

--- a/app/lua/lua.c
+++ b/app/lua/lua.c
@@ -11,6 +11,8 @@
 #include "c_string.h"
 #include "flash_fs.h"
 #include "user_version.h"
+#include "driver/readline.h"
+#include "driver/uart.h"
 
 #define lua_c
 

--- a/app/lua/lua.h
+++ b/app/lua/lua.h
@@ -19,6 +19,7 @@
 #include "c_stdarg.h"
 #include "c_stddef.h"
 #include "c_types.h"
+#include <ctype.h>
 #endif
 
 #include "luaconf.h"

--- a/app/lua/luaconf.h
+++ b/app/lua/luaconf.h
@@ -632,7 +632,7 @@ extern int readline4lua(const char *prompt, char *buffer, int length);
 /*
 @@ The luai_num* macros define the primitive operations over numbers.
 */
-#if defined(LUA_CORE)
+#if defined(LUA_CORE) || defined(LUA_LIB)
 #ifdef LUA_CROSS_COMPILER
 #include <math.h>
 #else

--- a/app/mqtt/Makefile
+++ b/app/mqtt/Makefile
@@ -15,6 +15,8 @@ ifndef PDIR
 GEN_LIBS = mqtt.a
 endif
 
+STD_CFLAGS=-std=gnu11 -Wimplicit
+
 #############################################################
 # Configuration i.e. compile options etc.
 # Target specific stuff (defines etc.) goes in here!

--- a/sdk-overrides/include/osapi.h
+++ b/sdk-overrides/include/osapi.h
@@ -4,6 +4,7 @@
 #include "rom.h"
 void ets_timer_arm_new (ETSTimer *a, int b, int c, int isMstimer);
 
+int atoi(const char *nptr);
 int os_printf(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
 int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
 


### PR DESCRIPTION
Some low-hanging fruits for #927.

Except for `app/lua`. Please review the following changes which I'm not 100% comfortable with:

`lbaselib.c` uses `strtoul()` which is not found in "c_stdlib.h" but in the toolchain's stdlib.h.
I added an `#include <stdlib.h>` in libc's `c_stdlib.h` which works but looks a bit quirky.

When building for `LUA_NUMBER_INTEGRAL`, lmathlib.c is looking for `luai_ipow()`. It's delcared in `luaconf.h`, but only for `LUA_CORE` components. My best guess was to enable this block also for `LUA_LIB` components.