### PR TITLE
Queueing example for net.socket:send()

### DIFF
--- a/docs/en/modules/net.md
+++ b/docs/en/modules/net.md
@@ -261,7 +261,8 @@ end)
 ```
 
 #### See also
-[`net.socket:on()`](#netsocketon)
+- `lua_examples/net_send_queue.lua`
+- [`net.socket:on()`](#netsocketon)
 
 # net.dns Module
 

--- a/lua_examples/net_send_queue.lua
+++ b/lua_examples/net_send_queue.lua
@@ -1,0 +1,46 @@
+------------------------------------------------------------------------------
+-- Net send queueing helper
+--
+-- See also
+--   https://nodemcu.readthedocs.org/en/dev/en/modules/net/#netsocketsend
+--
+-- Based on Vladimir Dronnikov's
+--   MQTT queuing publish helper
+--   https://github.com/dvv/nodemcu-thingies/blob/master/mqtt-queue-helper.lua
+--   LICENCE: http://opensource.org/licenses/MIT
+--
+-- Send arbitrary payload:
+--   local socket = net.createConnection(net.TCP, 0)
+--   socket:connect(port, ip)
+--   local net_send = dofile("net_send_queue.lua")(socket)
+--   net_send(payload1)
+--   net_send(payload2)
+--   net_send(payload3)
+--
+------------------------------------------------------------------------------
+do
+  -- cache
+  local shift = table.remove
+  -- queue handler
+  local make_sender = function(socket)
+    local queue = { }
+    local is_sending = false
+    local function send()
+      if #queue > 0 then
+        local item = shift(queue, 1)
+        socket:send(item, send)
+      else
+        is_sending = false
+      end
+    end
+    return function(...)
+      queue[#queue + 1] = ...
+      if not is_sending then
+        is_sending = true
+        send()
+      end
+    end
+  end
+  -- expose
+  return make_sender
+end


### PR DESCRIPTION
This is a follow-up to #1190 and #993 to add a send queueing handler to the examples collection.
It's based on [Vladimir Dronnikov's MQTT queuing publish helper](https://github.com/dvv/nodemcu-thingies/blob/master/mqtt-queue-helper.lua) from where it borrows most of the nifty Lua stuff.

Queueing up items appears to work within the application's memory constraints. Most importantly, there's no way for the application to determine whether sending finished and how big the queue actually grew at a given point.