### PR TITLE
Try to make qos~=0 work better

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -223,7 +223,7 @@ static sint8 mqtt_send_if_possible(struct espconn *pesp_conn)
       mud->keep_alive_tick = 0;
     }
   }
-  NODE_DBG("receive, queue size: %d\n", msg_size(&(mud->mqtt_state.pending_msg_q)));
+  NODE_DBG("send_if_poss, queue size: %d\n", msg_size(&(mud->mqtt_state.pending_msg_q)));
   return espconn_status;
 }
 
@@ -559,7 +559,6 @@ void mqtt_socket_timer(void *arg)
       // no queued event.
       mud->keep_alive_tick ++;
       if(mud->keep_alive_tick > mud->mqtt_state.connect_info->keepalive){
-        mud->event_timeout = MQTT_SEND_TIMEOUT;
         uint8_t temp_buffer[MQTT_BUF_SIZE];
         mqtt_msg_init(&mud->mqtt_state.mqtt_connection, temp_buffer, MQTT_BUF_SIZE);
         NODE_DBG("\r\nMQTT: Send keepalive packet\r\n");

--- a/app/mqtt/mqtt_msg.c
+++ b/app/mqtt/mqtt_msg.c
@@ -402,14 +402,19 @@ mqtt_message_t* mqtt_msg_pubcomp(mqtt_connection_t* connection, uint16_t message
   return fini_message(connection, MQTT_MSG_TYPE_PUBCOMP, 0, 0, 0);
 }
 
-mqtt_message_t* mqtt_msg_subscribe(mqtt_connection_t* connection, const char* topic, int qos, uint16_t* message_id)
+mqtt_message_t* mqtt_msg_subscribe_init(mqtt_connection_t* connection, uint16_t *message_id)
 {
   init_message(connection);
 
-  if(topic == NULL || topic[0] == '\0')
+  if((*message_id = append_message_id(connection, 0)) == 0)
     return fail_message(connection);
 
-  if((*message_id = append_message_id(connection, 0)) == 0)
+  return &connection->message;
+}
+
+mqtt_message_t* mqtt_msg_subscribe_topic(mqtt_connection_t* connection, const char* topic, int qos)
+{
+  if(topic == NULL || topic[0] == '\0')
     return fail_message(connection);
 
   if(append_string(connection, topic, c_strlen(topic)) < 0)
@@ -419,7 +424,27 @@ mqtt_message_t* mqtt_msg_subscribe(mqtt_connection_t* connection, const char* to
     return fail_message(connection);
   connection->buffer[connection->message.length++] = qos;
 
+  return &connection->message;
+}
+
+mqtt_message_t* mqtt_msg_subscribe_fini(mqtt_connection_t* connection)
+{
   return fini_message(connection, MQTT_MSG_TYPE_SUBSCRIBE, 0, 1, 0);
+}
+
+mqtt_message_t* mqtt_msg_subscribe(mqtt_connection_t* connection, const char* topic, int qos, uint16_t* message_id)
+{
+  mqtt_message_t* result;
+  
+  result = mqtt_msg_subscribe_init(connection, message_id);
+  if (result->length != 0) {
+    result = mqtt_msg_subscribe_topic(connection, topic, qos);
+  }
+  if (result->length != 0) {
+    result = mqtt_msg_subscribe_fini(connection);
+  }
+
+  return result;
 }
 
 mqtt_message_t* mqtt_msg_unsubscribe(mqtt_connection_t* connection, const char* topic, uint16_t* message_id)

--- a/app/mqtt/mqtt_msg.h
+++ b/app/mqtt/mqtt_msg.h
@@ -120,6 +120,10 @@ mqtt_message_t* mqtt_msg_pingreq(mqtt_connection_t* connection);
 mqtt_message_t* mqtt_msg_pingresp(mqtt_connection_t* connection);
 mqtt_message_t* mqtt_msg_disconnect(mqtt_connection_t* connection);
 
+mqtt_message_t* mqtt_msg_subscribe_init(mqtt_connection_t* connection, uint16_t* message_id);
+mqtt_message_t* mqtt_msg_subscribe_topic(mqtt_connection_t* connection, const char* topic, int qos);
+mqtt_message_t* mqtt_msg_subscribe_fini(mqtt_connection_t* connection);
+
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION
There are two things in the PR

* Make sure that we send the next message in the queue whenever possible. This *should* fix all the delays. I can send multiple messages per second with non zero QOS now with no obvious delays (and no queue buildup). 

* Make sure that we don't save the lua_State pointer and use it later. This fails in all sorts of horrible ways in the presence of coroutines.

As a benefit, this actually reduces the number of lines of code.....