### PR TITLE
SNTP module enhancements

### DIFF
--- a/app/modules/sntp.c
+++ b/app/modules/sntp.c
@@ -341,8 +341,8 @@ static int sntp_sync (lua_State *L)
   if (!state->pcb)
     sync_err ("out of memory");
 
-  if (udp_bind (state->pcb, IP_ADDR_ANY, NTP_PORT) != ERR_OK)
-    sync_err ("ntp port in use");
+  if (udp_bind (state->pcb, IP_ADDR_ANY, 0) != ERR_OK)
+    sync_err ("no port available");
 
   udp_recv (state->pcb, on_recv, L);
 

--- a/docs/en/modules/sntp.md
+++ b/docs/en/modules/sntp.md
@@ -18,7 +18,11 @@ Attempts to obtain time synchronization.
 #### Parameters
 - `server_ip` if non-`nil`, that server is used. If `nil`, then the last contacted server is used. This ties in with the NTP anycast mode, where the first responding server is remembered for future synchronization requests. The easiest way to use anycast is to always pass nil for the server argument.
 - `callback` Iif provided it will be invoked on a successful synchronization, with three parameters: seconds, microseconds, and server. Note that when the [rtctime](rtctime.md) module is available, there is no need to explicitly call [`rtctime.set()`](rtctime.md#rtctimeset) - this module takes care of doing so internally automatically, for best accuracy.
-- `errcallback` failure callback with no parameters. The module automatically performs a number of retries before giving up and reporting the error.
+- `errcallback` failure callback with a single integer parameter describing the type of error. The module automatically performs a number of retries before giving up and reporting the error. Error codes:
+  - 1: DNS lookup failed
+  - 2: Memory allocation failure
+  - 3: UDP send failed
+  - 4: Timeout, no NTP response received
 
 #### Returns
 `nil`


### PR DESCRIPTION
Two small but important enhancements included here:

- Improved diagnostics by way of error code now passed to the error handler function
- Switch to use an ephemeral source port for NTP requests.

The necessity of the latter we discovered through the use of the former. It appears that some ISPs, in their finite wisdom, block all NTP-port traffic to their customers presumably as a misguided attempt at limiting DDoS attempts. So even though NTP is meant to run 53<->53, and it's only a subtype 7(?) control packet which has any chance of causing amplification, these ISPs block it all if it's destined to port 53 on the customer's end. Switching to an ephemeral source port resolved the problem in both our encountered cases.