### PR TITLE
Limit file.open() names to 31 char max C string format

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -20,7 +20,7 @@ static int file_open( lua_State* L )
   }
 
   const char *fname = luaL_checklstring( L, 1, &len );
-  luaL_argcheck(L, len <= FS_NAME_MAX_LENGTH, 1, "filename too long");
+  luaL_argcheck(L, len < FS_NAME_MAX_LENGTH && c_strlen(fname) == len, 1, "filename invalid");
 
   const char *mode = luaL_optstring(L, 2, "r");
 

--- a/app/spiffs/spiffs_hydrogen.c
+++ b/app/spiffs/spiffs_hydrogen.c
@@ -764,7 +764,8 @@ static s32_t spiffs_read_dir_v(
           (SPIFFS_PH_FLAG_DELET | SPIFFS_PH_FLAG_IXDELE)) {
     struct spiffs_dirent *e = (struct spiffs_dirent *)user_p;
     e->obj_id = obj_id;
-    strcpy((char *)e->name, (char *)objix_hdr.name);
+    strncpy((char *)e->name, (char *)objix_hdr.name, SPIFFS_OBJ_NAME_LEN);
+
     e->type = objix_hdr.type;
     e->size = objix_hdr.size == SPIFFS_UNDEFINED_LEN ? 0 : objix_hdr.size;
     e->pix = pix;

--- a/app/spiffs/spiffs_nucleus.c
+++ b/app/spiffs/spiffs_nucleus.c
@@ -1349,7 +1349,7 @@ static s32_t spiffs_object_find_object_index_header_by_name_v(
   if (objix_hdr.p_hdr.span_ix == 0 &&
       (objix_hdr.p_hdr.flags & (SPIFFS_PH_FLAG_DELET | SPIFFS_PH_FLAG_FINAL | SPIFFS_PH_FLAG_IXDELE)) ==
           (SPIFFS_PH_FLAG_DELET | SPIFFS_PH_FLAG_IXDELE)) {
-    if (strcmp((char *)user_p, (char *)objix_hdr.name) == 0) {
+    if (strncmp((char *)user_p, (char *)objix_hdr.name, SPIFFS_OBJ_NAME_LEN) == 0) {
       return SPIFFS_OK;
     }
   }
@@ -1715,7 +1715,7 @@ static s32_t spiffs_obj_lu_find_free_obj_id_bitmap_v(spiffs *fs, spiffs_obj_id i
       if (objix_hdr.p_hdr.span_ix == 0 &&
           (objix_hdr.p_hdr.flags & (SPIFFS_PH_FLAG_DELET | SPIFFS_PH_FLAG_FINAL | SPIFFS_PH_FLAG_IXDELE)) ==
               (SPIFFS_PH_FLAG_DELET | SPIFFS_PH_FLAG_IXDELE)) {
-        if (strcmp((char *)user_p, (char *)objix_hdr.name) == 0) {
+        if (strncmp((char *)user_p, (char *)objix_hdr.name, SPIFFS_OBJ_NAME_LEN) == 0) {
           return SPIFFS_ERR_CONFLICTING_NAME;
         }
       }
@@ -1745,7 +1745,7 @@ static s32_t spiffs_obj_lu_find_free_obj_id_compact_v(spiffs *fs, spiffs_obj_id 
         ((objix_hdr.p_hdr.flags & (SPIFFS_PH_FLAG_INDEX | SPIFFS_PH_FLAG_FINAL | SPIFFS_PH_FLAG_DELET)) ==
             (SPIFFS_PH_FLAG_DELET))) {
       // ok object look up entry
-      if (state->conflicting_name && strcmp((const char *)state->conflicting_name, (char *)objix_hdr.name) == 0) {
+      if (state->conflicting_name && strncmp((const char *)state->conflicting_name, (char *)objix_hdr.name, SPIFFS_OBJ_NAME_LEN) == 0) {
         return SPIFFS_ERR_CONFLICTING_NAME;
       }
 


### PR DESCRIPTION
@devyte raised this bug in #1112.  This PR closes this bug.
```
> file.format()
format done.
> fn1="return function(...) print(...) end"
> function wf(f,fn) d=file.open(f, "w") or error("failed") file.write(fn) file.close() end
> function lf() for k,l in pairs(file.list()) do print (k, k:len(), l) end end
> wf("testfilename34567890123456.lua",fn1)
> wf("testfilename345678901234567.lua",fn1)
> wf("testfilename3456789012345678.lua",fn1)
stdin:1: bad argument #1 to 'open' (filename invalid)
stack traceback:
        [C]: in function 'open'
        stdin:1: in function 'wf'
        stdin:1: in main chunk
> wf("testfilename34567.lua\0xx",fn1)
stdin:1: bad argument #1 to 'open' (filename invalid)
stack traceback:
        [C]: in function 'open'
        stdin:1: in function 'wf'
        stdin:1: in main chunk
> lf()
testfilename345678901234567.lua 31      35
testfilename34567890123456.lua  30      35
>
```