### PR TITLE
Enable spi clock_div < 4.

### DIFF
--- a/app/modules/spi.c
+++ b/app/modules/spi.c
@@ -39,8 +39,8 @@ static int spi_setup( lua_State *L )
     return luaL_error( L, "out of range" );
   }
 
-  if (clock_div < 4) {
-    // defaulting to 8
+  if (clock_div == 0) {
+    // defaulting to 8 for backward compatibility
     clock_div = 8;
   }
 

--- a/docs/en/modules/spi.md
+++ b/docs/en/modules/spi.md
@@ -97,9 +97,9 @@ Refer to [Serial Peripheral Interface Bus](https://en.wikipedia.org/wiki/Serial_
 	- `spi.CPHA_LOW`
 	- `spi.CPHA_HIGH`
 - `databits` number of bits per data item 1 - 32
-- `clock_div` SPI clock divider, f(SPI) = f(CPU) / `clock_div`
+- `clock_div` SPI clock divider, f(SPI) = 80 MHz / `clock_div`, 1 .. n (0 defaults to divider 8)
 - `duplex_mode` duplex mode
-	-  `spi.HALFDUPLEX` (default when omitted)
+	- `spi.HALFDUPLEX` (default when omitted)
 	- `spi.FULLDUPLEX`
 
 #### Returns


### PR DESCRIPTION
This PR adds the clock divider configuration scheme from SDK 1.5.3. Dividers down to 1 are now supported and #1244 should be resolved now.

I also had a look at Espressif's CPOL/CPHA handling, but that didn't reveal any further info. `SPI_CK_I_EDGE` is not referenced there and it's listed for slave mode in the [SPI register doc](http://bbs.espressif.com/download/file.php?id=623).