### PR TITLE
fix for #1065

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -991,117 +991,65 @@ static int wifi_station_status( lua_State* L )
   return 1; 
 }
 
-/**
-  * wifi.sta.eventMonStop()
-  * Description:
-  * 	Stop wifi station event monitor
-  * Syntax:
-  * 	wifi.sta.eventMonStop()
-  * 	wifi.sta.eventMonStop("unreg all")
-  * Parameters:
-  * 	"unreg all": unregister all previously registered functions
-  * Returns:
-  * 	Nothing.
-  *
-  *	Example:
-  	  	  --stop wifi event monitor
-  	  	  wifi.sta.eventMonStop()
-
-  	  	  --stop wifi event monitor and unregister all callbacks
-  	  	  wifi.sta.eventMonStop("unreg all")
-  */
-static void wifi_station_event_mon_stop(lua_State* L)
+// wifi.sta.eventMonStop()
+void wifi_station_event_mon_stop(lua_State* L)
 {
   os_timer_disarm(&wifi_sta_status_timer);
   if(lua_isstring(L,1))
   {
-
-    if (c_strcmp(luaL_checkstring(L, 1), "unreg all")==0)
+    int i;
+    for (i=0; i<6; i++)
     {
-	  int i;
-	  for (i=0;i<6;i++)
+  	  if(wifi_status_cb_ref[i] != LUA_NOREF)
   	  {
-  	    if(wifi_status_cb_ref[i] != LUA_NOREF)
-	    {
-		  luaL_unref(L, LUA_REGISTRYINDEX, wifi_status_cb_ref[i]);
-		  wifi_status_cb_ref[i] = LUA_NOREF;
-	    }
+		luaL_unref(L, LUA_REGISTRYINDEX, wifi_status_cb_ref[i]);
+		wifi_status_cb_ref[i] = LUA_NOREF;
 	  }
     }
   }
+  return;
 }
 
 static void wifi_status_cb(int arg)
 {
-  if (wifi_get_opmode()==2)
+  lua_State* L = lua_getstate();
+  if (wifi_get_opmode() == SOFTAP_MODE)
   {
-	  os_timer_disarm(&wifi_sta_status_timer);
-	  return;
+    os_timer_disarm(&wifi_sta_status_timer);
+    return;
   }
-  int wifi_status=wifi_station_get_connect_status();
-  if (wifi_status!=prev_wifi_status)
+  int wifi_status = wifi_station_get_connect_status();
+  if (wifi_status != prev_wifi_status)
   {
- 	if(wifi_status_cb_ref[wifi_status]!=LUA_NOREF)
- 	{
-	  lua_rawgeti(gL, LUA_REGISTRYINDEX, wifi_status_cb_ref[wifi_status]);
-	  lua_call(gL, 0, 0);
- 	}
+    if(wifi_status_cb_ref[wifi_status] != LUA_NOREF)
+    {
+      lua_rawgeti(L, LUA_REGISTRYINDEX, wifi_status_cb_ref[wifi_status]);
+      lua_pushnumber(L, prev_wifi_status);
+      lua_call(L, 1, 0);
+    }
   }
-  prev_wifi_status=wifi_status;
+  prev_wifi_status = wifi_status;
 }
 
