### PR TITLE
Enable UART baudrate 256000 in platform layer.

### DIFF
--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -195,6 +195,7 @@ uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int pari
     case BIT_RATE_74880:
     case BIT_RATE_115200:
     case BIT_RATE_230400:
+    case BIT_RATE_256000:
     case BIT_RATE_460800:
     case BIT_RATE_921600:
     case BIT_RATE_1843200:

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -67,7 +67,7 @@ end, 0)
 
 #### Parameters
 - `id` always zero, only one uart supported
-- `baud` one of 300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 460800, 921600, 1843200, 2686400
+- `baud` one of 300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 256000, 460800, 921600, 1843200, 3686400
 - `databits` one of 5, 6, 7, 8
 - `parity` `uart.PARITY_NONE`, `uart.PARITY_ODD`, or `uart.PARITY_EVEN`
 - `stopbits` `uart.STOPBITS_1`, `uart.STOPBITS_1_5`, or `uart.STOPBITS_2`


### PR DESCRIPTION
Fixes #1045 and corrects doc wrt baudrate 3686400.