### PR TITLE
one line bugfix to GPIO.c -- Oops!

### DIFF
--- a/docs/en/modules/gpio.md
+++ b/docs/en/modules/gpio.md
@@ -98,18 +98,18 @@ gpio.serout(1,1,{8,18},8) -- serial 30% pwm 38k, lasts 8 cycles
 
 ## gpio.trig()
 
-Establish a callback function to run on interrupt for a pin.
-
-There is currently no support for unregistering the callback.
+Establish or clear a callback function to run on interrupt for a pin.
 
 This function is not available if GPIO_INTERRUPT_ENABLE was undefined at compile time.
 
 #### Syntax
-`gpio.trig(pin, type [, function(level)])`
+`gpio.trig(pin, [type [, function(level)]})`
 
 #### Parameters
 - `pin` **1~12**, IO index, pin D0 does not support interrupt.
-- `type` "up", "down", "both", "low", "high", which represent rising edge, falling edge, both edge, low level, high level trig mode correspondingly.
+- `type` "up", "down", "both", "low", "high", which represent rising edge, falling edge, both edge, 
+low level, high level trig mode correspondingly. If the type is "none" or omitted then the
+callback function is removed and the interrupt disabled.
 - `function(level)` callback function when triggered. The gpio level is the param. Use previous callback function if undefined here.
 
 #### Returns
@@ -131,6 +131,9 @@ function pin1cb(level)
 end
 gpio.trig(pin, "down", pin1cb)
 
+```
+```Lua
+gpio.trig(4, 'none') -- remove any existing trigger
 ```
 #### See also
 [`gpio.mode()`](#gpiomode)

--- a/docs/en/modules/gpio.md
+++ b/docs/en/modules/gpio.md
@@ -103,14 +103,16 @@ Establish or clear a callback function to run on interrupt for a pin.
 This function is not available if GPIO_INTERRUPT_ENABLE was undefined at compile time.
 
 #### Syntax
-`gpio.trig(pin, [type [, function(level)]})`
+`gpio.trig(pin, [type [, callback_function]])`
 
 #### Parameters
-- `pin` **1~12**, IO index, pin D0 does not support interrupt.
-- `type` "up", "down", "both", "low", "high", which represent rising edge, falling edge, both edge, 
-low level, high level trig mode correspondingly. If the type is "none" or omitted then the
-callback function is removed and the interrupt disabled.
-- `function(level)` callback function when triggered. The gpio level is the param. Use previous callback function if undefined here.
+- `pin` **1-12**, pin to trigger on, IO index. Note that pin 0 does not support interrupts.
+- `type` "up", "down", "both", "low", "high", which represent *rising edge*, *falling edge*, *both 
+edges*, *low level*, and *high level* trigger modes respectivey. If the type is "none" or omitted 
+then the callback function is removed and the interrupt is disabled.
+- `callback_function(level)` callback function when trigger occurs. The level of the specified pin 
+at the interrupt passed as the parameter to the callback. The previous callback function will be 
+used if the function is omitted.
 
 #### Returns
 `nil`
@@ -118,23 +120,20 @@ callback function is removed and the interrupt disabled.
 #### Example
 
 ```lua
--- use pin 1 as the input pulse width counter
-pin = 1
-pulse1 = 0
-du = 0
-gpio.mode(pin,gpio.INT)
-function pin1cb(level)
-  du = tmr.now() - pulse1
-  print(du)
-  pulse1 = tmr.now()
-  if level == gpio.HIGH then gpio.trig(pin, "down") else gpio.trig(pin, "up") end
+do
+  -- use pin 1 as the input pulse width counter
+  local pin, pulse1, du, now, trig = 1, 0, 0, tmr.now, gpio.trig
+  gpio.mode(pin,gpio.INT)
+  local function pin1cb(level)
+    local pulse2 = now()
+    print( level, pulse2 - pulse1 )
+    pulse1 = pulse2
+    trig(pin, level == gpio.HIGH  and "down" or "up")
+  end
+  trig(pin, "down", pin1cb)
 end
-gpio.trig(pin, "down", pin1cb)
+```
 
-```
-```Lua
-gpio.trig(4, 'none') -- remove any existing trigger
-```
 #### See also
 [`gpio.mode()`](#gpiomode)
 


### PR DESCRIPTION
I left the NULL terminator off the end of a `luaL_checkoption()` options list.  Idiot.  How did I miss that?