### PR TITLE
Add notes on user_override.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,8 @@ CCFLAGS += 			\
 	-mtext-section-literals
 #	-Wall			
 
-ifneq ($(wildcard $(TOP_DIR)/user_config.h),)
-INCLUDES += -include "$(TOP_DIR)/user_config.h"
+ifneq ($(wildcard $(TOP_DIR)/user_override.h),)
+INCLUDES += -include "$(TOP_DIR)/user_override.h"
 endif
 
 CFLAGS = $(CCFLAGS) $(DEFINES) $(EXTRA_CCFLAGS) $(STD_CFLAGS) $(INCLUDES)

--- a/app/include/u8g_config.h
+++ b/app/include/u8g_config.h
@@ -6,8 +6,14 @@
 // Configure U8glib fonts
 //
 // Add a U8G_FONT_TABLE_ENTRY for each font you want to compile into the image
+// or just define U8G_FONT_TABLE_EXTRA as U8G_FONT_TABLE_ENTRY(font_helvB24)
+
+#ifndef U8G_FONT_TABLE_EXTRA
+#define U8G_FONT_TABLE_EXTRA
+#endif
+
 #define U8G_FONT_TABLE_ENTRY(font)
-#define U8G_FONT_TABLE                          \
+#define U8G_FONT_TABLE    U8G_FONT_TABLE_EXTRA  \
     U8G_FONT_TABLE_ENTRY(font_6x10)             \
     U8G_FONT_TABLE_ENTRY(font_chikita)
 #undef U8G_FONT_TABLE_ENTRY

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -15,10 +15,10 @@ NodeMCU firmware developers commit or contribute to the project on GitHub and mi
 
 ## Customizing the build
 
-There is an optional file `user_config.h` that can be placed at the root of the build tree. If this file is present then it
+There is an optional file `user_override.h` that can be placed at the root of the build tree. If this file is present then it
 will be included into the compile of every file. This allows you to customize the build without altering any of the
 files that are part of the firmware. Note that this file is included *in addtion to* all the existing files so it 
-will typically be short. This file does not replace the `app/include/user_config.h`.
+will typically be short. 
 
 In order to include extra fonts into the build, just add a #define:
 

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -12,3 +12,35 @@ Occasional NodeMCU firmware hackers don't need full control over the complete to
 
 ## Linux Build Environment
 NodeMCU firmware developers commit or contribute to the project on GitHub and might want to build their own full fledged build environment with the complete tool chain. There is a [post in the esp8266.com Wiki](http://www.esp8266.com/wiki/doku.php?id=toolchain#how_to_setup_a_vm_to_host_your_toolchain) that describes this.
+
+## Customizing the build
+
+There is an optional file `user_config.h` that can be placed at the root of the build tree. If this file is present then it
+will be included into the compile of every file. This allows you to customize the build without altering any of the
+files that are part of the firmware.
+
+In order to include extra fonts into the build, just add a #define:
+
+```
+#define U8G_FONT_TABLE_EXTRA U8G_FONT_TABLE_ENTRY(font_helvB24)
+```
+
+or
+
+```
+#define U8G_FONT_TABLE_EXTRA U8G_FONT_TABLE_ENTRY(font_helvB24) U8G_FONT_TABLE_ENTRY(font_helvR12)
+```
+
+In order to enable asserts:
+
+```
+#define DEVELOPMENT_TOOLS
+```
+
+In order to add a module into the build:
+
+```
+#define LUA_USE_MODULES_ENDUSER_SETUP
+````
+
+In this way, you can have your custom configuration which will work across multiple versions/branches of the firmware.

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -17,7 +17,8 @@ NodeMCU firmware developers commit or contribute to the project on GitHub and mi
 
 There is an optional file `user_config.h` that can be placed at the root of the build tree. If this file is present then it
 will be included into the compile of every file. This allows you to customize the build without altering any of the
-files that are part of the firmware.
+files that are part of the firmware. Note that this file is included *in addtion to* all the existing files so it 
+will typically be short. This file does not replace the `app/include/user_config.h`.
 
 In order to include extra fonts into the build, just add a #define:
 
@@ -44,3 +45,21 @@ In order to add a module into the build:
 ````
 
 In this way, you can have your custom configuration which will work across multiple versions/branches of the firmware.
+
+For a project to control humidity in a carnivorous plant terrarium, you might have:
+
+```
+#define LUA_USE_MODULES_MDNS
+#define LUA_USE_MODULES_MQTT
+#define LUA_USE_MODULES_DHT
+#define LUA_USE_MODULES_RTCTIME
+#define LUA_USE_MODULES_RTCMEM
+#define LUA_USE_MODULES_SNTP
+#define LUA_USE_MODULES_ENDUSER_SETUP
+
+#define U8G_FONT_TABLE_EXTRA    U8G_FONT_TABLE_ENTRY(font_helvB24)
+#define LUA_USE_MODULES_U8G
+#define LUA_USE_MODULES_UCG
+
+#define DEVELOPMENT_TOOLS
+```


### PR DESCRIPTION
This small PR does two things:

* Adds a note describing how to use the user_override.h that can be placed in the root of the build tree

* Adds support for being able to add fonts to the build by editing the user_override.h file.

If you wonder where the user_override.h stuff came from, then it appears that it got committed/merged as part of another PR that I submitted some time ago. It was the mechanism that I use to maintain my set of modules as I switch between branches. [It was originally called user_config.h, but I renamed it in this PR to over_override.h]