### PR TITLE
Shorten ucg constructors to keep them below LUA_MAX_ROTABLE_NAME

### DIFF
--- a/app/include/ucg_config.h
+++ b/app/include/ucg_config.h
@@ -30,10 +30,10 @@
 //    UCG_DISPLAY_TABLE_ENTRY(ili9163_18x128x128_hw_spi, ucg_dev_ili9163_18x128x128, ucg_ext_ili9163_18) \
 //    UCG_DISPLAY_TABLE_ENTRY(ili9341_18x240x320_hw_spi, ucg_dev_ili9341_18x240x320, ucg_ext_ili9341_18) \
 //    UCG_DISPLAY_TABLE_ENTRY(pcf8833_16x132x132_hw_spi, ucg_dev_pcf8833_16x132x132, ucg_ext_pcf8833_16) \
-//    UCG_DISPLAY_TABLE_ENTRY(seps225_16x128x128_univision_hw_spi, ucg_dev_seps225_16x128x128_univision, ucg_ext_seps225_16) \
+//    UCG_DISPLAY_TABLE_ENTRY(seps225_16x128x128_uvis_hw_spi, ucg_dev_seps225_16x128x128_univision, ucg_ext_seps225_16) \
 //    UCG_DISPLAY_TABLE_ENTRY(ssd1351_18x128x128_hw_spi, ucg_dev_ssd1351_18x128x128_ilsoft, ucg_ext_ssd1351_18) \
 //    UCG_DISPLAY_TABLE_ENTRY(ssd1351_18x128x128_ft_hw_spi, ucg_dev_ssd1351_18x128x128_ft, ucg_ext_ssd1351_18) \
-//    UCG_DISPLAY_TABLE_ENTRY(ssd1331_18x96x64_univision_hw_spi, ucg_dev_ssd1331_18x96x64_univision, ucg_ext_ssd1331_18) \
+//    UCG_DISPLAY_TABLE_ENTRY(ssd1331_18x96x64_uvis_hw_spi, ucg_dev_ssd1331_18x96x64_univision, ucg_ext_ssd1331_18) \
 //    UCG_DISPLAY_TABLE_ENTRY(st7735_18x128x160_hw_spi, ucg_dev_st7735_18x128x160, ucg_ext_st7735_18) \
 
 #define UCG_DISPLAY_TABLE_ENTRY(binding, device, extension)

--- a/docs/en/modules/ucg.md
+++ b/docs/en/modules/ucg.md
@@ -77,10 +77,10 @@ Initialize a display via Hardware SPI.
 - `ili9163_18x128x128_hw_spi()`
 - `ili9341_18x240x320_hw_spi()`
 - `pcf8833_16x132x132_hw_spi()`
-- `seps225_16x128x128_univision_hw_spi()`
+- `seps225_16x128x128_uvis_hw_spi()`
 - `ssd1351_18x128x128_hw_spi()`
 - `ssd1351_18x128x128_ft_hw_spi()`
-- `ssd1331_18x96x64_univision_hw_spi()`
+- `ssd1331_18x96x64_uvis_hw_spi()`
 - `st7735_18x128x160_hw_spi()`
 
 #### Syntax


### PR DESCRIPTION
Fixes #1188.