### PR TITLE
Enable -std=gnu11 for user dir

### DIFF
--- a/app/include/rom.h
+++ b/app/include/rom.h
@@ -149,4 +149,7 @@ void srand(unsigned int);
 
 void uart_div_modify(int no, unsigned int freq);
 
+/* Returns 0 on success, 1 on failure */
+uint8_t SPIRead(uint32_t src_addr, uint32_t *des_addr, uint32_t size);
+
 #endif

--- a/app/platform/flash_api.h
+++ b/app/platform/flash_api.h
@@ -86,6 +86,8 @@ typedef struct
     uint32_t segment_size;
 } ICACHE_STORE_TYPEDEF_ATTR SPIFlashInfo;
 
+SpiFlashOpResult SPIRead(uint32_t src_addr, uint32_t *des_addr, uint32_t size);
+
 uint32_t flash_detect_size_byte(void);
 uint32_t flash_safe_get_size_byte(void);
 uint16_t flash_safe_get_sec_num(void);

--- a/app/platform/flash_api.h
+++ b/app/platform/flash_api.h
@@ -86,8 +86,6 @@ typedef struct
     uint32_t segment_size;
 } ICACHE_STORE_TYPEDEF_ATTR SPIFlashInfo;
 
-SpiFlashOpResult SPIRead(uint32_t src_addr, uint32_t *des_addr, uint32_t size);
-
 uint32_t flash_detect_size_byte(void);
 uint32_t flash_safe_get_size_byte(void);
 uint16_t flash_safe_get_sec_num(void);

--- a/app/user/Makefile
+++ b/app/user/Makefile
@@ -15,6 +15,7 @@ ifndef PDIR
 GEN_LIBS = libuser.a
 endif
 
+STD_CFLAGS=-std=gnu11 -Wimplicit
 
 #############################################################
 # Configuration i.e. compile options etc.

--- a/app/user/user_exceptions.h
+++ b/app/user/user_exceptions.h
@@ -3,3 +3,4 @@
 #include <xtensa/corebits.h>
 
 void load_non_32_wide_handler (struct exception_frame *ef, uint32_t cause) TEXT_SECTION_ATTR;
+void __real__xtos_set_exception_handler (uint32_t cause, exception_handler_fn fn);

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -13,6 +13,7 @@
 #include "c_string.h"
 #include "c_stdlib.h"
 #include "flash_fs.h"
+#include "flash_api.h"
 #include "user_interface.h"
 #include "user_exceptions.h"
 #include "user_modules.h"
@@ -69,7 +70,7 @@ void TEXT_SECTION_ATTR user_start_trampoline (void)
    * terse and not as readable as one might like.
    */
   SPIFlashInfo sfi;
-  SPIRead (0, &sfi, sizeof (sfi)); // Cache read not enabled yet, safe to use
+  SPIRead (0, (uint32_t *)(&sfi), sizeof (sfi)); // Cache read not enabled yet, safe to use
   if (sfi.size < 2) // Compensate for out-of-order 4mbit vs 2mbit values
     sfi.size ^= 1;
   uint32_t flash_end_addr = (256 * 1024) << sfi.size;

--- a/sdk-overrides/include/osapi.h
+++ b/sdk-overrides/include/osapi.h
@@ -10,6 +10,8 @@ int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 
 
 void NmiTimSetFunc(void (*func)(void));
 
+void call_user_start(void);
+
 #include_next "osapi.h"
 
 #endif


### PR DESCRIPTION
The last of the gnu11 iterations for #927.

@jmattsson please review whether `flash_api.h` is a suitable place for declaring `SPIRead()`. It's provided from ROM but adding it to `sdk-overrides/include/rom.h` would require to include flash_api.h which complicates things a bit.
