### PR TITLE
Ensure that load_store exceptions trigger the exception handler

### DIFF
--- a/app/user/user_exceptions.c
+++ b/app/user/user_exceptions.c
@@ -72,7 +72,8 @@ void load_non_32_wide_handler (struct exception_frame *ef, uint32_t cause)
   else
   {
 die:
-    /* Turns out we couldn't fix this, trigger a system break instead
+    /* Turns out we couldn't fix this, so try and chain to the handler
+     * that was set by the SDK. If none then trigger a system break instead
      * and hang if the break doesn't get handled. This is effectively
      * what would happen if the default handler was installed. */
     if (load_store_handler) {
@@ -107,7 +108,8 @@ die:
  * of whether there's a proper handler installed for EXCCAUSE_LOAD_STORE_ERROR,
  * which of course breaks everything if we allow that to go through. As such,
  * we use the linker to wrap that call and stop the SDK from shooting itself in
- * its proverbial foot.
+ * its proverbial foot. We do save the EXCCAUSE_LOAD_STORE_ERROR handler so that
+ * we can chain to it above.
  */
 exception_handler_fn TEXT_SECTION_ATTR
 __wrap__xtos_set_exception_handler (uint32_t cause, exception_handler_fn fn)


### PR DESCRIPTION
This fixes a problem where store instructions that reference the flash currently cause watchdog timeouts. This change makes them crash the system immediately and provides the correct data for node.bootreason().

The root cause was that nodemcu has its own load_store exception handler where certain exceptions can be fixed. The other exceptions ended up in a busy loop. 