### PR TITLE
Fixed bug where default hostname is not set on boot when in SoftAP mode

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1311,6 +1311,8 @@ static const LUA_REG_TYPE wifi_map[] =  {
 
 void wifi_change_default_host_name(void)
 {
+  uint8 opmode_temp=wifi_get_opmode();
+  wifi_set_opmode_current(STATION_MODE);
 #ifndef WIFI_STA_HOSTNAME
   char temp[32];
   uint8_t mac[6];
@@ -1318,7 +1320,7 @@ void wifi_change_default_host_name(void)
   c_sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
   wifi_sta_sethostname((const char*)temp, strlen(temp));
 
- #elif defined(WIFI_STA_HOSTNAME) && !defined(WIFI_STA_HOSTNAME_APPEND_MAC)
+#elif defined(WIFI_STA_HOSTNAME) && !defined(WIFI_STA_HOSTNAME_APPEND_MAC)
   if(!wifi_sta_sethostname(WIFI_STA_HOSTNAME, strlen(WIFI_STA_HOSTNAME)))
   {
     char temp[32];
@@ -1335,11 +1337,14 @@ void wifi_change_default_host_name(void)
   c_sprintf(temp, "%s%X%X%X", WIFI_STA_HOSTNAME, (mac)[3], (mac)[4], (mac)[5]);
   if(!wifi_sta_sethostname(temp, strlen(temp)))
   {
-	c_sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
+    c_sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
     wifi_sta_sethostname((const char*)temp, strlen(temp));
   }
 #endif
-
+  if(opmode_temp!=wifi_get_opmode())
+  {
+    wifi_set_opmode_current(opmode_temp);
+  }
 }
 
 int luaopen_wifi( lua_State *L )

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -122,7 +122,7 @@ void nodemcu_init(void)
 
 void user_rf_pre_init(void)
 {
-//set WiFi hostname before RF initialization (adds ~440 us to boot time)
+//set WiFi hostname before RF initialization (adds ~479 us to boot time)
   wifi_change_default_host_name();
 }
 #endif


### PR DESCRIPTION
Fixes #1340.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [X] I have thoroughly tested my contribution.

This PR is to fix a bug where default hostname is not set if ESP8266 is booted up in SoftAP mode.