### PR TITLE
Add caching for multi-byte transfers

### DIFF
--- a/app/modules/ucg.c
+++ b/app/modules/ucg.c
@@ -703,6 +703,23 @@ static int lucg_undoScale( lua_State *L )
 }
 
 
+spi_data_type cache;
+uint8_t cached;
+
+#define CACHED_TRANSFER(dat, num) cache = cached = 0;  \
+    while( arg > 0 ) {                                \
+        if (cached == 4) {                                              \
+            platform_spi_transaction( 1, 0, 0, 32, cache, 0, 0, 0 );    \
+            cache = cached = 0;                                         \
+        }                                                               \
+        cache = (cache << num*8) | dat;                                 \
+        cached += num;                                                  \
+        arg--;                                                          \
+    }                                                                   \
+    if (cached > 0) {                                                   \
+        platform_spi_transaction( 1, 0, 0, cached * 8, cache, 0, 0, 0 ); \
+    }
+
 
 static int16_t ucg_com_esp8266_hw_spi(ucg_t *ucg, int16_t msg, uint16_t arg, uint8_t *data)
 {
@@ -754,67 +771,22 @@ static int16_t ucg_com_esp8266_hw_spi(ucg_t *ucg, int16_t msg, uint16_t arg, uin
         break;
 
     case UCG_COM_MSG_REPEAT_1_BYTE:
-        {
-        spi_data_type cache = 0;
-        uint8_t cached = 0;
-        while( arg > 0 ) {
-            if (cached == 4) {
-                platform_spi_transaction( 1, 0, 0, 32, cache, 0, 0, 0 );
-                cache = cached = 0;
-            }
-            cache = (cache << 8) | data[0];
-            cached++;
-            arg--;
-        }
-        if (cached > 0) {
-            platform_spi_transaction( 1, 0, 0, cached * 8, cache, 0, 0, 0 );
-        }
-        }
+        CACHED_TRANSFER(data[0], 1);
         break;
 
     case UCG_COM_MSG_REPEAT_2_BYTES:
-        {
-        spi_data_type cache = 0;
-        uint8_t cached = 0;
-        while( arg > 0 ) {
-            if (cached == 4) {
-                platform_spi_transaction( 1, 0, 0, 32, cache, 0, 0, 0 );
-                cache = cached = 0;
-            }
-            cache = (cache << 16) | (data[0] << 8) | data[1];
-            cached += 2;
-            arg--;
-        }
-        if (cached > 0) {
-            platform_spi_transaction( 1, 0, 0, cached * 8, cache, 0, 0, 0 );
-        }
-        }
+        CACHED_TRANSFER((data[0] << 8) | data[1], 2);
         break;
 
     case UCG_COM_MSG_REPEAT_3_BYTES:
         while( arg > 0 ) {
-            platform_spi_transaction( 1, 0, 0, 24, (data[0] << 16) | (data[1] << 8) | data[0], 0, 0, 0 );
+            platform_spi_transaction( 1, 0, 0, 24, (data[0] << 16) | (data[1] << 8) | data[2], 0, 0, 0 );
             arg--;
         }
         break;
 
     case UCG_COM_MSG_SEND_STR:
-        {
-        spi_data_type cache = 0;
-        uint8_t cached = 0;
-        while( arg > 0 ) {
-            if (cached == 4) {
-                platform_spi_transaction( 1, 0, 0, 32, cache, 0, 0, 0 );
-                cache = cached = 0;
-            }
-            cache = (cache << 8) | *data++;
-            cached++;
-            arg--;
-        }
-        if (cached > 0) {
-            platform_spi_transaction( 1, 0, 0, cached * 8, cache, 0, 0, 0 );
-        }
-        }
+        CACHED_TRANSFER(*data++, 1);
         break;
 
     case UCG_COM_MSG_SEND_CD_DATA_SEQUENCE:

--- a/app/modules/ucg.c
+++ b/app/modules/ucg.c
@@ -754,33 +754,66 @@ static int16_t ucg_com_esp8266_hw_spi(ucg_t *ucg, int16_t msg, uint16_t arg, uin
         break;
 
     case UCG_COM_MSG_REPEAT_1_BYTE:
+        {
+        spi_data_type cache = 0;
+        uint8_t cached = 0;
         while( arg > 0 ) {
-            platform_spi_send( 1, 8, data[0] );
+            if (cached == 4) {
+                platform_spi_transaction( 1, 0, 0, 32, cache, 0, 0, 0 );
+                cache = cached = 0;
+            }
+            cache = (cache << 8) | data[0];
+            cached++;
             arg--;
+        }
+        if (cached > 0) {
+            platform_spi_transaction( 1, 0, 0, cached * 8, cache, 0, 0, 0 );
+        }
         }
         break;
 
     case UCG_COM_MSG_REPEAT_2_BYTES:
+        {
+        spi_data_type cache = 0;
+        uint8_t cached = 0;
         while( arg > 0 ) {
-            platform_spi_send( 1, 8, data[0] );
-            platform_spi_send( 1, 8, data[1] );
+            if (cached == 4) {
+                platform_spi_transaction( 1, 0, 0, 32, cache, 0, 0, 0 );
+                cache = cached = 0;
+            }
+            cache = (cache << 16) | (data[0] << 8) | data[1];
+            cached += 2;
             arg--;
+        }
+        if (cached > 0) {
+            platform_spi_transaction( 1, 0, 0, cached * 8, cache, 0, 0, 0 );
+        }
         }
         break;
 
     case UCG_COM_MSG_REPEAT_3_BYTES:
         while( arg > 0 ) {
-            platform_spi_send( 1, 8, data[0] );
-            platform_spi_send( 1, 8, data[1] );
-            platform_spi_send( 1, 8, data[2] );
+            platform_spi_transaction( 1, 0, 0, 24, (data[0] << 16) | (data[1] << 8) | data[0], 0, 0, 0 );
             arg--;
         }
         break;
 
     case UCG_COM_MSG_SEND_STR:
+        {
+        spi_data_type cache = 0;
+        uint8_t cached = 0;
         while( arg > 0 ) {
-            platform_spi_send( 1, 8, *data++ );
+            if (cached == 4) {
+                platform_spi_transaction( 1, 0, 0, 32, cache, 0, 0, 0 );
+                cache = cached = 0;
+            }
+            cache = (cache << 8) | *data++;
+            cached++;
             arg--;
+        }
+        if (cached > 0) {
+            platform_spi_transaction( 1, 0, 0, cached * 8, cache, 0, 0, 0 );
+        }
         }
         break;
 

--- a/lua_examples/ucglib/GraphicsTest.lua
+++ b/lua_examples/ucglib/GraphicsTest.lua
@@ -3,12 +3,15 @@ function init_spi_display()
     -- Hardware SPI CLK  = GPIO14
     -- Hardware SPI MOSI = GPIO13
     -- Hardware SPI MISO = GPIO12 (not used)
+    -- Hardware SPI /CS  = GPIO15 (not used)
     -- CS, D/C, and RES can be assigned freely to available GPIOs
     local cs  = 8 -- GPIO15, pull-down 10k to GND
     local dc  = 4 -- GPIO2
     local res = 0 -- GPIO16
 
     spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, 8, 8)
+    -- we won't be using the HSPI /CS line, so disable it again
+    gpio.mode(8, gpio.INPUT, gpio.PULLUP)
 
     -- initialize the matching driver for your display
     -- see app/include/ucg_config.h

--- a/lua_examples/ucglib/HelloWorld.lua
+++ b/lua_examples/ucglib/HelloWorld.lua
@@ -3,13 +3,20 @@ function init_spi_display()
    -- Hardware SPI CLK  = GPIO14
    -- Hardware SPI MOSI = GPIO13
    -- Hardware SPI MISO = GPIO12 (not used)
+   -- Hardware SPI /CS  = GPIO15 (not used)
    -- CS, D/C, and RES can be assigned freely to available GPIOs
    local cs  = 8 -- GPIO15, pull-down 10k to GND
    local dc  = 4 -- GPIO2
    local res = 0 -- GPIO16
 
    spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, 8, 8)
-   disp = ucg.ili9341_18x240x320_hw_spi(cs, dc, res)
+   -- we won't be using the HSPI /CS line, so disable it again
+   gpio.mode(8, gpio.INPUT, gpio.PULLUP)
+
+   -- initialize the matching driver for your display
+   -- see app/include/ucg_config.h
+   --disp = ucg.ili9341_18x240x320_hw_spi(cs, dc, res)
+   disp = ucg.st7735_18x128x160_hw_spi(cs, dc, res)
 end
 
 

--- a/lua_examples/ucglib/UcgLogo.lua
+++ b/lua_examples/ucglib/UcgLogo.lua
@@ -3,12 +3,19 @@ function init_spi_display()
     -- Hardware SPI CLK  = GPIO14
     -- Hardware SPI MOSI = GPIO13
     -- Hardware SPI MISO = GPIO12 (not used)
+    -- Hardware SPI /CS  = GPIO15 (not used)
     -- CS, D/C, and RES can be assigned freely to available GPIOs
     local cs  = 8 -- GPIO15, pull-down 10k to GND
     local dc  = 4 -- GPIO2
     local res = 0 -- GPIO16
 
     spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, 8, 8)
+    -- we won't be using the HSPI /CS line, so disable it again
+    gpio.mode(8, gpio.INPUT, gpio.PULLUP)
+
+    -- initialize the matching driver for your display
+    -- see app/include/ucg_config.h
+    --disp = ucg.ili9341_18x240x320_hw_spi(cs, dc, res)
     disp = ucg.st7735_18x128x160_hw_spi(cs, dc, res)
 end
 


### PR DESCRIPTION
And handle HSPI /CS in examples. Hardware /CS generation is not used and in case pin 8 / GPIO15 is not used for /CS, D/C, or /RES then this pin should be set back to default input.
