### PR TITLE
Move call to set the default wifi hostname to user_main.c (fix for #1259)

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1309,7 +1309,7 @@ static const LUA_REG_TYPE wifi_map[] =  {
   { LNILKEY, LNILVAL }
 };
 
-static void wifi_change_default_host_name(task_param_t param, uint8 priority)
+void wifi_change_default_host_name(void)
 {
 #ifndef WIFI_STA_HOSTNAME
   char temp[32];
@@ -1344,7 +1344,6 @@ static void wifi_change_default_host_name(task_param_t param, uint8 priority)
 
 int luaopen_wifi( lua_State *L )
 {
-  task_post_low(task_get_id(wifi_change_default_host_name), FALSE);
 #if defined(WIFI_SDK_EVENT_MONITOR_ENABLE)
   wifi_eventmon_init();
 #endif

--- a/app/modules/wifi_common.h
+++ b/app/modules/wifi_common.h
@@ -35,6 +35,8 @@ static inline void unregister_lua_cb(lua_State* L, int* cb_ref)
   }
 }
 
+void wifi_change_default_host_name(void);
+
 #ifdef NODE_DEBUG
 #define EVENT_DBG(...) c_printf(__VA_ARGS__)
 #else

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -117,6 +117,16 @@ void nodemcu_init(void)
     task_post_low(task_get_id(start_lua),'s');
 }
 
+#ifdef LUA_USE_MODULES_WIFI
+#include "../modules/wifi_common.h"
+
+void user_rf_pre_init(void)
+{
+//set WiFi hostname before RF initialization (adds ~440 us to boot time)
+  wifi_change_default_host_name();
+}
+#endif
+
 /******************************************************************************
  * FunctionName : user_init
  * Description  : entry of user application, init user function here


### PR DESCRIPTION
This PR moves the call to set the default WiFi hostname from `luaopen_wifi (wifi.c)` to `user_rf_pre_init
(user_main.c)` as discussed in issue #1259.

This change will add ~440 us to boot time.