### PR TITLE
Autobaudrate detection by default -- to reduce problems with speed change

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ editing `BIT_RATE_DEFAULT` in `app/include/user_config.h`:
 #define BIT_RATE_DEFAULT BIT_RATE_115200
 ```
 
+Note that, by default, the firmware runs an auto-baudrate detection algorithm so that typing a few characters at boot time will cause
+the firmware to lock onto that baud rate (between 1200 and 230400). 
+
 ### Debugging
 
 To enable runtime debug messages to serial console edit `app/include/user_config.h`

--- a/app/driver/uart.c
+++ b/app/driver/uart.c
@@ -298,6 +298,12 @@ uart_init_autobaud(uint32_t uart_no)
   os_timer_arm(&autobaud_timer, 100, TRUE);
 }
 
+static void 
+uart_stop_autobaud()
+{
+  os_timer_disarm(&autobaud_timer);
+}
+
 /******************************************************************************
  * FunctionName : uart_init
  * Description  : user interface for init uart
@@ -326,6 +332,9 @@ uart_init(UartBautRate uart0_br, UartBautRate uart1_br, os_signal_t sig_input)
 void ICACHE_FLASH_ATTR
 uart_setup(uint8 uart_no)
 {
+#ifdef BIT_RATE_AUTOBAUD
+    uart_stop_autobaud();
+#endif
     ETS_UART_INTR_DISABLE();
     uart_config(uart_no);
     ETS_UART_INTR_ENABLE();

--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -34,10 +34,12 @@ extern void luaL_assertfail(const char *file, int line, const char *message);
 #ifdef DEVELOP_VERSION
 #define NODE_DEBUG
 #define COAP_DEBUG
-#else
-#define BIT_RATE_DEFAULT BIT_RATE_115200
 #endif /* DEVELOP_VERSION */
 
+#define BIT_RATE_DEFAULT BIT_RATE_115200
+
+// This enables automatic baud rate detection at startup
+#define BIT_RATE_AUTOBAUD
 
 #define NODE_ERROR
 

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -5,6 +5,8 @@
 
 The [UART](https://en.wikipedia.org/wiki/Universal_asynchronous_receiver/transmitter) (Universal asynchronous receiver/transmitter) module allows configuration of and communication over the UART serial port.
 
+The default setup for the uart is controlled by build-time settings. The default rate is 115,200 bps. In addition, auto-baudrate detection is enabled for the first two minutes
+after platform boot. This will cause a switch to the correct baud rate once a few characters are received. Auto-baudrate detection is disabled when `uart.setup` is called.
 ## uart.alt()
 Change UART pin assignment.
 

--- a/sdk-overrides/include/osapi.h
+++ b/sdk-overrides/include/osapi.h
@@ -8,6 +8,8 @@ int atoi(const char *nptr);
 int os_printf(const char *format, ...) __attribute__ ((format (printf, 1, 2)));
 int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
 
+unsigned int uart_baudrate_detect(unsigned int uart_no, unsigned int async);
+
 void NmiTimSetFunc(void (*func)(void));
 
 #include_next "osapi.h"


### PR DESCRIPTION
It turns out that doing auto baud rate detection at startup is pretty simple. I added this under a compile time option (but defaulting it to on).

This means that if you bring up the firmware and attach a terminal at the wrong speed, and enter a few characters, it will switch to that speed. It only does this once per boot (and if it hasn't seen any input for two minutes, then it gives up anyway).

If you connect your terminal at 115200, then there is no visible change. However, if you think that the platform runs at 9600, then you can send it a few characters and it will start responding at 9600.

My feeling is that, once we merge the 115200 dev branch to master, then a lot of people will start to complain that the new version doesn't work. Also, it isn't clear how many vendors ship the nodemcu firmware and whether people expect it to be running at 9600. I think that is a plausible approach to keep most people happy.

The only thing that I couldn't decide was whether an explicit set of the baud rate (after the initial setting) would shut off the autobaud detection. Maybe it should.