### PR TITLE
Add regular sends to mdns. Check for (some) buffer overflows. Make it handle unicast

### DIFF
--- a/app/modules/mdns.c
+++ b/app/modules/mdns.c
@@ -94,7 +94,7 @@ static wrapper_t *process_args(lua_State *L, phase_t phase, size_t *sizep)
       } else {
         // put in the key
 	c_strcpy(p, luaL_checkstring(L, -2));
-        result->mdns_info.txt_data[slot] = p;
+        result->mdns_info.txt_data[slot++] = p;
 	p = advance_over_string(p);
 
 	// now smash in the value

--- a/docs/en/modules/mdns.md
+++ b/docs/en/modules/mdns.md
@@ -17,6 +17,10 @@ Register a hostname and start the mDNS service. If the service is already runnin
 - `port` The port number for the primary service.
 - `attributes` A optional table of up to 10 attributes to be exposed. The keys must all be strings.
 
+There is a special option where you can specify (essentially) two hostnames. One is the pretty name, and the other is the simple name. In order to do this,
+you specify the pretty name as the hostname parameter, and then add an attribute with key hostname and value of the simple name. See the second example below 
+for an example.
+
 #### Returns
 `nil`
 
@@ -28,6 +32,8 @@ Various errors can be generated during argument validation. The NodeMCU must hav
     mdns.register("fishtank", "http", 80, { hardware='NodeMCU'})
 
 Using `dns-sd` on OS X, you can see `fishtank.local` as providing the `_http._tcp` service. You can also browse directly to `fishtank.local`. In Safari you can get all the mDNS web pages as part of your bookmarks menu.
+
+    mdns.register("Top Fishtank", "http", 80, { hostname='toptank', location='Living Room' })
 
 ## mdns.close()
 Shut down the mDNS service. This is not normally needed.


### PR DESCRIPTION
This code was *ugly*. It is only a little better now. Some of the ugliness is due to the espressif sdk referencing (I think) into this code (so I can't change the mdns_info structure).

Anyway, the changes are as follows:

* Retransmit the registration packet every 120 seconds. This keeps most oses happy.
* Make it handle requests sent directly to port 5353 and respond with its standard packet.

There is still stuff that I don't understand in this code. I'm reluctant to rip it out entirely. 

I'm expecting a bunch of feedback on this one. 

It still doesn't work unless you are in STATION mode. It tries to do stuff in the other modes, but it doesn't appear to work. I'm sure that you can corrupt memory by passing in really long fields. So don't do that! 