### PR TITLE
With this small patch, the DNS transaction ID space increases from 250 to 65536 states

### DIFF
--- a/app/lwip/core/dns.c
+++ b/app/lwip/core/dns.c
@@ -570,7 +570,7 @@ dns_send(u8_t numdns, const char* name, u8_t id)
   char *query, *nptr;
   const char *pHostname;
   u8_t n;
-  dns_random = os_random();
+  dns_random = (u16_t)os_random();
   LWIP_DEBUGF(DNS_DEBUG, ("dns_send: dns_servers[%"U16_F"] \"%s\": request\n",
               (u16_t)(numdns), name));
   LWIP_ASSERT("dns server out of array", numdns < DNS_MAX_SERVERS);

--- a/app/lwip/core/dns.c
+++ b/app/lwip/core/dns.c
@@ -227,7 +227,7 @@ static ip_addr_t              dns_servers[DNS_MAX_SERVERS];
 /** Contiguous buffer for processing responses */
 //static u8_t                   dns_payload_buffer[LWIP_MEM_ALIGN_BUFFER(DNS_MSG_SIZE)];
 static u8_t*                  dns_payload;
-static u8_t					  dns_random;
+static u16_t					  dns_random;
 /**
  * Initialize the resolver: set up the UDP pcb and configure the default server
  * (DNS_SERVER_ADDRESS).
@@ -570,7 +570,7 @@ dns_send(u8_t numdns, const char* name, u8_t id)
   char *query, *nptr;
   const char *pHostname;
   u8_t n;
-  dns_random = os_random()%250;
+  dns_random = os_random();
   LWIP_DEBUGF(DNS_DEBUG, ("dns_send: dns_servers[%"U16_F"] \"%s\": request\n",
               (u16_t)(numdns), name));
   LWIP_ASSERT("dns server out of array", numdns < DNS_MAX_SERVERS);


### PR DESCRIPTION
The ID space was artificially limited to only 250 values, making spoofing trivial. I tested this change and it works for me, and I checked the DNS random and id recovery logic and that works too. 