### PR TITLE
Crash-fixes for enduser_setup module

### DIFF
--- a/app/modules/enduser_setup.c
+++ b/app/modules/enduser_setup.c
@@ -332,7 +332,8 @@ static void enduser_setup_check_station_stop(void)
 {
   ENDUSER_SETUP_DEBUG(lua_getstate(), "enduser_setup_check_station_stop");
 
-  os_timer_disarm(&(state->check_station_timer));
+  if (state != NULL)
+    os_timer_disarm(&(state->check_station_timer));
 }
 
 
@@ -1197,7 +1198,7 @@ static void enduser_setup_dns_stop(void)
 {
   ENDUSER_SETUP_DEBUG(lua_getstate(), "enduser_setup_dns_stop");
 
-  if (state->espconn_dns_udp != NULL)
+  if (state != NULL && state->espconn_dns_udp != NULL)
   {
     espconn_delete(state->espconn_dns_udp);
   }


### PR DESCRIPTION
It turns out we had a few nasty bugs lurking in the enduser_setup module. The biggest one being that apparently one should *not* update the station config from within a receive callback on the AP interface. We encountered a situation where by submitting an incorrect wifi password, the ESP:
  1. Crashed
  2. Upon restart, started leaking memory somewhere inside the SDK like there was no tomorrow, and after a minute or so ran out of memory - goto (1).

If the wifi password was correct however, the ESP only crashed, but didn't end up leaking memory. It would seem that by doing the wifi station config from within the callback, not only did it mess up the running memory, but something in the system RTC memory also got corrupted which then caused it to start leaking memory **after the restart**. This is the first time I've run into a bug with this particular modus operandi I must admit... Needless to say, this was an absolute P.I.T.A. to manage to track down. The memory leak is dependent on what else is going on in the system, which meant that it wasn't easy to reproduce the issue on anything but our production hardware, which of course isn't the best for trouble-shooting... \*deep sigh\*

Additionally, and compounding our woes was that there were a couple of missing null-checks which made it impossible to call enduser_setup.stop() more than once, and presented another way to crash the ESP while chasing the main issue.

There is one commit for each of these issues here, and also included here is a small quality-of-life improvement by including the SSID in the status message. If you really want to you can pick-n-choose, but I'd prefer to see it all get merged.

PS. @TerryE Thanks for the task framework - it made the fixing part of this nice and easy at least!