### PR TITLE
sntp: Include user_interface.h to avoid implicit decls

### DIFF
--- a/app/modules/sntp.c
+++ b/app/modules/sntp.c
@@ -41,6 +41,7 @@
 #include "c_stdlib.h"
 #include "user_modules.h"
 #include "lwip/dns.h"
+#include "user_interface.h"
 
 #ifdef LUA_USE_MODULES_RTCTIME
 #include "rtc/rtctime.h"


### PR DESCRIPTION
As reported in #967, building with sntp module errors out due to implicit declaration of `system_get_time()`. This happens under the condition that the rtctime module is not included in the build.