### PR TITLE
Made level triggers work better than before

### DIFF
--- a/app/modules/gpio.c
+++ b/app/modules/gpio.c
@@ -19,8 +19,9 @@
 #ifdef GPIO_INTERRUPT_ENABLE
 static int gpio_cb_ref[GPIO_PIN_NUM];
 
-// This task is scheduled by the ISP if pin_trigger[pin] is true and is used
-// to intitied the Lua-land gpio.trig() callback function
+// This task is scheduled by the ISR and is used
+// to initiate the Lua-land gpio.trig() callback function
+// It also re-enables the pin interrupt, so that we get another callback queued
 static void gpio_intr_callback_task (task_param_t param, uint8 priority)
 {
   unsigned pin = param >> 1;
@@ -32,11 +33,21 @@ static void gpio_intr_callback_task (task_param_t param, uint8 priority)
     // GPIO callbacks are run in L0 and inlcude the level as a parameter
     lua_State *L = lua_getstate();
     NODE_DBG("Calling: %08x\n", gpio_cb_ref[pin]);
-    // The trigger is reset before the callback, as the callback itself might reset the trigger
-    pin_trigger[pin] = true;
+    //
+    if (pin_int_type[pin] < 4) {
+      // Edge triggered -- re-enable the interrupt
+      platform_gpio_intr_init(pin, pin_int_type[pin]);
+    }
+
+    // Do the actual callback
     lua_rawgeti(L, LUA_REGISTRYINDEX, gpio_cb_ref[pin]);
     lua_pushinteger(L, level);
     lua_call(L, 1, 0);
+
+    if (pin_int_type[pin] >= 4) {
+      // Level triggered -- re-enable the callback
+      platform_gpio_intr_init(pin, pin_int_type[pin]);
+    }
   }
 }
 
@@ -60,8 +71,8 @@ static int lgpio_trig( lua_State* L )
     lua_pushvalue(L, 3);  // copy argument (func) to the top of stack
     gpio_cb_ref[pin] = luaL_ref(L, LUA_REGISTRYINDEX);
   }
-  NODE_DBG("Pin data: %d %d %08x, %d %d %d %d, %08x\n",
-          pin, type, pin_mux[pin], pin_num[pin], pin_func[pin], pin_int_type[pin], pin_trigger[pin], gpio_cb_ref[pin]);
+  NODE_DBG("Pin data: %d %d %08x, %d %d %d, %08x\n",
+          pin, type, pin_mux[pin], pin_num[pin], pin_func[pin], pin_int_type[pin], gpio_cb_ref[pin]);
   platform_gpio_intr_init(pin, type);
   return 0;
 }
@@ -83,8 +94,8 @@ static int lgpio_mode( lua_State* L )
   if(pullup!=FLOAT) pullup = PULLUP;
 
 NODE_DBG("pin,mode,pullup= %d %d %d\n",pin,mode,pullup);
-NODE_DBG("Pin data at mode: %d %08x, %d %d %d %d, %08x\n",
-          pin, pin_mux[pin], pin_num[pin], pin_func[pin], pin_int_type[pin], pin_trigger[pin], gpio_cb_ref[pin]);
+NODE_DBG("Pin data at mode: %d %08x, %d %d %d, %08x\n",
+          pin, pin_mux[pin], pin_num[pin], pin_func[pin], pin_int_type[pin], gpio_cb_ref[pin]);
 
 #ifdef GPIO_INTERRUPT_ENABLE
   if (mode != INTERRUPT){     // disable interrupt

--- a/app/platform/pin_map.h
+++ b/app/platform/pin_map.h
@@ -15,7 +15,6 @@ extern uint8_t  pin_func[GPIO_PIN_NUM];
 #ifdef GPIO_INTERRUPT_ENABLE
 extern uint8_t  pin_num_inv[GPIO_PIN_NUM_INV];
 extern uint8_t  pin_int_type[GPIO_PIN_NUM];
-extern uint8_t  pin_trigger[GPIO_PIN_NUM];
 #endif
 
 void get_pin_map(void);


### PR DESCRIPTION
I hope that this PR fixes #1078. In my testing it makes level triggers behave in a reasonable way -- they get repeatedly called while the situation persists. However, there is only ever one callback queued for each pin at a time. 

I'm interested in whether this solves @NicolSpies problem.

@TerryE since you did the original big rework, I'd appreciate your input. I removed the pin_trigger stuff and just emulated it by disabling and re-enabling the interrupts on a per pin basis.

This code, when saved to a file and then dofile'd exercises some pieces of the gpio interrupt system. You should be able to run it on any board if you connect gpio 4 to gpio 5 with a bit of wire.

```Lua
function stringify_table(t)
  if type(t) == "table" then
    return table.concat(t, ",")
  end
  return t
end

function assertEquals(exp, act)
  exp=stringify_table(exp)
  act=stringify_table(act)
  if exp ~= act then
    error(string.format("ASSERT: %s != %s", exp, act))
  end
end

local log = {}

function record(typ, level)
  print(typ)
  if #log >= 3 then
    if typ == "low" then
      gpio.write(5,1)
    elseif typ == "high" then
      gpio.write(5,0)
    end
    return
  end
  table.insert(log, string.format("%s:%d", typ, level))
end

function setTrig(typ)
  gpio.trig(4, typ, function(level) 
    record(typ, level)
  end)
end


function asyncDelay(ms)
  coroutine.yield(ms)
end

function runTest()
    gpio.mode(5, gpio.OUTPUT)
    gpio.mode(4, gpio.INPUT)
    
    -- verify connected together
    gpio.write(5, 1)
    assertEquals(1, gpio.read(4))
    gpio.write(5, 0)
    assertEquals(0, gpio.read(4))
    
    gpio.mode(4, gpio.INT)
    
    setTrig("down")
    assertEquals({}, log)
    gpio.write(5, 1)
    assertEquals({}, log)
    
    gpio.write(5, 0)
    asyncDelay(10)
    assertEquals("down:0", log)
    log = {}
    gpio.write(5, 1)
    asyncDelay(10)
    assertEquals({}, log)

    gpio.write(5, 0)
    gpio.write(5, 1)
    gpio.write(5, 0)
    gpio.write(5, 1)
    asyncDelay(10)
    assertEquals("down:0", log)
    log = {}

    gpio.write(5, 0)
    asyncDelay(10)
    assertEquals("down:0", log)
    log = {}


    setTrig("both")
    gpio.write(5, 1)
    asyncDelay(10)
    assertEquals("both:1", log)
    log = {}
    gpio.write(5, 0)
    asyncDelay(10)
    assertEquals("both:0", log)

    gpio.mode(4, gpio.INPUT)
    
    setTrig("low")
    print("set-low")
    log = {}
    asyncDelay(30)
    assertEquals("low:0,low:0,low:0", log)
    gpio.write(5, 1)
    log = {}
    print("set-low-high")
    assertEquals({}, log)
    gpio.write(5, 0)    
    asyncDelay(30)
    assertEquals("low:0,low:0,low:0", log)
    
end

co = coroutine.create(runTest)

function doDelay()
  local ok, delay = coroutine.resume(co)
  if not ok then
    print(delay)
    return
  end
  if delay then
    tmr.alarm(0, delay, 0, doDelay)
  end
end

doDelay()
```