### PR TITLE
Add some easy development debugging

### DIFF
--- a/app/driver/uart.c
+++ b/app/driver/uart.c
@@ -291,11 +291,6 @@ uart_init(UartBautRate uart0_br, UartBautRate uart1_br, os_signal_t sig_input)
     UartDev.baut_rate = uart1_br;
     uart_config(UART1);
     ETS_UART_INTR_ENABLE();
-
-    // install uart1 putc callback
-#ifndef NODE_DEBUG
-    os_install_putc1((void *)uart1_write_char);
-#endif
 }
 
 void ICACHE_FLASH_ATTR

--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -16,7 +16,20 @@
 #define ESP_INIT_DATA_ENABLE_READVDD33
 //#define ESP_INIT_DATA_ENABLE_READADC
 //#define ESP_INIT_DATA_FIXED_VDD33_VALUE 33
+//
 
+// This adds the asserts in LUA. It also adds some useful extras to the
+// node module. This is all silent in normal operation and so can be enabled
+// without any harm (except for the code size increase and slight slowdown)
+//#define DEVELOPMENT_TOOLS
+
+#ifdef DEVELOPMENT_TOOLS
+extern void luaL_assertfail(const char *file, int line, const char *message);
+#define lua_assert(x)    ((x) ? (void) 0 : luaL_assertfail(__FILE__, __LINE__, #x))
+#endif
+
+// This enables lots of debug output and changes the serial bit rate. This
+// is normally only used by hardcore developers
 // #define DEVELOP_VERSION
 #ifdef DEVELOP_VERSION
 #define NODE_DEBUG

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -806,6 +806,9 @@ static void *l_alloc (void *ud, void *ptr, size_t osize, size_t nsize) {
   return nptr;
 }
 
+LUALIB_API void luaL_assertfail(const char *file, int line, const char *message) {
+  c_printf("ASSERT@%s(%d): %s\n", file, line, message); 
+}
 
 static int panic (lua_State *L) {
   (void)L;  /* to avoid warnings */

--- a/app/lua/lauxlib.h
+++ b/app/lua/lauxlib.h
@@ -100,7 +100,7 @@ LUALIB_API const char *(luaL_gsub) (lua_State *L, const char *s, const char *p,
 LUALIB_API const char *(luaL_findtable) (lua_State *L, int idx,
                                          const char *fname, int szhint);
 
-
+LUALIB_API void luaL_assertfail(const char *file, int line, const char *message);
 
 
 /*

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -604,6 +604,20 @@ static int node_egc_setmode(lua_State* L) {
   legc_set_mode( L, mode, limit );
   return 0;
 }
+//
+// Lua: osprint(true/false)
+// Allows you to turn on the native Espressif SDK printing
+static int node_osprint( lua_State* L )
+{
+  if (lua_toboolean(L, 1)) {
+    system_set_os_print(1);
+  } else {
+    system_set_os_print(0);
+  }
+
+  return 0;  
+}
+
 // Module function map
 
 static const LUA_REG_TYPE node_egc_map[] = {
@@ -650,6 +664,9 @@ static const LUA_REG_TYPE node_map[] =
 #endif
   { LSTRKEY( "egc" ),  LROVAL( node_egc_map ) },
   { LSTRKEY( "task" ), LROVAL( node_task_map ) },
+#ifdef DEVELOPMENT_TOOLS
+  { LSTRKEY( "osprint" ), LFUNCVAL( node_osprint ) },
+#endif
 
 // Combined to dsleep(us, option)
 // { LSTRKEY( "dsleepsetoption" ), LFUNCVAL( node_deepsleep_setoption) },

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -170,9 +170,9 @@ void user_init(void)
     input_sig = task_get_id(handle_input);
     uart_init (br, br, input_sig);
 
-    #ifndef NODE_DEBUG
+#ifndef NODE_DEBUG
     system_set_os_print(0);
-    #endif
+#endif
 
     system_init_done_cb(nodemcu_init);
 }

--- a/docs/en/modules/node.md
+++ b/docs/en/modules/node.md
@@ -382,6 +382,25 @@ node.compile('bigstuff.lua')
 #### See also
 [`node.compile()`](#nodecompile)
 
+## node.osprint()
+
+Controls whether the debugging output from the Espressif SDK is printed. Note that this is only available if
+the firmware is build with DEVELOPMENT_TOOLS defined.
+
+####Syntax
+`node.osprint(enabled)`
+
+#### Parameters
+- `enabled` This is either `true` to enable printing, or `false` to disable it. The default is `false`.
+
+#### Returns
+Nothing
+
+#### Example
+```lua
+node.osprint(true)
+```
+
 # node.egc module
 
 ## node.egc.setmode()


### PR DESCRIPTION
This adds (under a new #define) two things:

* node.osprint(true/false) -- this enables/disables the espressif sdk logging. This is *really* useful when trying to debug certificate issues

* enables all the asserts

It leaves the bit rate alone. There is no extra output by default so all the existing upload tools continue to work. The problem with DEVELOP_VERSION is that it generates a lot of extra output....