### PR TITLE
Enable spi functionality on pins after internal config has been applied.

### DIFF
--- a/app/driver/spi.c
+++ b/app/driver/spi.c
@@ -70,21 +70,6 @@ void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_
 
 	if(spi_no>1) 		return; //handle invalid input number
 
-	if(spi_no==SPI){
-		WRITE_PERI_REG(PERIPHS_IO_MUX, 0x005); 
-		PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CLK_U, 1);//configure io to spi mode
-		PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CMD_U, 1);//configure io to spi mode	
-		PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA0_U, 1);//configure io to spi mode	
-		PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA1_U, 1);//configure io to spi mode	
-	}
-	else if(spi_no==HSPI){
-		WRITE_PERI_REG(PERIPHS_IO_MUX, 0x105); 
-		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDI_U, 2);//configure io to spi mode
-		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTCK_U, 2);//configure io to spi mode	
-		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTMS_U, 2);//configure io to spi mode	
-		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, 2);//configure io to spi mode	
-	}
-
 	SET_PERI_REG_MASK(SPI_USER(spi_no), SPI_CS_SETUP|SPI_CS_HOLD|SPI_RD_BYTE_ORDER|SPI_WR_BYTE_ORDER|SPI_DOUTDIN);
 
 	//set clock polarity (Reference: http://bbs.espressif.com/viewtopic.php?f=49&t=1570)
@@ -121,6 +106,21 @@ void spi_master_init(uint8 spi_no, unsigned cpol, unsigned cpha, uint32_t clock_
 					((1&SPI_CLKCNT_N)<<SPI_CLKCNT_N_S)|
 					((0&SPI_CLKCNT_H)<<SPI_CLKCNT_H_S)|
 					((1&SPI_CLKCNT_L)<<SPI_CLKCNT_L_S)); //clear bit 31,set SPI clock div
+
+	if(spi_no==SPI){
+		WRITE_PERI_REG(PERIPHS_IO_MUX, 0x005); 
+		PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CLK_U, 1);//configure io to spi mode
+		PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_CMD_U, 1);//configure io to spi mode	
+		PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA0_U, 1);//configure io to spi mode	
+		PIN_FUNC_SELECT(PERIPHS_IO_MUX_SD_DATA1_U, 1);//configure io to spi mode	
+	}
+	else if(spi_no==HSPI){
+		WRITE_PERI_REG(PERIPHS_IO_MUX, 0x105); 
+		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDI_U, 2);//configure io to spi mode
+		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTCK_U, 2);//configure io to spi mode	
+		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTMS_U, 2);//configure io to spi mode	
+		PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, 2);//configure io to spi mode	
+	}
 }
 
 /******************************************************************************


### PR DESCRIPTION
The current implementation switches the SPI module to the pins and afterwards applies the configuration settings. This can lead to intermittent low level on (H)SPICLK in case of CPOL=1.

Solution with this PR: Finalize module configuration *before* SPI signals are routed to the external pins, resulting in a clean transition from GPIO to SPI mode.
