### PR TITLE
Queue for net.socket:send

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -46,6 +46,7 @@
 #define ICACHE_RAM_ATTR __attribute__((section(".iram0.text")))
 
 #define CLIENT_SSL_ENABLE
+//#define SENDQUEUE_ENABLE
 #define GPIO_INTERRUPT_ENABLE
 //#define MD2_ENABLE
 #define SHA2_ENABLE

--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -12,7 +12,6 @@
 #include "lwip/ip_addr.h"
 #include "espconn.h"
 #include "lwip/dns.h"
-
 #ifdef CLIENT_SSL_ENABLE
 unsigned char *default_certificate;
 unsigned int default_certificate_len = 0;
@@ -41,12 +40,10 @@ static struct espconn *pUdpServer = NULL;
 
 typedef struct t_sendqueue // queue chain [block]->[block]->...->NULL
 {
-  uint16_t len;
-  char *data;
+  uint16_t pos; // position
+  int lua_data;
   struct t_sendqueue* next;
 } t_sendqueue;
-
-static int sendqueue_commited = 0;
 
 typedef struct lnet_userdata
 {
@@ -58,20 +55,24 @@ typedef struct lnet_userdata
   int cb_receive_ref;
   int cb_send_ref;
   int cb_dns_found_ref;
+#ifdef SENDQUEUE_ENABLE
   struct t_sendqueue *sendqueue; // stick to lua-datablock
   uint8_t sending; // flag
+#endif
 #ifdef CLIENT_SSL_ENABLE
   uint8_t secure;
 #endif
 } lnet_userdata;
 
+#ifdef SENDQUEUE_ENABLE
 #define SENDQUEUE_MAX_BLOCK_SIZE 1460    // chunking threshold
 
 static void sendqueue_prepare(lnet_userdata* nud);  // Init queue
-static void sendqueue_drop(lnet_userdata* nud);     // Destroy entire chain
-static void sendqueue_node_free(t_sendqueue *d);    // Destroy one node
-static void sendqueue_proceed(lnet_userdata* nud);  // Send
-static int sendqueue_add(lnet_userdata* nud, char *data, uint16_t len);
+static void sendqueue_drop(lua_State* L, lnet_userdata* nud);     // Destroy entire chain
+static void sendqueue_node_free(lua_State* L, t_sendqueue *d);    // Destroy one node
+static void sendqueue_proceed(lua_State* L, lnet_userdata* nud);  // Send
+static void sendqueue_add(lua_State* L, lnet_userdata* nud, int lua_data);
+#endif
 
 static void net_server_disconnected(void *arg)    // for tcp server only
 {
@@ -99,8 +100,9 @@ static void net_server_disconnected(void *arg)    // for tcp server only
     lua_rawgeti(gL, LUA_REGISTRYINDEX, nud->self_ref);  // pass the userdata(client) to callback func in lua
     lua_call(gL, 1, 0);
   }
