### PR TITLE
Fixed double-free in crypto module

### DIFF
--- a/app/modules/crypto.c
+++ b/app/modules/crypto.c
@@ -238,7 +238,6 @@ static int crypto_hash_gcdelete (lua_State *L)
   luaL_argcheck(L, dudat, 1, "crypto.hash expected");
 
   os_free(dudat->ctx);
-  os_free(dudat);
 
   return 0;
 }


### PR DESCRIPTION
This one showed up after @pjsg 's commit 84487d300b97650ecfb4e613307185e1a50487de let the SDK drop error messages onto uart0 rather than hiding them on uart1.

And in case anyone sees "E:M \<number\>" messages and wonders that they mean, those are the result of a failed malloc of \<number\> bytes.