### PR TITLE
Provide crypto.rnd32() interface to os_random()

### DIFF
--- a/app/modules/crypto.c
+++ b/app/modules/crypto.c
@@ -362,6 +362,24 @@ static int lcrypto_decrypt (lua_State *L)
   return crypto_encdec (L, false);
 }
 
+// returns integer between 0 and 2^32-1, inclusive
+static int lcrypto_rnd32 (lua_State *L)
+{
+  lua_pushnumber (L, (uint32_t)os_random());
+
+  return 1;
+}
+
+#ifndef LUA_NUMBER_INTEGRAL
+// returns double in the range [0,1)
+static int lcrypto_frnd (lua_State *L)
+{
+  lua_pushnumber (L, (double)((uint32_t)os_random())/4294967296.0);
+
+  return 1;
+}
+#endif
+
 // Hash function map
 static const LUA_REG_TYPE crypto_hash_map[] = {
   { LSTRKEY( "update" ),  LFUNCVAL( crypto_hash_update ) },
@@ -384,6 +402,10 @@ static const LUA_REG_TYPE crypto_map[] = {
   { LSTRKEY( "hmac"   ),   LFUNCVAL( crypto_lhmac ) },
   { LSTRKEY( "encrypt" ),  LFUNCVAL( lcrypto_encrypt ) },
   { LSTRKEY( "decrypt" ),  LFUNCVAL( lcrypto_decrypt ) },
+  { LSTRKEY( "rnd32" ),    LFUNCVAL( lcrypto_rnd32 ) },
+#ifndef LUA_NUMBER_INTEGRAL
+  { LSTRKEY( "frnd" ),     LFUNCVAL( lcrypto_frnd ) },
+#endif
   { LNILKEY, LNILVAL }
 };
 

--- a/docs/en/modules/crypto.md
+++ b/docs/en/modules/crypto.md
@@ -90,6 +90,29 @@ A binary string containing the message digest. To obtain the textual version (AS
 print(crypto.toHex(crypto.fhash("sha1","myfile.lua")))
 ```
 
+## crypto.frnd()
+
+Obtain a random number from the hardware random number generator in the
+range \[0,1). Not available in an integer-only build.
+
+#### Syntax
+`random = crypto.frnd()`
+
+#### Parameters
+none
+
+#### Returns
+A random floating point number in the range \[0,1), sourced from the hardware
+random number generator.
+
+#### Example
+```lua
+int0_to_5 = math.floor(crypto.frnd() * 6)
+```
+
+#### See also
+  - [`crypto.rnd32()`](#cryptornd32)
+
 ## crypto.hash()
 
 Compute a cryptographic hash of a Lua string.
@@ -190,6 +213,28 @@ The masked message, as a binary string. Use [`crypto.toHex()`](#cryptotohex) to 
 ```lua
 print(crypto.toHex(crypto.mask("some message to obscure","X0Y7")))
 ```
+
+## crypto.rnd32()
+
+Provides access to the hardware random number generator on the ESP.
+
+#### Syntax
+`random = crypto.rnd32()`
+
+#### Parameters
+none
+
+#### Return
+A 32bit (unsigned) random value, sourced from the hardware random number generator.
+
+#### Example
+```lua
+-- Seed the regular Lua PRNG from the HWRNG
+math.randomseed(crypto.rnd32())
+```
+
+#### See also
+  - [`crypto.frnd()`](#cryptofrnd)
 
 ## crypto.toBase64()
 


### PR DESCRIPTION
Since the regular `math.random()` is a PRNG which doesn't get seeded it can be hard go get good random numbers in Lua. Since the ESP has an onboard HWRNG, it seemed useful to expose it.

(I squashed my docs into Bernie's commit, don't blame him if there's something wrong in the docs :D )