### PR TITLE
Extend data type for spi miso/mosi buffer offset to 16 bit.

### DIFF
--- a/app/driver/spi.c
+++ b/app/driver/spi.c
@@ -128,12 +128,12 @@ void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_
  * Description  : Enter provided data into MOSI buffer.
  *                The data is regarded as a sequence of bits with length 'bitlen'.
  *                It will be written left-aligned starting from position 'offset'.
- * Parameters   :   uint8 spi_no - SPI module number, Only "SPI" and "HSPI" are valid
- *                  uint8 offset - offset into MOSI buffer (number of bits)
- *                  uint8 bitlen - valid number of bits in data
+ * Parameters   :   uint8  spi_no - SPI module number, Only "SPI" and "HSPI" are valid
+ *                  uint16 offset - offset into MOSI buffer (number of bits)
+ *                  uint8  bitlen - valid number of bits in data
  *                  uint32 data  - data to be written into buffer
 *******************************************************************************/
-void spi_mast_set_mosi(uint8 spi_no, uint8 offset, uint8 bitlen, uint32 data)
+void spi_mast_set_mosi(uint8 spi_no, uint16 offset, uint8 bitlen, uint32 data)
 {
     uint8  wn, wn_offset, wn_bitlen;
     uint32 wn_data;
@@ -186,11 +186,11 @@ void spi_mast_set_mosi(uint8 spi_no, uint8 offset, uint8 bitlen, uint32 data)
  * Description  : Retrieve data from MISO buffer.
  *                The data is regarded as a sequence of bits with length 'bitlen'.
  *                It will be read starting left-aligned from position 'offset'.
- * Parameters   :   uint8 spi_no - SPI module number, Only "SPI" and "HSPI" are valid
- *                  uint8 offset - offset into MISO buffer (number of bits)
- *                  uint8 bitlen - requested number of bits in data
+ * Parameters   :   uint8  spi_no - SPI module number, Only "SPI" and "HSPI" are valid
+ *                  uint16 offset - offset into MISO buffer (number of bits)
+ *                  uint8  bitlen - requested number of bits in data
 *******************************************************************************/
-uint32 spi_mast_get_miso(uint8 spi_no, uint8 offset, uint8 bitlen)
+uint32 spi_mast_get_miso(uint8 spi_no, uint16 offset, uint8 bitlen)
 {
     uint8  wn, wn_offset, wn_bitlen;
     uint32 wn_data = 0;

--- a/app/include/driver/spi.h
+++ b/app/include/driver/spi.h
@@ -20,9 +20,9 @@ void spi_lcd_9bit_write(uint8 spi_no,uint8 high_bit,uint8 low_8bit);
 //spi master init funtion
 void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_div);
 // fill MOSI buffer
-void spi_mast_set_mosi(uint8 spi_no, uint8 offset, uint8 bitlen, uint32 data);
+void spi_mast_set_mosi(uint8 spi_no, uint16 offset, uint8 bitlen, uint32 data);
 // retrieve data from MISO buffer
-uint32 spi_mast_get_miso(uint8 spi_no, uint8 offset, uint8 bitlen);
+uint32 spi_mast_get_miso(uint8 spi_no, uint16 offset, uint8 bitlen);
 // initiate SPI transaction
 void spi_mast_transaction(uint8 spi_no, uint8 cmd_bitlen, uint16 cmd_data, uint8 addr_bitlen, uint32 addr_data,
                           uint16 mosi_bitlen, uint8 dummy_bitlen, sint16 miso_bitlen);

--- a/app/modules/spi.c
+++ b/app/modules/spi.c
@@ -292,7 +292,7 @@ static int spi_transaction( lua_State *L )
     return luaL_error( L, "dummy_bitlen out of range" );
   }
 
-  if (miso_bitlen < -512 || miso_bitlen > 511) {
+  if (miso_bitlen < -512 || miso_bitlen > 512) {
     return luaL_error( L, "miso_bitlen out of range" );
   }
 

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -478,7 +478,7 @@ spi_data_type platform_spi_send_recv( uint8_t id, uint8_t bitlen, spi_data_type 
   return spi_mast_get_miso( id, 0, bitlen );
 }
 
-int platform_spi_set_mosi( uint8_t id, uint8_t offset, uint8_t bitlen, spi_data_type data )
+int platform_spi_set_mosi( uint8_t id, uint16_t offset, uint8_t bitlen, spi_data_type data )
 {
   if (offset + bitlen > 512)
     return PLATFORM_ERR;
@@ -488,7 +488,7 @@ int platform_spi_set_mosi( uint8_t id, uint8_t offset, uint8_t bitlen, spi_data_
   return PLATFORM_OK;
 }
 
-spi_data_type platform_spi_get_miso( uint8_t id, uint8_t offset, uint8_t bitlen )
+spi_data_type platform_spi_get_miso( uint8_t id, uint16_t offset, uint8_t bitlen )
 {
   if (offset + bitlen > 512)
     return 0;

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -101,8 +101,8 @@ int platform_spi_send( uint8_t id, uint8_t bitlen, spi_data_type data );
 spi_data_type platform_spi_send_recv( uint8_t id, uint8_t bitlen, spi_data_type data );
 void platform_spi_select( unsigned id, int is_select );
 
-int platform_spi_set_mosi( uint8_t id, uint8_t offset, uint8_t bitlen, spi_data_type data );
-spi_data_type platform_spi_get_miso( uint8_t id, uint8_t offset, uint8_t bitlen );
+int platform_spi_set_mosi( uint8_t id, uint16_t offset, uint8_t bitlen, spi_data_type data );
+spi_data_type platform_spi_get_miso( uint8_t id, uint16_t offset, uint8_t bitlen );
 int platform_spi_transaction( uint8_t id, uint8_t cmd_bitlen, spi_data_type cmd_data,
                               uint8_t addr_bitlen, spi_data_type addr_data,
                               uint16_t mosi_bitlen, uint8_t dummy_bitlen, int16_t miso_bitlen );


### PR DESCRIPTION
SPI platform and driver code restricted the MISO/MOSI buffer to 256 (of 512) bits since they used uint8 for the offset parameter. This PR upgrades them to uint16 so that the complete buffer can be used.