### PR TITLE
Add file.fscfg() command for fs location + size.

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -307,6 +307,13 @@ static int file_writeline( lua_State* L )
   return 1;
 }
 
+static int file_fscfg (lua_State *L)
+{
+  lua_pushinteger (L, fs.cfg.phys_addr);
+  lua_pushinteger (L, fs.cfg.phys_size);
+  return 2;
+}
+
 // Module function map
 static const LUA_REG_TYPE file_map[] = {
   { LSTRKEY( "list" ),      LFUNCVAL( file_list ) },
@@ -323,6 +330,7 @@ static const LUA_REG_TYPE file_map[] = {
   { LSTRKEY( "flush" ),     LFUNCVAL( file_flush ) },
   { LSTRKEY( "rename" ),    LFUNCVAL( file_rename ) },
   { LSTRKEY( "fsinfo" ),    LFUNCVAL( file_fsinfo ) },
+  { LSTRKEY( "fscfg" ),    LFUNCVAL( file_fscfg ) },
   { LSTRKEY( "exists" ),    LFUNCVAL( file_exists ) },  
 #endif
   { LNILKEY, LNILVAL }

--- a/docs/en/modules/file.md
+++ b/docs/en/modules/file.md
@@ -99,6 +99,25 @@ none
 #### See also
 [`file.remove()`](#fileremove)
 
+## file.fscfg ()
+
+Returns the flash address and physical size of the file system area, in bytes.
+
+#### Syntax
+`file.fscfg()`
+
+#### Parameters
+none
+
+#### Returns
+- `flash address` (number)
+- `size` (number)
+
+#### Example
+```lua
+print(string.format("0x%x", file.fscfg()))
+```
+
 ## file.fsinfo()
 
 Return size information for the file system, in bytes.


### PR DESCRIPTION
With the apparent interest of flashing pre-built filesystems together with NodeMCU, this command might save some hassle working out where to flash said filesystem to.

Simply boot NodeMCU, run `file.fscfg()` and you'll see precisely where this particular NodeMCU firmware is expecting the filesystem to sit.