### PR TITLE
Added file.exists() method 

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -114,6 +114,22 @@ static int file_seek (lua_State *L)
   return 1;
 }
 
+// Lua: exists(filename)
+static int file_exists( lua_State* L )
+{
+  size_t len;
+  const char *fname = luaL_checklstring( L, 1, &len );
+  if( len > FS_NAME_MAX_LENGTH )
+    return luaL_error(L, "filename too long");
+
+  spiffs_stat stat;
+  int rc = SPIFFS_stat(&fs, (char *)fname, &stat);
+
+  lua_pushboolean(L, (rc == SPIFFS_OK ? 1 : 0));
+
+  return 1;
+}
+
 // Lua: remove(filename)
 static int file_remove( lua_State* L )
 {
@@ -312,6 +328,7 @@ static const LUA_REG_TYPE file_map[] = {
 //{ LSTRKEY( "check" ),     LFUNCVAL( file_check ) },
   { LSTRKEY( "rename" ),    LFUNCVAL( file_rename ) },
   { LSTRKEY( "fsinfo" ),    LFUNCVAL( file_fsinfo ) },
+  { LSTRKEY( "exists" ),    LFUNCVAL( file_exists ) },  
 #endif
   { LNILKEY, LNILVAL }
 };

--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -20,8 +20,8 @@ static int file_open( lua_State* L )
   }
 
   const char *fname = luaL_checklstring( L, 1, &len );
-  if( len > FS_NAME_MAX_LENGTH )
-    return luaL_error(L, "filename too long");
+  luaL_argcheck(L, len <= FS_NAME_MAX_LENGTH, 1, "filename too long");
+
   const char *mode = luaL_optstring(L, 2, "r");
 
   file_fd = fs_open(fname, fs_mode2flag(mode));
@@ -118,9 +118,8 @@ static int file_seek (lua_State *L)
 static int file_exists( lua_State* L )
 {
   size_t len;
-  const char *fname = luaL_checklstring( L, 1, &len );
-  if( len > FS_NAME_MAX_LENGTH )
-    return luaL_error(L, "filename too long");
+  const char *fname = luaL_checklstring( L, 1, &len );    
+  luaL_argcheck(L, len <= FS_NAME_MAX_LENGTH, 1, "filename too long");
 
   spiffs_stat stat;
   int rc = SPIFFS_stat(&fs, (char *)fname, &stat);
@@ -134,9 +133,8 @@ static int file_exists( lua_State* L )
 static int file_remove( lua_State* L )
 {
   size_t len;
-  const char *fname = luaL_checklstring( L, 1, &len );
-  if( len > FS_NAME_MAX_LENGTH )
-    return luaL_error(L, "filename too long");
+  const char *fname = luaL_checklstring( L, 1, &len );    
+  luaL_argcheck(L, len <= FS_NAME_MAX_LENGTH, 1, "filename too long");
   file_close(L);
   SPIFFS_remove(&fs, (char *)fname);
   return 0;  
@@ -173,12 +171,10 @@ static int file_rename( lua_State* L )
   }
 
   const char *oldname = luaL_checklstring( L, 1, &len );
-  if( len > FS_NAME_MAX_LENGTH )
-    return luaL_error(L, "filename too long");
-
-  const char *newname = luaL_checklstring( L, 2, &len );
-  if( len > FS_NAME_MAX_LENGTH )
-    return luaL_error(L, "filename too long");
+  luaL_argcheck(L, len <= FS_NAME_MAX_LENGTH, 1, "filename too long");
+  
+  const char *newname = luaL_checklstring( L, 2, &len );  
+  luaL_argcheck(L, len <= FS_NAME_MAX_LENGTH, 2, "filename too long");
 
   if(SPIFFS_OK==myspiffs_rename( oldname, newname )){
     lua_pushboolean(L, 1);
@@ -325,7 +321,6 @@ static const LUA_REG_TYPE file_map[] = {
   { LSTRKEY( "remove" ),    LFUNCVAL( file_remove ) },
   { LSTRKEY( "seek" ),      LFUNCVAL( file_seek ) },
   { LSTRKEY( "flush" ),     LFUNCVAL( file_flush ) },
-//{ LSTRKEY( "check" ),     LFUNCVAL( file_check ) },
   { LSTRKEY( "rename" ),    LFUNCVAL( file_rename ) },
   { LSTRKEY( "fsinfo" ),    LFUNCVAL( file_fsinfo ) },
   { LSTRKEY( "exists" ),    LFUNCVAL( file_exists ) },  

--- a/docs/en/modules/file.md
+++ b/docs/en/modules/file.md
@@ -28,6 +28,34 @@ file.close()
 #### See also
 [`file.open()`](#fileopen)
 
+## file.exists()
+
+Determines whether the specified file exists.
+
+#### Syntax
+`file.exists(filename)`
+
+#### Parameters
+- `filename` file to check
+
+#### Returns
+true of the file exists (even if 0 bytes in size), and false if it does not exist
+
+#### Example
+
+```lua
+files = file.list()
+if files["device.config"] then
+    print("Config file exists")
+end
+
+if file.exists("device.config") then
+    print("Config file exists")
+end
+```
+#### See also
+[`file.list()`](#filelist)
+
 ## file.flush()
 
 Flushes any pending writes to the file system, ensuring no data is lost on a restart. Closing the open file using [`file.close()`](#fileclose) performs an implicit flush as well.


### PR DESCRIPTION
I found myself using `if file.list()["filename"] then` in order to check for the existence of files, which is a silly waste of processing for that purpose. This PR adds a `file.exists(filename)` function, with the approach borrowed from the Arduino project.