-  sendqueue_drop(nud);
-
+#ifdef SENDQUEUE_ENABLE
+  sendqueue_drop(gL, nud);
+#endif
   int i;
   lua_gc(gL, LUA_GCSTOP, 0);
   for(i=0; i < MAX_SOCKET; i++){
@@ -139,7 +141,9 @@ static void net_socket_disconnected(void *arg)    // tcp only
   if(nud->pesp_conn)
     c_free(nud->pesp_conn);
   nud->pesp_conn = NULL;  // espconn is already disconnected
-  sendqueue_drop(nud);
+#ifdef SENDQUEUE_ENABLE
+  sendqueue_drop(gL, nud);
+#endif
   lua_gc(gL, LUA_GCSTOP, 0);
   if(nud->self_ref != LUA_NOREF){
     luaL_unref(gL, LUA_REGISTRYINDEX, nud->self_ref);
@@ -194,10 +198,13 @@ static void net_socket_sent(void *arg)
   if(nud == NULL)
     return;
 
+#ifdef SENDQUEUE_ENABLE
   if (nud->sendqueue) {
-    sendqueue_proceed(nud);
+    sendqueue_proceed(gL, nud);
     return;
   }
+  nud->sending = 0;
+#endif
 
   if(nud->cb_send_ref == LUA_NOREF)
     return;
@@ -340,7 +347,6 @@ static void net_server_connected(void *arg) // for tcp only
   lua_pushvalue(gL, -1);  // copy the top of stack
   skt->self_ref = luaL_ref(gL, LUA_REGISTRYINDEX);    // ref to it self, for module api to find the userdata
   socket[i] = skt->self_ref;  // save to socket array
-  sendqueue_prepare(skt);
   socket_num++;
   skt->cb_connect_ref = LUA_NOREF;  // this socket already connected
   skt->cb_reconnect_ref = LUA_NOREF;
@@ -352,6 +358,9 @@ static void net_server_connected(void *arg) // for tcp only
 
 #ifdef CLIENT_SSL_ENABLE
   skt->secure = 0;    // as a server SSL is not supported.
+#endif
+#ifdef SENDQUEUE_ENABLE
+  sendqueue_prepare(skt);
 #endif
 
   skt->pesp_conn = pesp_conn;   // point to the espconn made by low level sdk
@@ -459,8 +468,9 @@ static int net_create( lua_State* L, const char* mt )
 #ifdef CLIENT_SSL_ENABLE
   nud->secure = secure;
 #endif
+#ifdef SENDQUEUE_ENABLE
   sendqueue_prepare(nud);
-
+#endif
   // set its metatable
   luaL_getmetatable(L, mt);
   lua_setmetatable(L, -2);
@@ -577,7 +587,9 @@ static int net_delete( lua_State* L, const char* mt )
     nud->pesp_conn = NULL;    // for socket, it will free this when disconnected
   }
 
-  sendqueue_drop(nud);
+#ifdef SENDQUEUE_ENABLE
+  sendqueue_drop(L, nud);
+#endif
   // free (unref) callback ref
   if(LUA_NOREF!=nud->cb_connect_ref){
     luaL_unref(L, LUA_REGISTRYINDEX, nud->cb_connect_ref);
@@ -809,10 +821,10 @@ static int net_start( lua_State* L, const char* mt )
   }
 
   if(!isserver || pesp_conn->type == ESPCONN_UDP){    // self_ref is only needed by socket userdata, or udp server
-  	lua_pushvalue(L, 1);  // copy to the top of stack
+    lua_pushvalue(L, 1);  // copy to the top of stack
     if(nud->self_ref != LUA_NOREF)
       luaL_unref(L, LUA_REGISTRYINDEX, nud->self_ref);
-  	nud->self_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    nud->self_ref = luaL_ref(L, LUA_REGISTRYINDEX);
   }
 
   if( pesp_conn->type == ESPCONN_TCP )
@@ -942,13 +954,13 @@ static int net_close( lua_State* L, const char* mt )
       {
   #ifdef CLIENT_SSL_ENABLE
         if(skt->secure){
-        	if(skt->pesp_conn->proto.tcp->remote_port || skt->pesp_conn->proto.tcp->local_port)
-        	  espconn_secure_disconnect(skt->pesp_conn);
+          if(skt->pesp_conn->proto.tcp->remote_port || skt->pesp_conn->proto.tcp->local_port)
+            espconn_secure_disconnect(skt->pesp_conn);
         }
         else
   #endif
         {
-        	if(skt->pesp_conn->proto.tcp->remote_port || skt->pesp_conn->proto.tcp->local_port)
+          if(skt->pesp_conn->proto.tcp->remote_port || skt->pesp_conn->proto.tcp->local_port)
             espconn_disconnect(skt->pesp_conn);
         }
       }else if(skt->pesp_conn->type == ESPCONN_UDP)
@@ -966,8 +978,8 @@ static int net_close( lua_State* L, const char* mt )
 #if 0
     // unref the self_ref
     if(LUA_NOREF!=skt->self_ref){    // for a server self_ref is NOREF
-    	luaL_unref(L, LUA_REGISTRYINDEX, skt->self_ref);
-    	skt->self_ref = LUA_NOREF;   // for a socket, now only var in lua is ref to the userdata
+      luaL_unref(L, LUA_REGISTRYINDEX, skt->self_ref);
+      skt->self_ref = LUA_NOREF;   // for a socket, now only var in lua is ref to the userdata
     }
 #endif
     lua_settop(L, n);   // reset the stack top
@@ -1041,7 +1053,7 @@ static int net_on( lua_State* L, const char* mt )
       luaL_unref(L, LUA_REGISTRYINDEX, nud->cb_dns_found_ref);
     nud->cb_dns_found_ref = luaL_ref(L, LUA_REGISTRYINDEX);
   }else{
-  	lua_pop(L, 1);
+    lua_pop(L, 1);
     return luaL_error( L, "method not supported" );
   }
 
