### PR TITLE
Fix redefine error on some other version build environment.

### DIFF
--- a/app/include/arch/cc.h
+++ b/app/include/arch/cc.h
@@ -38,7 +38,10 @@
 #include "c_types.h"
 #include "ets_sys.h"
 #include "osapi.h"
+
+#ifndef EFAULT
 #define EFAULT 14
+#endif
 
 //#define LWIP_PROVIDE_ERRNO
 


### PR DESCRIPTION
This macro will cause EFAULT redefine error while compile in espressif's Lubuntu build environment and ai-thinker's build environment. So add #ifndef EFAULT to check it is more safe.