-/**
-  * wifi.sta.eventMonReg()
-  * Description:
-  * 	Register callback for wifi station status event
-  * Syntax:
-  * 	wifi.sta.eventMonReg(wifi_status, function)
-  * 	wifi.sta.eventMonReg(wifi.status, "unreg") //unregister callback
-  * Parameters:
-  * 	wifi_status: wifi status you would like to set callback for
-  * 		Valid wifi states:
-  * 			wifi.STA_IDLE
-  *				wifi.STA_CONNECTING
-  *				wifi.STA_WRONGPWD
-  *				wifi.STA_APNOTFOUND
-  *  			wifi.STA_FAIL
-  *  			wifi.STA_GOTIP
-  * 	function: function to perform
-  * 	"unreg": unregister previously registered function
-  * Returns:
-  * 	Nothing.
-  *
-  *	Example:
-  	  	--register callback
-  	  	wifi.sta.eventMonReg(0, function() print("STATION_IDLE") end)
-		wifi.sta.eventMonReg(1, function() print("STATION_CONNECTING") end)
-		wifi.sta.eventMonReg(2, function() print("STATION_WRONG_PASSWORD") end)
-		wifi.sta.eventMonReg(3, function() print("STATION_NO_AP_FOUND") end)
-		wifi.sta.eventMonReg(4, function() print("STATION_CONNECT_FAIL") end)
-		wifi.sta.eventMonReg(5, function() print("STATION_GOT_IP") end)
-
-		--unregister callback
-		wifi.sta.eventMonReg(0, "unreg")
-  */
-static int wifi_station_event_mon_reg(lua_State* L)
+// wifi.sta.eventMonReg()
+int wifi_station_event_mon_reg(lua_State* L)
 {
-  gL=L;
-  uint8 id=luaL_checknumber(L, 1);
-  if (!(id >= 0 && id <=5))
+  uint8 id=(uint8)luaL_checknumber(L, 1);
+  if ((id > 5)) // verify user specified a valid wifi status
   {
-	return luaL_error( L, "valid wifi status:0-5" );
+    return luaL_error( L, "valid wifi status:0-5" );
   }
 
-  if (lua_type(L, 2) == LUA_TFUNCTION || lua_type(L, 2) == LUA_TLIGHTFUNCTION)
+  if (lua_type(L, 2) == LUA_TFUNCTION || lua_type(L, 2) == LUA_TLIGHTFUNCTION) //check if 2nd item on stack is a function
   {
-    lua_pushvalue(L, 2);  // copy argument (func) to the top of stack
+    lua_pushvalue(L, 2); //push function to top of stack
     if(wifi_status_cb_ref[id] != LUA_NOREF)
     {
       luaL_unref(L, LUA_REGISTRYINDEX, wifi_status_cb_ref[id]);
     }
     wifi_status_cb_ref[id] = luaL_ref(L, LUA_REGISTRYINDEX);
   }
-  else if (c_strcmp(luaL_checkstring(L, 2), "unreg")==0)
+  else
   {
     if(wifi_status_cb_ref[id] != LUA_NOREF)
     {
@@ -1113,25 +1061,7 @@ static int wifi_station_event_mon_reg(lua_State* L)
 }
 
 
-/**
-  * wifi.sta.eventMonStart()
-  * Description:
-  * 	Start wifi station event monitor
-  * Syntax:
-  * 	wifi.sta.eventMonStart()
-  * 	wifi.sta.eventMonStart(mS)
-  * Parameters:
-  * 	mS:interval between checks in milliseconds. defaults to 150 mS if not provided
-  * Returns:
-  * 	Nothing.
-  *
-  *	Example:
- 		--start wifi event monitor with default interval
- 		wifi.sta.eventMonStart()
-
- 		--start wifi event monitor with 100 mS interval
- 		wifi.sta.eventMonStart(100)
-  */
+//wifi.sta.eventMonStart()
 static int wifi_station_event_mon_start(lua_State* L)
 {
   if(wifi_get_opmode() == SOFTAP_MODE)

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -326,19 +326,18 @@ none
 Registers callbacks for WiFi station status events.
 
 ####  Syntax
-- `wifi.sta.eventMonReg(wifi_status, function([previous_state]))`
-- `wifi.sta.eventMonReg(wifi.status, "unreg")`
+- `wifi.sta.eventMonReg(wifi_status[, function([previous_state])])`
 
 ####  Parameters
-- `wifi_status` WiFi status you would like to set callback for, one of: 
+- `wifi_status` WiFi status you would like to set a callback for: 
     - `wifi.STA_IDLE`
     - `wifi.STA_CONNECTING`
     - `wifi.STA_WRONGPWD`
     - `wifi.STA_APNOTFOUND`
     - `wifi.STA_FAIL`
     - `wifi.STA_GOTIP`
-- `function` function to perform when event occurs
-- `"unreg"` unregister previously registered callback
+- `function` callback function to perform when event occurs 
+	- Note: leaving field blank unregisters callback.
 - `previous_state` previous wifi_state(0 - 5)
 
 ####  Returns
@@ -364,7 +363,7 @@ wifi.sta.eventMonReg(wifi.STA_CONNECTING, function(previous_State)
 end)
   
 --unregister callback
-wifi.sta.eventMonReg(wifi.STA_IDLE, "unreg")
+wifi.sta.eventMonReg(wifi.STA_IDLE)
 ```
 #### See also
 - [`wifi.sta.eventMonStart()`](#wifistaeventmonstart)
@@ -395,15 +394,16 @@ wifi.sta.eventMonStart(100)
 #### See also
 - [`wifi.sta.eventMonReg()`](#wifistaeventmonreg)
 - [`wifi.sta.eventMonStop()`](#wifistaeventmonstop)
-- 
+
 ## wifi.sta.eventMonStop()
 
 Stops WiFi station event monitor.
 ####  Syntax
-`wifi.sta.eventMonStop(["unreg all"])`
+`wifi.sta.eventMonStop([unregister_all])`
 
 ####  Parameters
-`"unreg all"` unregister all previously registered functions
+- `unregister_all` enter 1 to unregister all previously registered functions.
+	- Note: leave blank to leave callbacks registered
 
 ####  Returns
 `nil`
@@ -414,7 +414,7 @@ Stops WiFi station event monitor.
 wifi.sta.eventMonStop()
 
 --stop WiFi event monitor and unregister all callbacks
-wifi.sta.eventMonStop("unreg all")
+wifi.sta.eventMonStop(1)
 ```
 
 #### See also


### PR DESCRIPTION
Fixed bug where `previous_state` was not being returned

Also changed wifi.sta.eventMonStop("unreg all") to
wifi.sta.eventMonStop(1) and wifi.sta.eventMonReg(wifi.status, "unreg")
to wifi.sta.eventMonReg(wifi.status)

ALL backwards compatibility was preserved