### PR TITLE
Initial version of the hw_timer as part of the platform

### DIFF
--- a/app/platform/hw_timer.c
+++ b/app/platform/hw_timer.c
@@ -1,0 +1,160 @@
+/******************************************************************************
+* Copyright 2013-2014 Espressif Systems (Wuxi)
+*
+* FileName: hw_timer.c
+*
+* Description: hw_timer driver
+*
+* Modification history:
+*     2014/5/1, v1.0 create this file.
+*     
+* Adapted for NodeMCU 2016
+* 
+* The owner parameter should be a unique value per module using this API
+* It could be a pointer to a bit of data or code 
+* e.g.   #define OWNER    ((os_param_t) module_init)   
+* where module_init is a function. For builtin modules, it might be 
+* a small numeric value that is known not to clash.
+*******************************************************************************/
+#include "ets_sys.h"
+#include "os_type.h"
+#include "osapi.h"
+
+#include "hw_timer.h"
+
+#define FRC1_ENABLE_TIMER  BIT7
+#define FRC1_AUTO_LOAD  BIT6
+
+//TIMER PREDIVIDED MODE
+typedef enum {
+    DIVIDED_BY_1 = 0,		//timer clock
+    DIVIDED_BY_16 = 4,	//divided by 16
+    DIVIDED_BY_256 = 8,	//divided by 256
+} TIMER_PREDIVIDED_MODE;
+
+typedef enum {			//timer interrupt mode
+    TM_LEVEL_INT = 1,	// level interrupt
+    TM_EDGE_INT   = 0,	//edge interrupt
+} TIMER_INT_MODE;
+
+static os_param_t the_owner;
+static os_param_t callback_arg;
+static void (* user_hw_timer_cb)(os_param_t);
+
+#define VERIFY_OWNER(owner)  if (owner != the_owner) { if (the_owner) { return 0; } the_owner = owner; }
+
+/******************************************************************************
+* FunctionName : platform_hw_timer_arm_us
+* Description  : set a trigger timer delay for this timer.
+* Parameters   : os_param_t owner
+*                uint32 microseconds :
+* in autoload mode
+*                         50 ~ 0x7fffff;  for FRC1 source.
+*                         100 ~ 0x7fffff;  for NMI source.
+* in non autoload mode:
+*                         10 ~ 0x7fffff;
+* Returns      : true if it worked
+*******************************************************************************/
+bool ICACHE_RAM_ATTR platform_hw_timer_arm_ticks(os_param_t owner, uint32_t ticks)
+{
+  VERIFY_OWNER(owner);
+  RTC_REG_WRITE(FRC1_LOAD_ADDRESS, ticks);
+
+  return 1;
+}
+
+bool ICACHE_RAM_ATTR platform_hw_timer_arm_us(os_param_t owner, uint32_t microseconds)
+{
+  VERIFY_OWNER(owner);
+  RTC_REG_WRITE(FRC1_LOAD_ADDRESS, US_TO_RTC_TIMER_TICKS(microseconds));
+
+  return 1;
+}
+
+/******************************************************************************
+* FunctionName : platform_hw_timer_set_func
+* Description  : set the func, when trigger timer is up.
+* Parameters   : os_param_t owner
+*                void (* user_hw_timer_cb_set)(os_param_t):
+                        timer callback function
+*	         os_param_t arg
+* Returns      : true if it worked
+*******************************************************************************/
+bool ICACHE_RAM_ATTR platform_hw_timer_set_func(os_param_t owner, void (* user_hw_timer_cb_set)(os_param_t), os_param_t arg)
+{
+  VERIFY_OWNER(owner);
+  callback_arg = arg;
+  user_hw_timer_cb = user_hw_timer_cb_set;
+  return 1;
+}
+
+static void ICACHE_RAM_ATTR hw_timer_isr_cb(void *arg)
+{
+  if (user_hw_timer_cb != NULL) {
+    (*(user_hw_timer_cb))(callback_arg);
+  }
+}
+
+static void ICACHE_RAM_ATTR hw_timer_nmi_cb(void)
+{
+  if (user_hw_timer_cb != NULL) {
+    (*(user_hw_timer_cb))(callback_arg);
+  }
+}
+
+/******************************************************************************
+* FunctionName : platform_hw_timer_init
+* Description  : initialize the hardware isr timer
+* Parameters   : os_param_t owner
+* FRC1_TIMER_SOURCE_TYPE source_type:
+*                         FRC1_SOURCE,    timer use frc1 isr as isr source.
+*                         NMI_SOURCE,     timer use nmi isr as isr source.
+* bool autoload:
+*                         0,  not autoload,
+*                         1,  autoload mode,
+* Returns      : true if it worked
+*******************************************************************************/
+bool platform_hw_timer_init(os_param_t owner, FRC1_TIMER_SOURCE_TYPE source_type, bool autoload)
+{
+  VERIFY_OWNER(owner);
+  if (autoload) {
+    RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
+		  FRC1_AUTO_LOAD | DIVIDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
+  } else {
+    RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
+		  DIVIDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
+  }
+
+  if (source_type == NMI_SOURCE) {
+    ETS_FRC_TIMER1_NMI_INTR_ATTACH(hw_timer_nmi_cb);
+  } else {
+    ETS_FRC_TIMER1_INTR_ATTACH(hw_timer_isr_cb, NULL);
+  }
+
+  TM1_EDGE_INT_ENABLE();
+  ETS_FRC1_INTR_ENABLE();
+
+  return 1;
+}
+
+/******************************************************************************
+* FunctionName : platform_hw_timer_close
+* Description  : ends use of the hardware isr timer
+* Parameters   : os_param_t owner
+* Returns      : true if it worked
+*******************************************************************************/
+bool ICACHE_RAM_ATTR platform_hw_timer_close(os_param_t owner)
+{
+  VERIFY_OWNER(owner);
+
+  /* Set no reload mode */
+  RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
+		DIVIDED_BY_16 | TM_EDGE_INT);
+
+  TM1_EDGE_INT_DISABLE();
+
+  user_hw_timer_cb = NULL;
+
+  return 1;
+}
+

