### PR TITLE
Fix null-pointer crash on early input

### DIFF
--- a/app/lua/lua.c
+++ b/app/lua/lua.c
@@ -468,7 +468,7 @@ int lua_main (int argc, char **argv) {
 
 void lua_handle_input (bool force)
 {
-  if (force || readline (&gLoad))
+  if (gLoad.L && (force || readline (&gLoad)))
     dojob (&gLoad);
 }
 

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -80,19 +80,16 @@ void TEXT_SECTION_ATTR user_start_trampoline (void)
   call_user_start ();
 }
 
-static bool lua_started=false;
 // +================== New task interface ==================+
 static void start_lua(task_param_t param, uint8 priority) {
   char* lua_argv[] = { (char *)"lua", (char *)"-i", NULL };
   NODE_DBG("Task task_lua started.\n");
   lua_main( 2, lua_argv );
-  lua_started=true;
 }
 
 static void handle_input(task_param_t flag, uint8 priority) {
 //  c_printf("HANDLE_INPUT: %u %u\n", flag, priority);          REMOVE
-  if (lua_started)
-    lua_handle_input (flag);
+  lua_handle_input (flag);
 }
 
 static task_handle_t input_sig;

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -80,16 +80,19 @@ void TEXT_SECTION_ATTR user_start_trampoline (void)
   call_user_start ();
 }
 
+static bool lua_started=false;
 // +================== New task interface ==================+
 static void start_lua(task_param_t param, uint8 priority) {
   char* lua_argv[] = { (char *)"lua", (char *)"-i", NULL };
   NODE_DBG("Task task_lua started.\n");
   lua_main( 2, lua_argv );
+  lua_started=true;
 }
 
 static void handle_input(task_param_t flag, uint8 priority) {
 //  c_printf("HANDLE_INPUT: %u %u\n", flag, priority);          REMOVE
-  lua_handle_input (flag);
+  if (lua_started)
+    lua_handle_input (flag);
 }
 
 static task_handle_t input_sig;


### PR DESCRIPTION
With the recent changes to UART init and task handling, we've exposed a race condition that can cause a null-pointer crash whenever the ESP receives UART input in the window \[uart_config, lua_start). `lua_handle_input()` would happily be called before the Lua receive buffer has been allocated, with predictably bad results.

Tagging @TerryE for review/merge.