### PR TITLE
Ws2812

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -51,7 +51,9 @@ static void ICACHE_RAM_ATTR ws2812_write(uint8_t *pixels, uint32_t length) {
   // 0b00000111 => 000111 => [0]111000[1] => 10001110 => 01
   // 0b00110100 => 110100 => [0]001011[1] => 11101000 => 10
   // 0b00000100 => 000100 => [0]001000[1] => 11101110 => 11
-  uint8_t _uartData[4] = { 0b00110111, 0b00000111, 0b00110100, 0b00000100 };
+  // Array declared as static const to avoid runtime generation
+  // But declared in ".data" section to avoid read penalty from FLASH
+  static const __attribute__((section(".data._uartData"))) uint8_t _uartData[4] = { 0b00110111, 0b00000111, 0b00110100, 0b00000100 };
 
   uint8_t *end = pixels + length;
 

--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -80,19 +80,7 @@ static void ICACHE_RAM_ATTR ws2812_write(uint8_t *pixels, uint32_t length) {
 // ws2812.write(string.char(255, 0, 0, 255, 255, 255)) first LED green, second LED white.
 static int ICACHE_FLASH_ATTR ws2812_writegrb(lua_State* L) {
   size_t length;
-  const char *values;
-
-  // Buffer or string
-  if(lua_isuserdata(L, 1)) {
-    ws2812_buffer * buffer = (ws2812_buffer*)lua_touserdata(L, 2);
-
-    luaL_argcheck(L, buffer && buffer->canary == CANARY_VALUE, 2, "ws2812.buffer expected");
-
-    values = &buffer->values[0];
-    length = 3*buffer->size;
-  } else {
-    values = luaL_checklstring(L, 1, &length);
-  }
+  const char *values = luaL_checklstring(L, 1, &length);
 
   // Send the buffer
   ws2812_write((uint8_t*) values, length);

--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -18,7 +18,7 @@ typedef struct {
 
 // Init UART1 to be able to stream WS2812 data
 // We use GPIO2 as output pin
-static void ICACHE_FLASH_ATTR ws2812_init() {
+static void ws2812_init() {
   // Configure UART1
   // Set baudrate of UART1 to 3200000
   WRITE_PERI_REG(UART_CLKDIV(1), UART_CLK_FREQ / 3200000);
@@ -80,7 +80,7 @@ static void ICACHE_RAM_ATTR ws2812_write(uint8_t *pixels, uint32_t length) {
 // ws2812.write(string.char(0, 255, 0)) sets the first LED red.
 // ws2812.write(string.char(0, 0, 255):rep(10)) sets ten LEDs blue.
 // ws2812.write(string.char(255, 0, 0, 255, 255, 255)) first LED green, second LED white.
-static int ICACHE_FLASH_ATTR ws2812_writegrb(lua_State* L) {
+static int ws2812_writegrb(lua_State* L) {
   size_t length;
   const char *values = luaL_checklstring(L, 1, &length);
 
@@ -91,7 +91,7 @@ static int ICACHE_FLASH_ATTR ws2812_writegrb(lua_State* L) {
 }
 
 // Handle a buffer where we can store led values
-static int ICACHE_FLASH_ATTR ws2812_new_buffer(lua_State *L) {
+static int ws2812_new_buffer(lua_State *L) {
   const int leds = luaL_checkint(L, 1);
   const int colorsPerLed = luaL_checkint(L, 2);
 
@@ -116,7 +116,7 @@ static int ICACHE_FLASH_ATTR ws2812_new_buffer(lua_State *L) {
   return 1;
 }
 
-static int ICACHE_FLASH_ATTR ws2812_buffer_fill(lua_State* L) {
+static int ws2812_buffer_fill(lua_State* L) {
   ws2812_buffer * buffer = (ws2812_buffer*)lua_touserdata(L, 1);
 
   luaL_argcheck(L, buffer && buffer->canary == CANARY_VALUE, 1, "ws2812.buffer expected");
@@ -146,7 +146,7 @@ static int ICACHE_FLASH_ATTR ws2812_buffer_fill(lua_State* L) {
   return 0;
 }
 
-static int ICACHE_FLASH_ATTR ws2812_buffer_fade(lua_State* L) {
+static int ws2812_buffer_fade(lua_State* L) {
   ws2812_buffer * buffer = (ws2812_buffer*)lua_touserdata(L, 1);
   const int fade = luaL_checkinteger(L, 2);
 
@@ -163,7 +163,7 @@ static int ICACHE_FLASH_ATTR ws2812_buffer_fade(lua_State* L) {
   return 0;
 }
 
-static int ICACHE_FLASH_ATTR ws2812_buffer_get(lua_State* L) {
+static int ws2812_buffer_get(lua_State* L) {
   ws2812_buffer * buffer = (ws2812_buffer*)lua_touserdata(L, 1);
   const int led = luaL_checkinteger(L, 2) - 1;
 
@@ -179,7 +179,7 @@ static int ICACHE_FLASH_ATTR ws2812_buffer_get(lua_State* L) {
   return buffer->colorsPerLed;
 }
 
-static int ICACHE_FLASH_ATTR ws2812_buffer_set(lua_State* L) {
+static int ws2812_buffer_set(lua_State* L) {
   ws2812_buffer * buffer = (ws2812_buffer*)lua_touserdata(L, 1);
   const int led = luaL_checkinteger(L, 2) - 1;
 
@@ -227,7 +227,7 @@ static int ICACHE_FLASH_ATTR ws2812_buffer_set(lua_State* L) {
   return 0;
 }
 
-static int ICACHE_FLASH_ATTR ws2812_buffer_size(lua_State* L) {
+static int ws2812_buffer_size(lua_State* L) {
   ws2812_buffer * buffer = (ws2812_buffer*)lua_touserdata(L, 1);
 
   luaL_argcheck(L, buffer && buffer->canary == CANARY_VALUE, 1, "ws2812.buffer expected");
@@ -237,7 +237,7 @@ static int ICACHE_FLASH_ATTR ws2812_buffer_size(lua_State* L) {
   return 1;
 }
 
-static int ICACHE_FLASH_ATTR ws2812_buffer_write(lua_State* L) {
+static int ws2812_buffer_write(lua_State* L) {
   ws2812_buffer * buffer = (ws2812_buffer*)lua_touserdata(L, 1);
 
   luaL_argcheck(L, buffer && buffer->canary == CANARY_VALUE, 1, "ws2812.buffer expected");

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -1,57 +1,164 @@
 # WS2812 Module
 | Since  | Origin / Contributor  | Maintainer  | Source  |
 | :----- | :-------------------- | :---------- | :------ |
-| 2015-02-05 | [Till Klocke](https://github.com/dereulenspiegel) | [Till Klocke](https://github.com/dereulenspiegel) | [ws2812.c](../../../app/modules/ws2812.c)|
+| 2015-02-05 | [Till Klocke](https://github.com/dereulenspiegel), [Thomas Soëte](https://github.com/Alkorin) | [Till Klocke](https://github.com/dereulenspiegel) | [ws2812.c](../../../app/modules/ws2812.c)|
 
+ws2812 is a library to handle ws2812-like led strips.
+It works at least on WS2812, WS2812b, APA104, SK6812 (RGB or RGBW).
 
-## ws2812.write()
-Send GRB data in 8 bits to a WS2812 chain.
+The library uses UART1 routed on GPIO2 (Pin D4 on NodeMCU DEVKIT) to
+generate the bitstream.
 
-#### Syntax
-`ws2812.writegrb(pin, string)`
+## ws2812.init()
+Initialize UART1 and GPIO2, should be called once and before write()
 
 #### Parameters
-- `pin` is ignored. Only works with GPIO2.
-- `string` payload to be sent to one or more WS2812 LEDs.
-  It should be composed from a GRB triplet per element.
-    - `G1` the first pixel's Green channel (0-255)
-    - `R1` the first pixel's Red channel (0-255)
-    - `B1` the first pixel's Blue channel (0-255)<br />
-    ... You can connect a lot of WS2812 ...
-    - `G2`, `R2`, `B2` are the next WS2812's Green, Red, and Blue channel parameters
+none
 
 #### Returns
 `nil`
 
-```lua
-g = 0
-r = 255
-b = 0
-leds_grb = string.char(g,r,b, g,r,b) 
-ws2812.write(2, leds_grb) -- turn two WS2812Bs to red, connected to pin GPIO2
-```
-
-## ws2812.writergb()
-Send GRB data in 8bits to a WS2812 chain.
+## ws2812.write()
+Send data to a led strip using its native format which is generally Green,Red,Blue for RGB strips
+and Green,Red,Blue,White for RGBW strips.
 
 #### Syntax
-`ws2812.writergb(pin, string)`
+`ws2812.write(string)`
 
 #### Parameters
-- `pin` is ignored. Only works with GPIO2.
-- `string` payload to be sent to one or more WS2812 LEDs.
-  It should be composed from an RGB triplet per element.
-    - `R1` the first pixel's Red channel (0-255)
-    - `G1` the first pixel's Green channel (0-255)
-    - `B1` the first pixel's Blue channel (0-255)<br />
-    ... You can connect a lot of WS2812 ...
-    - `R2`, `G2`, `B2` are the next WS2812's Red, Green, and Blue channel parameters
+- `string` payload to be sent to one or more WS2812 like leds.
 
 #### Returns
 `nil`
 
 #### Example
 ```lua
-leds_rgb = string.char(255,0,0, 0,255,0, 0,0,255) 
-ws2812.writergb(2, leds_rgb) -- turn three WS2812Bs to red, green, and blue respectively
+ws2812.init()
+ws2812.write(string.char(255,0,0,255,0,0) -- turn the two first RGB leds to green
 ```
+
+```lua
+ws2812.init()
+ws2812.write(string.char(0,0,0,255,0,0,0,255) -- turn the two first RGBW leds to white
+```
+
+# Buffer module
+For more advanced animations, it is useful to keep a "framebuffer" of the strip,
+interact with it and flush it to the strip.
+
+For this purpose, the ws2812 library offers a read/write buffer.
+
+#### Example
+Led chaser with a RGBW strip
+```lua
+local i, b = 0, ws2812.newBuffer(300, 4); b:fill(0,0,0,0); tmr.alarm(0, 50, 1, function()
+        i=i+1
+        b:fade(2)
+        b:set(i%b:size()+1, 0, 0, 0, 255)
+        b:write()
+end)
+```
+
+## ws2812.newBuffer()
+Allocate a new memory buffer to store led values.
+
+#### Syntax
+`ws2812.newBuffer(numberOfLeds, bytesPerLed)`
+
+#### Parameters
+ - `numberOfLeds` length of the led strip
+ - `bytesPerLed` 3 for RGB strips and 4 for RGBW strips
+
+#### Returns
+`ws2812.buffer`
+
+## ws2812.buffer:get()
+Return the value at the given position
+
+#### Syntax
+`buffer:get(index)`
+
+#### Parameters
+ - `index` position in the buffer (1 for first led)
+
+#### Returns
+`(color)`
+
+#### Example
+```lua
+buffer:get(2) -- return the color of the second led
+```
+## ws2812.buffer:set()
+Set the value at the given position
+
+#### Syntax
+`buffer:set(index, color)`
+
+#### Parameters
+ - `index` position in the buffer (1 for the first led)
+ - `color` bytes of the color
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+buffer:set(1, 255, 0, 0) -- set the first led green for a RGB strip
+```
+## ws2812.buffer:size()
+Return the size of the buffer in number of leds
+
+#### Syntax
+`buffer:size()`
+
+#### Parameters
+none
+
+#### Returns
+`int`
+
+## ws2812.buffer:fill()
+Fill the buffer with the given color.
+The number of given bytes must match the number of bytesPerLed of the buffer
+
+#### Syntax
+`buffer:fill(color)`
+
+#### Parameters
+ - `color` bytes of the color
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+buffer:fill(0, 0, 0) -- fill the buffer with black for a RGB strip
+```
+## ws2812.buffer:fade()
+Divide each byte of each led by the given value. Useful for a fading effect
+
+#### Syntax
+`buffer:fade(value)`
+
+#### Parameters
+ - `value` value by which divide each byte
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+buffer:fade(2)
+```
+## ws2812.buffer:write()
+Output the buffer to the led strip
+
+#### Syntax
+`buffer:write()`
+
+#### Parameters
+none
+
+#### Returns
+`nil`
+


### PR DESCRIPTION
As promised but quite late sorry, the updated code with documentation.

Some improvements here: 
- Get rid of `ets_intr_lock`
- Add `ws2812.init()` to limit `ICACHE_RAM_ATTR` code
- Drop `ws2812.writergb`, it could be handled on LUA side (and then removed the naked malloc)
- Add support of RGBW strips