### PR TITLE
Fixed a typo in the wifi documentation

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -45,7 +45,7 @@ The WiFi mode, as one of the `wifi.STATION`, `wifi.SOFTAP`, `wifi.STATIONAP` or 
 Gets WiFi physical mode.
 
 #### Syntax
-`wifi.getpymode()`
+`wifi.getphymode()`
 
 #### Parameters
 none


### PR DESCRIPTION
I found a typo in the docs and fixed it.

Changed wifi.getpymode() into the correct wifi.getphymode().
