### PR TITLE
Omit all the PWM code if the PWM module is not included

### DIFF
--- a/app/modules/pwm.c
+++ b/app/modules/pwm.c
@@ -122,6 +122,11 @@ static int lpwm_getduty( lua_State* L )
   return 1;
 }
 
+int lpwm_open( lua_State *L ) {
+  platform_pwm_init();
+  return 0;
+}
+
 // Module function map
 static const LUA_REG_TYPE pwm_map[] = {
   { LSTRKEY( "setup" ),    LFUNCVAL( lpwm_setup ) },
@@ -135,4 +140,4 @@ static const LUA_REG_TYPE pwm_map[] = {
   { LNILKEY, LNILVAL }
 };
 
-NODEMCU_MODULE(PWM, "pwm", pwm_map, NULL);
+NODEMCU_MODULE(PWM, "pwm", pwm_map, lpwm_open);

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -32,15 +32,10 @@ static struct gpio_hook platform_gpio_hook;
 #endif
 #endif
 
-static void pwms_init();
-
 int platform_init()
 {
   // Setup the various forward and reverse mappings for the pins
   get_pin_map();
-
-  // Setup PWMs
-  pwms_init();
 
   cmn_platform_init();
   // All done
@@ -113,7 +108,9 @@ int platform_gpio_mode( unsigned pin, unsigned mode, unsigned pull )
     return 1;
   }
 
+#ifdef LUA_USE_MODULES_PWM
   platform_pwm_close(pin);    // closed from pwm module, if it is used in pwm
+#endif
 
   if (pull == PLATFORM_GPIO_PULLUP) {
     PIN_PULLUP_EN(pin_mux[pin]);
@@ -421,7 +418,7 @@ void platform_uart_send( unsigned id, u8 data )
 
 static uint16_t pwms_duty[NUM_PWM] = {0};
 
-static void pwms_init()
+void platform_pwm_init()
 {
   int i;
   for(i=0;i<NUM_PWM;i++){

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -70,7 +70,7 @@ enum
   ELUA_CAN_ID_EXT
 };
 
-static inline int platform_can_exists( unsigned id ) { return id < NUM_CAN; }
+static inline int platform_can_exists( unsigned id ) { return NUM_CAN && (id < NUM_CAN); }
 uint32_t platform_can_setup( unsigned id, uint32_t clock );
 int platform_can_send( unsigned id, uint32_t canid, uint8_t idtype, uint8_t len, const uint8_t *data );
 int platform_can_recv( unsigned id, uint32_t *canid, uint8_t *idtype, uint8_t *len, uint8_t *data );
@@ -171,6 +171,7 @@ void platform_uart_alt( int set );
 #define DUTY(d) ((uint16_t)( ((unsigned)(d)*PWM_DEPTH) / NORMAL_PWM_DEPTH) )
 
 // The platform PWM functions
+void platform_pwm_init( void );
 static inline int platform_pwm_exists( unsigned id ) { return ((id < NUM_PWM) && (id > 0)); }
 uint32_t platform_pwm_setup( unsigned id, uint32_t frequency, unsigned duty );
 void platform_pwm_close( unsigned id );


### PR DESCRIPTION
This resolves #1101 -- it turned out pretty simple.

Also, I fixed the compiler warning that annoyed me in every build (the warning about unsigned < 0 is always true.)