### PR TITLE
autobuild spiffs image from files in local/fs folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tools/spiffsimg"]
+	path = tools/spiffsimg
+	url = https://github.com/DiUS/spiffsimg.git

--- a/docs/en/flash.md
+++ b/docs/en/flash.md
@@ -43,6 +43,8 @@ Otherwise, if you built your own firmware from source code:
 
 Also, in some special circumstances, you may need to flash `blank.bin` or `esp_init_data_default.bin` to various addresses on the flash (depending on flash size and type), see [below](#upgrading-from-sdk-09x-firmware).
 
+If you have files added into the `local/fs/` folder you might want to flash the file named in `bin/spiffs.dat` to the address it's named about. This will copy the filesystem created as a copy of `local/fs/` to your nodeMCU and made available by the lua file module.
+
 If upgrading from [SPIFFS](https://github.com/pellepl/spiffs) version 0.3.2 to 0.3.3 or later, or after flashing any new firmware (particularly one with a much different size), you may need to run [`file.format()`](modules/file.md#fileformat) to re-format your flash filesystem. You will know if you need to do this if your flash files disappeared, or if they exist but seem empty, or if data cannot be written to new files.
 
 ## Upgrading from SDK 0.9.x Firmware

--- a/local/fs/.gitignore
+++ b/local/fs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -30,7 +30,7 @@ ROM0X10000SIZE = $$(du -b ../bin/0x10000.bin | cut -f 1)
 #
 
 SPIFFSBASE = $$(( ( ($(ROM0X10000SIZE) + 0x13FFF) / 0x4000) * 0x4000))
-SPIFFSBASEHEX = $$( echo "obase=16; $(SPIFFSBASE)" | bc )
+SPIFFSBASEHEX = $$( printf "%x" $(SPIFFSBASE) )
 SPIFFSOLDNAME = $$( cat ../bin/spiffs.dat )
 
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,0 +1,74 @@
+#  copyright (c) 2010 Espressif System
+#
+.NOTPARALLEL:
+ifndef PDIR
+
+endif
+#############################################################
+# Options
+#
+
+FSSOURCE ?= ../local/fs/
+FSSIZE ?= 196608
+SUBDIRS = 
+
+#############################################################
+# Get the files to pack into the spiffs image
+#
+
+SPIFFSFILES ?= $(patsubst $(FSSOURCE)%,%,$(shell find $(FSSOURCE) -name '*' ))
+
+#################################################################
+# Get the filesize of /bin/0x10000.bin
+#
+
+ROM0X10000SIZE = $$(du -b ../bin/0x10000.bin | cut -f 1)
+
+#################################################################
+# Calculate the address, the spiffs has o be placed for the given
+# 0x10000.bin file size.
+#
+
+SPIFFSBASE = $$(( ( ($(ROM0X10000SIZE) + 0x13FFF) / 0x4000) * 0x4000))
+SPIFFSBASEHEX = $$( echo "obase=16; $(SPIFFSBASE)" | bc )
+SPIFFSOLDNAME = $$( cat ../bin/spiffs.dat )
+
+
+#############################################################
+# Rules base
+#
+
+all:	spiffssript
+
+spiffssript:
+	$(MAKE) -C spiffsimg CC=gcc ;)
+	rm -f ./spiffsimg/spiffs.lst
+	rm -f $(SPIFFSOLDNAME) 
+	rm -f ../bin/spiffs.dat
+	echo "" >> ./spiffsimg/spiffs.lst
+	$(foreach f, $(SPIFFSFILES), echo "import $(FSSOURCE)$(f) $(f)" >> ./spiffsimg/spiffs.lst ;)
+	spiffsimg/spiffsimg -f ../bin/0x$(SPIFFSBASEHEX).bin -c $(FSSIZE) -r ./spiffsimg/spiffs.lst 
+	echo "0x$(SPIFFSBASEHEX).bin" >> ../bin/spiffs.dat
+	
+
+clean:
+	rm -f ./spiffsimg/spiffsimg
+	rm -f ./spiffsimg/spiffs.lst
+	rm -f $(SPIFFSOLDNAME) 
+	rm -f ../bin/spiffs.dat
+
+#############################################################
+# Recursion Magic - Don't touch this!!
+#
+# Each subtree potentially has an include directory
+#   corresponding to the common APIs applicable to modules
+#   rooted at that subtree. Accordingly, the INCLUDE PATH
+#   of a module can only contain the include directories up
+#   its parent path, and not its siblings
+#
+# Required for each makefile to inherit from the parent
+#
+
+INCLUDES := $(INCLUDES) -I $(PDIR)include -I $(PDIR)include/$(TARGET)
+PDIR := ../$(PDIR)
+sinclude $(PDIR)Makefile

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -25,7 +25,7 @@ SPIFFSFILES ?= $(patsubst $(FSSOURCE)%,%,$(shell find $(FSSOURCE) -name '*' ))
 ROM0X10000SIZE = $$(du -b ../bin/0x10000.bin | cut -f 1)
 
 #################################################################
-# Calculate the address, the spiffs has o be placed for the given
+# Calculate the address, the spiffs has to be placed for the given
 # 0x10000.bin file size.
 #
 
@@ -41,7 +41,7 @@ SPIFFSOLDNAME = $$( cat ../bin/spiffs.dat )
 all:	spiffssript
 
 spiffssript:
-	$(MAKE) -C spiffsimg CC=gcc ;)
+	$(MAKE) -C spiffsimg CC=gcc
 	rm -f ./spiffsimg/spiffs.lst
 	rm -f $(SPIFFSOLDNAME) 
 	rm -f ../bin/spiffs.dat


### PR DESCRIPTION
As the last try to PR, but now clean into one commit. Thank you @TerryE for the pointers. I guess it will still need a lot of excercise until I get a smooth usage of git ;-)

The files in local/fs will be taken to build thespiffs image.
The spiffs image is put into the bin folder with the name matching the destination address within the flash given the 0x10000.bin image.

For building the spiffsimg tool gcc is used (the xtensa compiler is overridden). This should make this Makefile usable everywhere gcc is installed and within the path.

For spiffsimg there is a bug in VirtualBox that keeps crashing spiffsimg with a segmentation fault (mmap is not supported in MAP_SHARED mode). This needs to be fixed within the spiffsimg git and is not part of this PR.

Refer [https://github.com/nodemcu/nodemcu-firmware/issues/1031]