### PR TITLE
Fix coroutine incompatibility in tmr module

### DIFF
--- a/app/modules/tmr.c
+++ b/app/modules/tmr.c
@@ -60,11 +60,8 @@ tmr.softwd(int)
 #define TIMER_MODE_AUTO 1
 #define TIMER_IDLE_FLAG (1<<7) 
 
-//in fact lua_State is constant, it's pointless to pass it around
-//but hey, whatever, I'll just pass it, still we waste 28B here
 typedef struct{
 	os_timer_t os;
-	lua_State* L;
 	sint32_t lua_ref;
 	uint32_t interval;
 	uint8_t mode;
@@ -76,24 +73,26 @@ static union {
 	uint64_t block;
 	uint32_t part[2];
 } rtc_time;
+
 static sint32_t soft_watchdog  = -1;
 static timer_struct_t alarm_timers[NUM_TMR];
 static os_timer_t rtc_timer;
 
 static void alarm_timer_common(void* arg){
 	timer_t tmr = &alarm_timers[(uint32_t)arg];
-	if(tmr->lua_ref == LUA_NOREF || tmr->L == NULL)
+	lua_State* L = lua_getstate();
+	if(tmr->lua_ref == LUA_NOREF)
 		return;
-	lua_rawgeti(tmr->L, LUA_REGISTRYINDEX, tmr->lua_ref);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, tmr->lua_ref);
 	//if the timer was set to single run we clean up after it
 	if(tmr->mode == TIMER_MODE_SINGLE){
-		luaL_unref(tmr->L, LUA_REGISTRYINDEX, tmr->lua_ref);
+		luaL_unref(L, LUA_REGISTRYINDEX, tmr->lua_ref);
 		tmr->lua_ref = LUA_NOREF;
 		tmr->mode = TIMER_MODE_OFF;
 	}else if(tmr->mode == TIMER_MODE_SEMI){
 		tmr->mode |= TIMER_IDLE_FLAG;
 	}
-	lua_call(tmr->L, 0, 0);
+	lua_call(L, 0, 0);
 }
 
 // Lua: tmr.delay( us )
@@ -145,7 +144,6 @@ static int tmr_register(lua_State* L){
 	tmr->lua_ref = ref;
 	tmr->mode = mode|TIMER_IDLE_FLAG;
 	tmr->interval = interval;
-	tmr->L = L; 
 	ets_timer_setfn(&tmr->os, alarm_timer_common, (void*)id);
 	return 0;  
 }


### PR DESCRIPTION
Fixed issue where timer callback wasn't using the proper lua_state.
This made the timer module incompatible with the lua coroutine module.

Discussion in issue #846.