### PR TITLE
[ws2812] Handle two strips in parallel using the two UARTs through GPIO2 and TXD0

### DIFF
--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -7,13 +7,22 @@ ws2812 is a library to handle ws2812-like led strips.
 It works at least on WS2812, WS2812b, APA104, SK6812 (RGB or RGBW).
 
 The library uses UART1 routed on GPIO2 (Pin D4 on NodeMCU DEVKIT) to
-generate the bitstream.
+generate the bitstream. It can uses UART0 routed to TXD0 as well to
+handle two led strips at the same time.
 
-## ws2812.init()
-Initialize UART1 and GPIO2, should be called once and before write()
+**WARNING**: In dual mode, you will loose access to the LUA's console
+through the serial port (it will be reconfigured to support WS2812-like 
+protocol). If you want to keep access to LUA's console, you will have to 
+use an other input channel like a TCP server (see [exemple](https://github.com/nodemcu/nodemcu-firmware/blob/master/examples/telnet.lua))
+
+## ws2812.init(mode)
+Initialize UART1 and GPIO2, should be called once and before write().
+Initialize UART0 (TXD0) too if `ws2812.DUAL` is set.
 
 #### Parameters
-none
+- `mode` (optional) either `ws2812.SINGLE` (default if omitted) or `ws2812.DUAL`. In `ws2812.DUAL`
+mode you will be able to handle two strips in parallel but will lose access
+to LUA's serial console.
 
 #### Returns
 `nil`
@@ -23,10 +32,11 @@ Send data to a led strip using its native format which is generally Green,Red,Bl
 and Green,Red,Blue,White for RGBW strips.
 
 #### Syntax
-`ws2812.write(string)`
+`ws2812.write(string1, [string2])`
 
 #### Parameters
-- `string` payload to be sent to one or more WS2812 like leds.
+- `string1` payload to be sent to one or more WS2812 like leds through GPIO2
+- `string2` (optional) payload to be sent to one or more WS2812 like leds through TXD0 (`ws2812.DUAL` mode required)
 
 #### Returns
 `nil`
@@ -34,12 +44,17 @@ and Green,Red,Blue,White for RGBW strips.
 #### Example
 ```lua
 ws2812.init()
-ws2812.write(string.char(255,0,0,255,0,0) -- turn the two first RGB leds to green
+ws2812.write(string.char(255,0,0,255,0,0)) -- turn the two first RGB leds to green
 ```
 
 ```lua
 ws2812.init()
-ws2812.write(string.char(0,0,0,255,0,0,0,255) -- turn the two first RGBW leds to white
+ws2812.write(string.char(0,0,0,255,0,0,0,255)) -- turn the two first RGBW leds to white
+```
+
+```lua
+ws2812.init(ws2812.DUAL)
+ws2812.write(string.char(255,0,0,255,0,0),string.char(0,255,0,0,255,0)) -- turn the two first RGB leds to green on the first strip and red on the second strip
 ```
 
 # Buffer module
@@ -178,6 +193,19 @@ Output the buffer to the led strip
 
 #### Parameters
 none
+
+#### Returns
+`nil`
+
+## ws2812.writeBuffer()
+Output on or two buffer to the led strips
+
+#### Syntax
+`ws2812.writeBuffer(buffer1, [buffer2])`
+
+#### Parameters
+- `buffer1` payload to be sent through GPIO2
+- `buffer2` (optional) payload to be sent through TXD0 (`ws2812.DUAL` mode required)
 
 #### Returns
 `nil`

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -7,36 +7,41 @@ ws2812 is a library to handle ws2812-like led strips.
 It works at least on WS2812, WS2812b, APA104, SK6812 (RGB or RGBW).
 
 The library uses UART1 routed on GPIO2 (Pin D4 on NodeMCU DEVKIT) to
-generate the bitstream. It can uses UART0 routed to TXD0 as well to
+generate the bitstream. It can use UART0 routed to TXD0 as well to
 handle two led strips at the same time.
 
-**WARNING**: In dual mode, you will loose access to the LUA's console
+**WARNING**: In dual mode, you will loose access to the Lua's console
 through the serial port (it will be reconfigured to support WS2812-like 
-protocol). If you want to keep access to LUA's console, you will have to 
-use an other input channel like a TCP server (see [exemple](https://github.com/nodemcu/nodemcu-firmware/blob/master/examples/telnet.lua))
+protocol). If you want to keep access to Lua's console, you will have to 
+use an other input channel like a TCP server (see [example](https://github.com/nodemcu/nodemcu-firmware/blob/master/examples/telnet.lua))
 
 ## ws2812.init(mode)
 Initialize UART1 and GPIO2, should be called once and before write().
-Initialize UART0 (TXD0) too if `ws2812.DUAL` is set.
+Initialize UART0 (TXD0) too if `ws2812.MODE_DUAL` is set.
 
 #### Parameters
-- `mode` (optional) either `ws2812.SINGLE` (default if omitted) or `ws2812.DUAL`. In `ws2812.DUAL`
-mode you will be able to handle two strips in parallel but will lose access
-to LUA's serial console.
+- `mode` (optional) either `ws2812.MODE_SINGLE` (default if omitted) or `ws2812.MODE_DUAL`.
+In `ws2812.MODE_DUAL` mode you will be able to handle two strips in parallel but will lose access
+to Lua's serial console as it shares the same UART and PIN.
 
 #### Returns
 `nil`
 
 ## ws2812.write()
-Send data to a led strip using its native format which is generally Green,Red,Blue for RGB strips
+Send data to one or two led strip using its native format which is generally Green,Red,Blue for RGB strips
 and Green,Red,Blue,White for RGBW strips.
 
 #### Syntax
-`ws2812.write(string1, [string2])`
+`ws2812.write(data1, [data2])`
 
 #### Parameters
-- `string1` payload to be sent to one or more WS2812 like leds through GPIO2
-- `string2` (optional) payload to be sent to one or more WS2812 like leds through TXD0 (`ws2812.DUAL` mode required)
+- `data1` payload to be sent to one or more WS2812 like leds through GPIO2
+- `data2` (optional) payload to be sent to one or more WS2812 like leds through TXD0 (`ws2812.MODE_DUAL` mode required)
+
+Payload type could be:
+- `nil` nothing is done
+- `string` representing bytes to send
+- `ws2812.buffer` see [Buffer module](#buffer-module)
 
 #### Returns
 `nil`
@@ -44,17 +49,22 @@ and Green,Red,Blue,White for RGBW strips.
 #### Example
 ```lua
 ws2812.init()
-ws2812.write(string.char(255,0,0,255,0,0)) -- turn the two first RGB leds to green
+ws2812.write(string.char(255, 0, 0, 255, 0, 0)) -- turn the two first RGB leds to green
 ```
 
 ```lua
 ws2812.init()
-ws2812.write(string.char(0,0,0,255,0,0,0,255)) -- turn the two first RGBW leds to white
+ws2812.write(string.char(0, 0, 0, 255, 0, 0, 0, 255)) -- turn the two first RGBW leds to white
 ```
 
 ```lua
-ws2812.init(ws2812.DUAL)
-ws2812.write(string.char(255,0,0,255,0,0),string.char(0,255,0,0,255,0)) -- turn the two first RGB leds to green on the first strip and red on the second strip
+ws2812.init(ws2812.MODE_DUAL)
+ws2812.write(string.char(255, 0, 0, 255, 0, 0), string.char(0, 255, 0, 0, 255, 0)) -- turn the two first RGB leds to green on the first strip and red on the second strip
+```
+
+```lua
+ws2812.init(ws2812.MODE_DUAL)
+ws2812.write(nil, string.char(0, 255, 0, 0, 255, 0)) -- turn the two first RGB leds to red on the second strip, do nothing on the first
 ```
 
 # Buffer module
@@ -66,11 +76,12 @@ For this purpose, the ws2812 library offers a read/write buffer.
 #### Example
 Led chaser with a RGBW strip
 ```lua
-local i, b = 0, ws2812.newBuffer(300, 4); b:fill(0,0,0,0); tmr.alarm(0, 50, 1, function()
+ws2812.init()
+local i, b = 0, ws2812.newBuffer(300, 4); b:fill(0, 0, 0, 0); tmr.alarm(0, 50, 1, function()
         i=i+1
         b:fade(2)
         b:set(i%b:size()+1, 0, 0, 0, 255)
-        b:write()
+        ws2812.write(b)
 end)
 ```
 
@@ -120,6 +131,15 @@ Set the value at the given position
 ```lua
 buffer:set(1, 255, 0, 0) -- set the first led green for a RGB strip
 ```
+
+```lua
+buffer:set(1, {255, 0, 0}) -- set the first led green for a RGB strip
+```
+
+```lua
+buffer:set(1, string.char(255, 0, 0)) -- set the first led green for a RGB strip
+```
+
 ## ws2812.buffer:size()
 Return the size of the buffer in number of leds
 
@@ -196,17 +216,3 @@ none
 
 #### Returns
 `nil`
-
-## ws2812.writeBuffer()
-Output on or two buffer to the led strips
-
-#### Syntax
-`ws2812.writeBuffer(buffer1, [buffer2])`
-
-#### Parameters
-- `buffer1` payload to be sent through GPIO2
-- `buffer2` (optional) payload to be sent through TXD0 (`ws2812.DUAL` mode required)
-
-#### Returns
-`nil`
-


### PR DESCRIPTION
Handle two strips using the two UARTS. The cost to pay is losing access to the LUA console through the serial port (which could still be accessed via a TCP server if needed)