### PR TITLE
Added crypto.fhash function for hashing files

### DIFF
--- a/app/crypto/digests.c
+++ b/app/crypto/digests.c
@@ -122,6 +122,36 @@ int ICACHE_FLASH_ATTR crypto_hash (const digest_mech_info_t *mi,
 }
 
 
+int ICACHE_FLASH_ATTR crypto_fhash (const digest_mech_info_t *mi,
+  read_fn read, int readarg,
+  uint8_t *digest)
+{
+  if (!mi)
+    return EINVAL;
+
+  // Initialise
+  void *ctx = (void *)os_malloc (mi->ctx_size);
+  if (!ctx)
+    return ENOMEM;
+  mi->create (ctx);
+
+  // Hash bytes from file in blocks
+  uint8_t* buffer = (uint8_t*)os_malloc (mi->block_size);
+  int read_len = 0;
+  do {
+    read_len = read(readarg, buffer, mi->block_size);
+    mi->update (ctx, buffer, read_len);
+  } while (read_len == mi->block_size);
+
+  // Finish up
+  mi->finalize (digest, ctx);
+
+  os_free (buffer);
+  os_free (ctx);
+  return 0;
+}
+
+
 int ICACHE_FLASH_ATTR crypto_hmac (const digest_mech_info_t *mi,
    const char *data, size_t data_len,
    const char *key, size_t key_len,

--- a/app/crypto/digests.h
+++ b/app/crypto/digests.h
@@ -6,6 +6,7 @@
 typedef void (*create_ctx_fn)(void *ctx);
 typedef void (*update_ctx_fn)(void *ctx, const uint8_t *msg, int len);
 typedef void (*finalize_ctx_fn)(uint8_t *digest, void *ctx);
+typedef size_t ( *read_fn )(int fd, void *ptr, size_t len);
 
 /**
  * Description of a message digest mechanism.
@@ -53,6 +54,16 @@ const digest_mech_info_t *crypto_digest_mech (const char *mech);
  */
 int crypto_hash (const digest_mech_info_t *mi, const char *data, size_t data_len, uint8_t *digest);
 
+/**
+ * Wrapper function for performing a one-in-all hashing operation of a file.
+ * @param mi       A mech from @c crypto_digest_mech(). A null pointer @c mi
+ *                 is harmless, but will of course result in an error return.
+ * @param read     Pointer to the read function (e.g. fs_read)
+ * @param readarg  Argument to pass to the read function (e.g. file descriptor)
+ * @param digest   Output buffer, must be at least @c mi->digest_size in size.
+ * @return 0 on success, non-zero on error.
+ */
+int crypto_fhash (const digest_mech_info_t *mi, read_fn read, int readarg, uint8_t *digest);
 
 /**
  * Generate a HMAC signature.


### PR DESCRIPTION
Added a new export for crypto that  provides hashing of files.
e.g.
```lua
local digest = crypto.fhash("SHA1", "myfile.ext")
```
File IO requirements kept within `crypto.c` module. New function added to `digests.c` to perform block by block hashing with a function pointer to a contiguous read function. This seemed neater than doing file I/O within `digests.c`.

Fixes issue #982.