### PR TITLE
Add support for GPIO open-drain output mode.

### DIFF
--- a/app/modules/gpio.c
+++ b/app/modules/gpio.c
@@ -12,6 +12,7 @@
 #define PULLUP PLATFORM_GPIO_PULLUP
 #define FLOAT PLATFORM_GPIO_FLOAT
 #define OUTPUT PLATFORM_GPIO_OUTPUT
+#define OPENDRAIN PLATFORM_GPIO_OPENDRAIN
 #define INPUT PLATFORM_GPIO_INPUT
 #define INTERRUPT PLATFORM_GPIO_INT
 #define HIGH PLATFORM_GPIO_HIGH
@@ -93,7 +94,7 @@ static int lgpio_mode( lua_State* L )
   unsigned pullup = luaL_optinteger( L, 3, FLOAT );
 
   luaL_argcheck(L, platform_gpio_exists(pin) && (mode!=INTERRUPT || pin>0), 1, "Invalid pin");
-  luaL_argcheck(L, mode==OUTPUT || mode==INPUT
+  luaL_argcheck(L, mode==OUTPUT || mode==OPENDRAIN || mode==INPUT
  #ifdef GPIO_INTERRUPT_ENABLE
                                                || mode==INTERRUPT
  #endif
@@ -203,12 +204,13 @@ static const LUA_REG_TYPE gpio_map[] = {
   { LSTRKEY( "trig" ),   LFUNCVAL( lgpio_trig ) },
   { LSTRKEY( "INT" ),    LNUMVAL( INTERRUPT ) },
 #endif
-  { LSTRKEY( "OUTPUT" ), LNUMVAL( OUTPUT ) },
-  { LSTRKEY( "INPUT" ),  LNUMVAL( INPUT ) },
-  { LSTRKEY( "HIGH" ),   LNUMVAL( HIGH ) },
-  { LSTRKEY( "LOW" ),    LNUMVAL( LOW ) },
-  { LSTRKEY( "FLOAT" ),  LNUMVAL( FLOAT ) },
-  { LSTRKEY( "PULLUP" ), LNUMVAL( PULLUP ) },
+  { LSTRKEY( "OUTPUT" ),    LNUMVAL( OUTPUT ) },
+  { LSTRKEY( "OPENDRAIN" ), LNUMVAL( OPENDRAIN ) },
+  { LSTRKEY( "INPUT" ),     LNUMVAL( INPUT ) },
+  { LSTRKEY( "HIGH" ),      LNUMVAL( HIGH ) },
+  { LSTRKEY( "LOW" ),       LNUMVAL( LOW ) },
+  { LSTRKEY( "FLOAT" ),     LNUMVAL( FLOAT ) },
+  { LSTRKEY( "PULLUP" ),    LNUMVAL( PULLUP ) },
   { LNILKEY, LNILVAL }
 };
 

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -32,6 +32,7 @@ uint8_t platform_key_led( uint8_t level);
 
 #define PLATFORM_GPIO_INT 2
 #define PLATFORM_GPIO_OUTPUT 1
+#define PLATFORM_GPIO_OPENDRAIN 3
 #define PLATFORM_GPIO_INPUT 0
 
 #define PLATFORM_GPIO_HIGH 1

--- a/docs/en/modules/gpio.md
+++ b/docs/en/modules/gpio.md
@@ -20,20 +20,20 @@ If not using a NodeMCU dev kit, please refer to the below GPIO pin maps for the 
 |        5 | GPIO14      |       12 | GPIO10      |
 |        6 | GPIO12      |          |             |
 
-** [*] D0(GPIO16) can only be used as gpio read/write. No interrupt support. No pwm/i2c/ow support. **
+** [*] D0(GPIO16) can only be used as gpio read/write. No support for open-drain/interrupt/pwm/i2c/ow. **
 
 
 ## gpio.mode()
 
-Initialize pin to GPIO mode, set the pin in/out direction, and optional internal pullup.
+Initialize pin to GPIO mode, set the pin in/out direction, and optional internal weak pull-up.
 
 #### Syntax
 `gpio.mode(pin, mode [, pullup])`
 
 #### Parameters
 - `pin` pin to configure, IO index
-- `mode` one of gpio.OUTPUT or gpio.INPUT, or gpio.INT(interrupt mode)
-- `pullup` gpio.PULLUP or gpio.FLOAT; default is gpio.FLOAT
+- `mode` one of gpio.OUTPUT, gpio.OPENDRAIN, gpio.INPUT, or gpio.INT (interrupt mode)
+- `pullup` gpio.PULLUP enables the weak pull-up resistor; default is gpio.FLOAT
 
 #### Returns
 `nil`


### PR DESCRIPTION
The discussion in #1139 highlighted that open-drain output mode is currently not supported by the gpio module. This PR adds a respective configuration option for *real* GPIOs (i.e. except pin 0 / GPIO16).
