### PR TITLE
Minimal changes to handle bad bodies in HTTP

### DIFF
--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -18,6 +18,7 @@
 #include "mem.h"
 #include "limits.h"
 #include "httpclient.h"
+#include "stdlib.h"
 
 /* Internal state. */
 typedef struct request_args_t {
@@ -80,110 +81,6 @@ esp_isdigit( char c )
 }
 
 
-/*
- * Convert a string to a long integer.
- *
- * Ignores `locale' stuff.  Assumes that the upper and lower case
- * alphabets and digits are each contiguous.
- */
-long ICACHE_FLASH_ATTR
-esp_strtol( nptr, endptr, base )
-const char *nptr;
-
-
-char	**endptr;
-int	base;
-{
-	const char	*s = nptr;
-	unsigned long	acc;
-	int		c;
-	unsigned long	cutoff;
-	int		neg = 0, any, cutlim;
-
-
-	/*
-	 * Skip white space and pick up leading +/- sign if any.
-	 * If base is 0, allow 0x for hex and 0 for octal, else
-	 * assume decimal; if base is already 16, allow 0x.
-	 */
-	do
-	{
-		c = *s++;
-	}
-	while ( esp_isspace( c ) );
-	if ( c == '-' )
-	{
-		neg	= 1;
-		c	= *s++;
-	} else if ( c == '+' )
-		c = *s++;
-	if ( (base == 0 || base == 16) &&
-	     c == '0' && (*s == 'x' || *s == 'X') )
-	{
-		c	= s[1];
-		s	+= 2;
-		base	= 16;
-	} else if ( (base == 0 || base == 2) &&
-		    c == '0' && (*s == 'b' || *s == 'B') )
-	{
-		c	= s[1];
-		s	+= 2;
-		base	= 2;
-	}
-	if ( base == 0 )
-		base = c == '0' ? 8 : 10;
-
-
-	/*
-	 * Compute the cutoff value between legal numbers and illegal
-	 * numbers.  That is the largest legal value, divided by the
-	 * base.  An input number that is greater than this value, if
-	 * followed by a legal input character, is too big.  One that
-	 * is equal to this value may be valid or not; the limit
-	 * between valid and invalid numbers is then based on the last
-	 * digit.  For instance, if the range for longs is
-	 * [-2147483648..2147483647] and the input base is 10,
-	 * cutoff will be set to 214748364 and cutlim to either
-	 * 7 (neg==0) or 8 (neg==1), meaning that if we have accumulated
-	 * a value > 214748364, or equal but the next digit is > 7 (or 8),
-	 * the number is too big, and we will return a range error.
-	 *
-	 * Set any if any `digits' consumed; make it negative to indicate
-	 * overflow.
-	 */
-	cutoff	= neg ? -(unsigned long) LONG_MIN : LONG_MAX;
-	cutlim	= cutoff % (unsigned long) base;
-	cutoff	/= (unsigned long) base;
-	for ( acc = 0, any = 0;; c = *s++ )
-	{
-		if ( esp_isdigit( c ) )
-			c -= '0';
-		else if ( esp_isalpha( c ) )
-			c -= esp_isupper( c ) ? 'A' - 10 : 'a' - 10;
-		else
-			break;
-		if ( c >= base )
-			break;
-		if ( any < 0 || acc > cutoff || acc == cutoff && c > cutlim )
-			any = -1;
-		else 
-		{
-			any	= 1;
-			acc	*= base;
-			acc	+= c;
-		}
-	}
-	if ( any < 0 )
-	{
-		acc = neg ? LONG_MIN : LONG_MAX;
-/*		errno = ERANGE; */
-	} else if ( neg )
-		acc = -acc;
-	if ( endptr != 0 )
-		*endptr = (char *) (any ? s - 1 : nptr);
-	return(acc);
-}
-
 static int ICACHE_FLASH_ATTR http_chunked_decode( const char * chunked, char * decode )
 {
 	int	i		= 0, j = 0;
@@ -191,9 +88,9 @@ static int ICACHE_FLASH_ATTR http_chunked_decode( const char * chunked, char * d
 	char	*str		= (char *) chunked;
 	do
 	{
-		char * endstr = NULL;
+		char * endstr;
 		/* [chunk-size] */
-		i = esp_strtol( str + j, endstr, 16 );
+		i = strtoul( str + j, NULL, 16 );
 		HTTPCLIENT_DEBUG( "Chunk Size:%d\r\n", i );
 		if ( i <= 0 )
 			break;
@@ -349,7 +246,7 @@ static void ICACHE_FLASH_ATTR http_disconnect_callback( void * arg )
 
 		if ( req->buffer == NULL )
 		{
-			HTTPCLIENT_DEBUG( "Buffer shouldn't be NULL\n" );
+			HTTPCLIENT_DEBUG( "Buffer probably shouldn't be NULL\n" );
 		}
 		else if ( req->buffer[0] != '\0' )
 		{
@@ -364,7 +261,18 @@ static void ICACHE_FLASH_ATTR http_disconnect_callback( void * arg )
 			else  
 			{
 				http_status	= atoi( req->buffer + strlen( version_1_0 ) );
-				body		= (char *) os_strstr( req->buffer, "\r\n\r\n" ) + 4;
+			        body            = (char *) os_strstr(req->buffer, "\r\n\r\n");
+
+				if (NULL == body) {
+					  /* Find missing body */
+					  HTTPCLIENT_DEBUG("Body shouldn't be NULL\n");
+					  /* To avoid NULL body */
+					  body = "";
+				} else {                                        
+					  /* Skip CR & LF */
+					  body = body + 4;
+				}
+								   
 				if ( os_strstr( req->buffer, "Transfer-Encoding: chunked" ) )
 				{
 					int	body_size = req->buffer_size - (body - req->buffer);
@@ -380,7 +288,9 @@ static void ICACHE_FLASH_ATTR http_disconnect_callback( void * arg )
 		{
 			req->callback_handle( body, http_status, req->buffer );
 		}
-		os_free( req->buffer );
+		if (req->buffer) {
+		  os_free( req->buffer );
+		}
 		os_free( req->hostname );
 		os_free( req->method );
 		os_free( req->path );


### PR DESCRIPTION
This is a simpler version of the vowstar fix to certain crashes due to invalid HTTP responses.

I removed the custom version of strtol that was in the httpclient.c file and we are now using the standard one (that was already being used by the lua code). Also fixed the saving of the lua_State pointer.