### PR TITLE
Add call to get_pin_map() in platform_init()

### DIFF
--- a/app/platform/pin_map.c
+++ b/app/platform/pin_map.c
@@ -9,7 +9,6 @@ uint8_t  pin_func[GPIO_PIN_NUM];
 #ifdef GPIO_INTERRUPT_ENABLE
 uint8_t  pin_num_inv[GPIO_PIN_NUM_INV];
 uint8_t  pin_int_type[GPIO_PIN_NUM];
-uint8_t  pin_trigger[GPIO_PIN_NUM];
 #endif
 
 typedef struct {
@@ -52,7 +51,6 @@ void get_pin_map(void) {
 #ifdef GPIO_INTERRUPT_ENABLE
     pin_num_inv[pin_num[i]] = i;
     pin_int_type[i]         = pin[i].intr_type;
-    pin_trigger[i]          = false;
 #endif
   }
 }

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -18,6 +18,9 @@ static void pwms_init();
 
 int platform_init()
 {
+  // Setup the various forward and reverse mappings for the pins
+  get_pin_map();
+
   // Setup PWMs
   pwms_init();
 
@@ -182,10 +185,8 @@ static void ICACHE_RAM_ATTR platform_gpio_intr_dispatcher (void *dummy){
 
 void platform_gpio_init( task_handle_t gpio_task )
 {
-  int i;
   gpio_task_handle = gpio_task;
 
-  get_pin_map();
   ETS_GPIO_INTR_ATTACH(platform_gpio_intr_dispatcher, NULL);
 }
 /*


### PR DESCRIPTION
This PR fixes the crash reported by @eku in #1057 (the original PR which added the new PWM support). 

There is ticket #1099 which explains the problem.

The fix here is just to call get_pin_map() during the pwms_init() -- in case it doesn't get called by the gpio init (e.g. if GPIO is not included).

I also removed the pin_trigger variable -- which I should have done as part of the PR #1082 