### PR TITLE
Allow interrupts when writing a ws2812 buffer

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -269,14 +269,8 @@ static int ICACHE_FLASH_ATTR ws2812_buffer_write(lua_State* L) {
 
   luaL_argcheck(L, buffer && buffer->canary == CANARY_VALUE, 1, "ws2812.buffer expected");
 
-  // Initialize the output pin
-  platform_gpio_mode(pin, PLATFORM_GPIO_OUTPUT, PLATFORM_GPIO_FLOAT);
-  platform_gpio_write(pin, 0);
-
   // Send the buffer
-  ets_intr_lock();
   ws2812_write(pin_num[pin], &buffer->values[0], 3*buffer->size);
-  ets_intr_unlock();
 
   return 0;
 }


### PR DESCRIPTION
The new ws2812 module allows interrupts everywhere except when calling `buffer:write(led_pin)` on a ws2812.buffer object.  This restriction seems unnecessary, because `ws2812.write(led_pin, buffer)` accomplishes the same without disabling interrupts.

This pull request removes the call to `ets_intr_lock` from `ws2812_buffer_write`.

Also, initializing the output pin is not necessary in `ws2812_buffer_write` because `ws2812_write` does it anyway.