--- a/app/platform/hw_timer.h
+++ b/app/platform/hw_timer.h
@@ -1,0 +1,27 @@
+#ifndef _HW_TIMER_H
+#define _HW_TIMER_H
+
+#define US_TO_RTC_TIMER_TICKS(t)          \
+    ((t) ?                                   \
+     (((t) > 0x35A) ?                   \
+      (((t)>>2) * ((APB_CLK_FREQ>>4)/250000) + ((t)&0x3) * ((APB_CLK_FREQ>>4)/1000000))  :    \
+      (((t) *(APB_CLK_FREQ>>4)) / 1000000)) :    \
+     0)
+
+typedef enum {
+    FRC1_SOURCE = 0,
+    NMI_SOURCE = 1,
+} FRC1_TIMER_SOURCE_TYPE;
+
+bool ICACHE_RAM_ATTR platform_hw_timer_arm_ticks(os_param_t owner, uint32_t ticks);
+
+bool ICACHE_RAM_ATTR platform_hw_timer_arm_us(os_param_t owner, uint32_t microseconds);
+
+bool ICACHE_RAM_ATTR platform_hw_timer_set_func(os_param_t owner, void (* user_hw_timer_cb_set)(os_param_t), os_param_t arg);
+
+bool platform_hw_timer_init(os_param_t owner, FRC1_TIMER_SOURCE_TYPE source_type, bool autoload);
+
+bool ICACHE_RAM_ATTR platform_hw_timer_close(os_param_t owner);
+
+#endif
+

--- a/sdk-overrides/include/osapi.h
+++ b/sdk-overrides/include/osapi.h
@@ -8,6 +8,8 @@ int atoi(const char *nptr);
 int os_printf(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
 int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
 
+void NmiTimSetFunc(void (*func)(void));
+
 #include_next "osapi.h"
 
 #endif


### PR DESCRIPTION
This is the base version of the platform_hw_timer code. I have verified that it works with my performance monitoring module. Once this gets merged, I'll squash the remaining commits in the performance branch to get that clean.

Not clear what to do about documentation. In most cases in the existing code there isn't much internal documentation, but I don't want to make things worse!