### PR TITLE
Fixed issue where default ESP_xxxxxx SSID was appearing

### DIFF
--- a/app/modules/enduser_setup.c
+++ b/app/modules/enduser_setup.c
@@ -665,8 +665,8 @@ static void enduser_setup_ap_start(void)
   cnf.ssid_hidden = 0;
   cnf.max_connection = 5;
   cnf.beacon_interval = 100;
+  wifi_set_opmode(SOFTAP_MODE | wifi_get_opmode()); // Changed behavior: Need to be in AP mode before AP config will save
   wifi_softap_set_config(&cnf);
-  wifi_set_opmode(SOFTAP_MODE | wifi_get_opmode());
 }
 
 


### PR DESCRIPTION
...for enduser_setup

Looks like SDK 1.5.1 may have changed behavior: AP config is not saved unless the wifi is in SoftAP (or Station+AP) mode.

Without this change, the SSID is not set to the "SetupGadget" naming convention (or whatever prefix you may have defined in user_config.h). Instead, you'll see the last-saved SSID being used, and by default, that looks like "ESP_xxxxxx".
