### PR TITLE
Fix HTTP response bug while server only support HTTP/1.0

### DIFF
--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -354,14 +354,16 @@ static void ICACHE_FLASH_ATTR http_disconnect_callback( void * arg )
 		else if ( req->buffer[0] != '\0' )
 		{
 			/* FIXME: make sure this is not a partial response, using the Content-Length header. */
-			const char * version = "HTTP/1.1 ";
-			if ( os_strncmp( req->buffer, version, strlen( version ) ) != 0 )
+			const char * version_1_0 = "HTTP/1.0 ";
+			const char * version_1_1 = "HTTP/1.1 ";
+			if (( os_strncmp( req->buffer, version_1_0, strlen( version_1_0 ) ) != 0 ) &&
+				( os_strncmp( req->buffer, version_1_1, strlen( version_1_1 ) ) != 0 ))
 			{
 				HTTPCLIENT_DEBUG( "Invalid version in %s\n", req->buffer );
 			}
 			else  
 			{
-				http_status	= atoi( req->buffer + strlen( version ) );
+				http_status	= atoi( req->buffer + strlen( version_1_0 ) );
 				body		= (char *) os_strstr( req->buffer, "\r\n\r\n" ) + 4;
 				if ( os_strstr( req->buffer, "Transfer-Encoding: chunked" ) )
 				{

--- a/app/http/httpclient.h
+++ b/app/http/httpclient.h
@@ -32,7 +32,7 @@
 /*
  * Size of http responses that will cause an error.
  */
-#define BUFFER_SIZE_MAX            (1024)
+#define BUFFER_SIZE_MAX            (0x2000)
 
 /*
  * Timeout of http request.


### PR DESCRIPTION
- Fix HTTP response bug while server response HTTP/1.0.
When server use HTTP/1.0 API, NodeMCU will receive error. So fix it, and now support both  HTTP/1.0 and HTTP/1.1,
- Change BUFFER_SIZE_MAX from 1024 to 0x2000. This doesn't consume more RAM because it is only a limit value, the buffer is allocated when data received. (but Lua in firmware not support such a long string, I don't find better way to hold it, may write it to filesystem directly?)