@@ -1051,7 +1063,9 @@ static int net_on( lua_State* L, const char* mt )
 static void net_send_do(lnet_userdata *nud, unsigned char *payload, size_t l) {
   struct espconn *pesp_conn = nud->pesp_conn;
 
+#ifdef SENDQUEUE_ENABLE
   nud->sending = 1;
+#endif
 #ifdef CLIENT_SSL_ENABLE
   if(nud->secure)
     espconn_secure_sent(pesp_conn, (unsigned char *)payload, l);
@@ -1061,7 +1075,7 @@ static void net_send_do(lnet_userdata *nud, unsigned char *payload, size_t l) {
 }
 
 // Lua: server/socket:send( string, function(sent) )
-static int net_send( lua_State* L, const char* mt )
+static int net_send( lua_State* L, const char* mt, uint8_t use_queue)
 {
   // NODE_DBG("net_send is called.\n");
   bool isserver = false;
@@ -1072,8 +1086,8 @@ static int net_send( lua_State* L, const char* mt )
   nud = (lnet_userdata *)luaL_checkudata(L, 1, mt);
   luaL_argcheck(L, nud, 1, "Server/Socket expected");
   if(nud==NULL){
-  	NODE_DBG("userdata is nil.\n");
-  	return 0;
+    NODE_DBG("userdata is nil.\n");
+    return 0;
   }
 
   if(nud->pesp_conn == NULL){
@@ -1107,8 +1121,13 @@ static int net_send( lua_State* L, const char* mt )
 #endif
 
   const char *payload = luaL_checklstring( L, 2, &l );
+#ifdef SENDQUEUE_ENABLE
   if (payload == NULL)
     return luaL_error( L, "need not null payload" );
+#else
+  if (l>1460 || payload == NULL)
+    return luaL_error( L, "need <1460 payload" );
+#endif
 
   if (lua_type(L, 3) == LUA_TFUNCTION || lua_type(L, 3) == LUA_TLIGHTFUNCTION){
     lua_pushvalue(L, 3);  // copy argument (func) to the top of stack
@@ -1127,14 +1146,15 @@ static int net_send( lua_State* L, const char* mt )
     // The remot_info apparently should *not* be os_free()d, fyi
   }
 
+#ifdef SENDQUEUE_ENABLE
   NODE_DBG("Sending status %d.\n", nud->sending);
-  if ( l > SENDQUEUE_MAX_BLOCK_SIZE || nud->sending || nud->sendqueue ) { // Already have a queue
+  if ( use_queue && (l > SENDQUEUE_MAX_BLOCK_SIZE || nud->sending || nud->sendqueue) ) { // Already have a queue
     NODE_DBG("sendqueue_add for %d bytes\n", l);
-    if (!sendqueue_add(nud, (unsigned char*)payload, l)) {
-      return luaL_error (L, "sendqueue: oom");
-    }
+    lua_pushvalue(L, 2);  // copy data
+    sendqueue_add(L, nud, luaL_ref(L, LUA_REGISTRYINDEX));
     return 0;
   }
+#endif
   net_send_do(nud, (unsigned char*)payload, l);
 
   return 0;
@@ -1306,8 +1326,16 @@ static int net_udpserver_on( lua_State* L )
 static int net_udpserver_send( lua_State* L )
 {
   const char *mt = "net.server";
-  return net_send(L, mt);;
+  return net_send(L, mt, 0);
 }
+// Lua: udpserver:sendq(string, function() )
+#ifdef SENDQUEUE_ENABLE
+static int net_udpserver_sendq( lua_State* L )
+{
+  const char *mt = "net.server";
+  return net_send(L, mt, 1);
+}
+#endif
 
 // Lua: s = net.createConnection(type, function(conn))
 static int net_createConnection( lua_State* L )
@@ -1348,8 +1376,17 @@ static int net_socket_on( lua_State* L )
 static int net_socket_send( lua_State* L )
 {
   const char *mt = "net.socket";
-  return net_send(L, mt);
+  return net_send(L, mt, 0);
 }
+
+// Lua: socket:sendq( string, function() )
+#ifdef SENDQUEUE_ENABLE
+static int net_socket_sendq( lua_State* L )
+{
+  const char *mt = "net.socket";
+  return net_send(L, mt, 1);
+}
+#endif
 
 static int net_socket_hold( lua_State* L )
 {
@@ -1433,50 +1470,50 @@ static int net_socket_dns( lua_State* L )
 
 static int net_multicastJoinLeave( lua_State *L, int join)
 {
-	  size_t il;
-	  ip_addr_t multicast_addr;
-	  ip_addr_t if_addr;
-	  const char *multicast_ip;
-	  const char *if_ip;
+    size_t il;
+    ip_addr_t multicast_addr;
+    ip_addr_t if_addr;
+    const char *multicast_ip;
+    const char *if_ip;
 
-	  NODE_DBG("net_multicastJoin is called.\n");
-	  if(! lua_isstring(L,1) ) return luaL_error( L, "wrong arg type" );
-	  if_ip = luaL_checklstring( L, 1, &il );
-	  if (if_ip != NULL)
-		 if ( if_ip[0] == '\0' || stricmp(if_ip,"any") == 0)
-	     {
-			 if_ip = "0.0.0.0";
-			 il = 7;
-	     }
-	  if (if_ip == NULL || il > 15 || il < 7) return luaL_error( L, "invalid if ip" );
-	  if_addr.addr = ipaddr_addr(if_ip);
+    NODE_DBG("net_multicastJoin is called.\n");
+    if(! lua_isstring(L,1) ) return luaL_error( L, "wrong arg type" );
+    if_ip = luaL_checklstring( L, 1, &il );
+    if (if_ip != NULL)
+     if ( if_ip[0] == '\0' || stricmp(if_ip,"any") == 0)
+     {
+       if_ip = "0.0.0.0";
+       il = 7;
+     }
+    if (if_ip == NULL || il > 15 || il < 7) return luaL_error( L, "invalid if ip" );
+    if_addr.addr = ipaddr_addr(if_ip);
 
-	  if(! lua_isstring(L,2) ) return luaL_error( L, "wrong arg type" );
-	  multicast_ip = luaL_checklstring( L, 2, &il );
-	  if (multicast_ip == NULL || il > 15 || il < 7) return luaL_error( L, "invalid multicast ip" );
-	  multicast_addr.addr = ipaddr_addr(multicast_ip);
-	  if (join)
-	  {
-		  espconn_igmp_join(&if_addr, &multicast_addr);
-	  }
-	  else
-	  {
-		  espconn_igmp_leave(&if_addr, &multicast_addr);
-	  }
-	  return 0;
+    if(! lua_isstring(L,2) ) return luaL_error( L, "wrong arg type" );
+    multicast_ip = luaL_checklstring( L, 2, &il );
+    if (multicast_ip == NULL || il > 15 || il < 7) return luaL_error( L, "invalid multicast ip" );
+    multicast_addr.addr = ipaddr_addr(multicast_ip);
+    if (join)
+    {
+      espconn_igmp_join(&if_addr, &multicast_addr);
+    }
+    else
+    {
+      espconn_igmp_leave(&if_addr, &multicast_addr);
+    }
+    return 0;
 }
 // Lua: net.multicastJoin(ifip, multicastip)
 // if ifip "" or "any" all interfaces are affected
 static int net_multicastJoin( lua_State* L )
 {
-	return net_multicastJoinLeave(L,1);
+  return net_multicastJoinLeave(L,1);
 }
 
 // Lua: net.multicastLeave(ifip, multicastip)
 // if ifip "" or "any" all interfaces are affected
 static int net_multicastLeave( lua_State* L )
 {
-	return net_multicastJoinLeave(L,0);
+  return net_multicastJoinLeave(L,0);
 }
 
 
@@ -1525,70 +1562,73 @@ static int net_getdnsserver( lua_State* L )
 }
 
 // Send queue management
+#ifdef SENDQUEUE_ENABLE
 static void sendqueue_prepare(lnet_userdata* nud)
 {
   nud->sending = 0;
   nud->sendqueue = NULL;
 }
 
-static void sendqueue_drop(lnet_userdata* nud)
+static void sendqueue_drop(lua_State* L, lnet_userdata* nud)
 {
   struct t_sendqueue* d = nud->sendqueue;
 
   nud->sending = 0;
   nud->sendqueue = NULL;
   while (d) {
-    sendqueue_node_free(d);
+    sendqueue_node_free(L, d);
     d = d->next;
   }
 }
 
-static void sendqueue_node_free(t_sendqueue *d)
+static void sendqueue_node_free(lua_State* L, t_sendqueue *d)
 {
-  sendqueue_commited -= sizeof(t_sendqueue) + d->len;
-  c_free(d->data);
+  luaL_unref(gL, LUA_REGISTRYINDEX, d->lua_data);
+  d->lua_data = LUA_NOREF;
   c_free(d);
-  NODE_DBG("sendqueue memory: %d bytes\n", sendqueue_commited);
 }
 
-static void sendqueue_proceed(lnet_userdata* nud)
+static void sendqueue_proceed(lua_State* L, lnet_userdata* nud)
 {
   struct t_sendqueue* d = nud->sendqueue;
+  size_t len;
+
   if (d) {
-    net_send_do(nud, d->data, d->len);
-    nud->sendqueue = d->next;
-    sendqueue_node_free(d);
+    lua_rawgeti(gL, LUA_REGISTRYINDEX, d->lua_data); // the only way to get lua string from ref I found.
+    const unsigned char *st = lua_tolstring (L, -1, &len);
+    lua_pop(L, 1);
+    if (!st) {
+      nud->sendqueue = d->next;
+      sendqueue_node_free(L, d);
+      return;
+    }
+    uint16_t l = len - d->pos > SENDQUEUE_MAX_BLOCK_SIZE ? SENDQUEUE_MAX_BLOCK_SIZE : len - d->pos; // TODO: Find the real block size <1460
+    net_send_do(nud, (unsigned char*) st + d->pos, l);
+    d->pos+=l;
+    if (d->pos >= len) {
+      nud->sendqueue = d->next;
+      sendqueue_node_free(L, d);
+    }
   } else {
     nud->sending = 0;
   }
 }
 
-// Return 0 if OOM or summary buffer limit reached.
-static int sendqueue_add(lnet_userdata* nud, char *data, uint16_t len)
+static void sendqueue_add(lua_State* L, lnet_userdata* nud, int lua_data)
 {
   struct t_sendqueue* d = nud->sendqueue;
   while (d && d->next) d = d->next; // goto the queue end
-
-  while (len) {
-    uint16_t l = len > SENDQUEUE_MAX_BLOCK_SIZE ? SENDQUEUE_MAX_BLOCK_SIZE : len; // TODO: Find the real block size <1460
-    if (d) {
-      d = d->next = c_malloc(sizeof(t_sendqueue));
-    } else { // empty queue
-      d = nud->sendqueue = c_malloc(sizeof(t_sendqueue));
-    }
-    if ( !(d && (d->data = c_malloc(l)) ) ) return 0; // yes it's '=', OOM check.
-    c_memcpy(d->data, data, l );
-    d->len = l;
-    data += l;
-    len -= l;
-    sendqueue_commited += sizeof(t_sendqueue) + l;
-    NODE_DBG("sendqueue memory: %d bytes\n", sendqueue_commited);
+  if (d) {
+    d = d->next = c_malloc(sizeof(t_sendqueue));
+  } else { // empty queue
+    d = nud->sendqueue = c_malloc(sizeof(t_sendqueue));
   }
+  d->lua_data = lua_data;
+  d->pos = 0;
   d->next = NULL;
-  if (!nud->sending) sendqueue_proceed(nud);
-  return 1;
+  if (!nud->sending) sendqueue_proceed(L, nud);
 }
-
+#endif
 
 #if 0
 static int net_array_index( lua_State* L )
@@ -1624,6 +1664,9 @@ static const LUA_REG_TYPE net_server_map[] = {
   { LSTRKEY( "close" ),   LFUNCVAL( net_server_close ) },
   { LSTRKEY( "on" ),      LFUNCVAL( net_udpserver_on ) },
   { LSTRKEY( "send" ),    LFUNCVAL( net_udpserver_send ) },
+#ifdef SENDQUEUE_ENABLE
+  { LSTRKEY( "sendq" ),   LFUNCVAL( net_udpserver_sendq ) },
+#endif
 //{ LSTRKEY( "delete" ),  LFUNCVAL( net_server_delete ) },
   { LSTRKEY( "__gc" ),    LFUNCVAL( net_server_delete ) },
   { LSTRKEY( "__index" ), LROVAL( net_server_map ) },
@@ -1635,6 +1678,9 @@ static const LUA_REG_TYPE net_socket_map[] = {
   { LSTRKEY( "close" ),   LFUNCVAL( net_socket_close ) },
   { LSTRKEY( "on" ),      LFUNCVAL( net_socket_on ) },
   { LSTRKEY( "send" ),    LFUNCVAL( net_socket_send ) },
+#ifdef SENDQUEUE_ENABLE
+  { LSTRKEY( "sendq" ),   LFUNCVAL( net_socket_sendq ) },
+#endif
   { LSTRKEY( "hold" ),    LFUNCVAL( net_socket_hold ) },
   { LSTRKEY( "unhold" ),  LFUNCVAL( net_socket_unhold ) },
   { LSTRKEY( "dns" ),     LFUNCVAL( net_socket_dns ) },


### PR DESCRIPTION
Implementation of a queue for ```net.socket:send``` (related: https://github.com/nodemcu/nodemcu-firmware/issues/730)
```lua
sk.send("one");
sk.send("two");
sk.send("three");
```

will send "one", "two", "three" to the socket, instead of sending "one" and discarding all other data. After empting the queue a ```sent``` event will occur.

Backward compatibility:  previous ```send-sent-send more``` model is
still usable without any extra memory cost.

Bonus: no more 1460 chars string limit - strings longer then 1460 will
be chunked to queue.

Formatting the code: tabs changed to two spaces, trailing spaces
removed etc.

Testing: worked for me for TCP client and server for a few days.

TODO: (discuss) fill entire queue block before creating another one for a bit better performance.
(discuss) Should fire ```sent``` event if connection was closed before queue empty?
(discuss) LUA-side access to the attribute ```sending``` and to the queue size.

Also I found undocumented features, like socket:hold() or server connections limit (5 atm) - any suggetions where I can obtain more information about net module?