### PR TITLE
Increase irom0_0_seg size for all-modules build.

### DIFF
--- a/tools/pr-build.sh
+++ b/tools/pr-build.sh
@@ -13,6 +13,11 @@ cat user_modules.h
 sed -i.bak 's@#define CLIENT_SSL_ENABLE@//#define CLIENT_SSL_ENABLE@' user_config.h
 cat user_config.h
 
+cd "$TRAVIS_BUILD_DIR"/ld || exit
+# increase irom0_0_seg size for all modules build
+sed -E -i.bak 's@(.*irom0_0_seg *:.*len *=) *[^,]*(.*)@\1 0x90000\2@' nodemcu.ld
+cat nodemcu.ld
+
 # change to "root" directory no matter where the script was started from
 cd "$TRAVIS_BUILD_DIR" || exit
 make clean


### PR DESCRIPTION
#1008 highlighted that the all-modules build breaks with irom0_0_seg size violation.
This PR provides more headroom.