### PR TITLE
Net docs, 2nd round

### DIFF
--- a/docs/en/modules/net.md
+++ b/docs/en/modules/net.md
@@ -110,6 +110,20 @@ end)
 #### See also
 [`net.createServer()`](#netcreateserver)
 
+## net.server:on()
+
+UDP server only: Register callback functions for specific events.
+
+#### See also
+[`net.socket:on()`](#netsocketon)
+
+## net.server:send()
+
+UDP server only: Sends data to remote peer.
+
+#### See also
+[`net.socket:send()`](#netsocketsend)
+
 # net.socket Module
 ## net.socket:close()
 
@@ -168,6 +182,20 @@ sk = nil
 #### See also
 [`net.createServer()`](#netcreateserver)
 
+## net.socket:getpeer()
+
+Retrieve port and ip of peer.
+
+#### Syntax
+`getpeer()`
+
+#### Parameters
+none
+
+#### Returns
+- `ip` of peer
+- `port` of peer
+
 ## net.socket:hold()
 
 Throttle data reception by placing a request to block the TCP receive function. This request is not effective immediately, Espressif recommends to call it while reserving 5*1460 bytes of memory.
@@ -215,7 +243,7 @@ end)
 
 ## net.socket:send()
 
-Sends data to server.
+Sends data to remote peer.
 
 #### Syntax
 `send(string[, function(sent)])`
@@ -282,7 +310,7 @@ end)
 
 ## net.socket:unhold()
 
-Unblock TCP receiving data, i.e. undo `hold()`.
+Unblock TCP receiving data by revocation of a preceding `hold()`.
 
 #### Syntax
 `unhold()`

--- a/docs/en/modules/net.md
+++ b/docs/en/modules/net.md
@@ -53,6 +53,34 @@ net.createServer(net.TCP, 30) -- 30s timeout
 #### See also
 [`net.createConnection()`](#netcreateconnection)
 
+## net.multicastJoin()
+
+Join multicast group.
+
+#### Syntax
+`net.multicastJoin(if_ip, multicast_ip)`
+
+#### Parameters
+- `if_ip` string containing the interface ip to join the multicast group. "any" or "" affects all interfaces.
+- `multicast_ip` of the group to join
+
+#### Returns
+`nil`
+
+## net.multicastLeave()
+
+Leave multicast group.
+
+#### Syntax
+`net.multicastLeave(if_ip, multicast_ip)`
+
+#### Parameters
+- `if_ip` string containing the interface ip to leave the multicast group. "any" or "" affects all interfaces.
+- `multicast_ip` of the group to leave
+
+#### Returns
+`nil`
+
 # net.server Module
 
 ## net.server:close()


### PR DESCRIPTION
My previous PR just added the docs I was missing at that time. Had a review of all net functions and found some more to be undoc'ed:
- `net.socket:getpeer()`
- `net.multicastJoin()` and `net.multicastLeave()` added by #361 
- for UDP server only: `net.server:on()` and `net.server:send()`

I didn't consider `net.cert.auth()` since it's still WIP as far as I understood from https://github.com/nodemcu/nodemcu-firmware/pull/1125/files#r55519170.