### PR TITLE
with this small fix, the DNS engine is RFC 5452 compliant because it …

### DIFF
--- a/app/include/lwip/udp.h
+++ b/app/include/lwip/udp.h
@@ -156,6 +156,11 @@ void             udp_input      (struct pbuf *p, struct netif *inp)ICACHE_FLASH_
 
 #define udp_init() /* Compatibility define, not init needed. */
 
+#ifndef UDP_LOCAL_PORT_RANGE_START
+#define UDP_LOCAL_PORT_RANGE_START 4096
+#define UDP_LOCAL_PORT_RANGE_END   0x7fff
+#endif
+
 #if UDP_DEBUG
 void udp_debug_print(struct udp_hdr *udphdr)ICACHE_FLASH_ATTR;
 #else

--- a/app/lwip/core/dns.c
+++ b/app/lwip/core/dns.c
@@ -254,8 +254,14 @@ dns_init()
       LWIP_ASSERT("For implicit initialization to work, DNS_STATE_UNUSED needs to be 0",
         DNS_STATE_UNUSED == 0);
 
-      /* initialize DNS client */
-      udp_bind(dns_pcb, IP_ADDR_ANY, 0);
+      /* initialize DNS client, try to get RFC 5452 random source port */
+      u16_t port = UDP_LOCAL_PORT_RANGE_START + (os_random() % (UDP_LOCAL_PORT_RANGE_END - UDP_LOCAL_PORT_RANGE_START));
+      for(;;) {
+        if(udp_bind(dns_pcb, IP_ADDR_ANY, port) == ERR_OK)
+          break;
+        LWIP_ASSERT("Unable to get a PCB for DNS", port != 0);
+        port=0; // try again with random source
+      }
       udp_recv(dns_pcb, dns_recv, NULL);
 
       /* initialize default DNS primary server */

--- a/app/lwip/core/udp.c
+++ b/app/lwip/core/udp.c
@@ -758,10 +758,6 @@ udp_bind(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port)
 
   /* no port specified? */
   if (port == 0) {
-#ifndef UDP_LOCAL_PORT_RANGE_START
-#define UDP_LOCAL_PORT_RANGE_START 4096
-#define UDP_LOCAL_PORT_RANGE_END   0x7fff
-#endif
     port = UDP_LOCAL_PORT_RANGE_START;
     ipcb = udp_pcbs;
     while ((ipcb != NULL) && (port != UDP_LOCAL_PORT_RANGE_END)) {


### PR DESCRIPTION
…now picks a random source port. This patch also moves the local UDP port range definition to udp.h from udp.c, which is probably a better place for it.

The original code did not deal with udp binding failures, this new code does one random port attempt and then sets port to 0 to get 'OS default' behaviour, and ASSERTs that that has to work.