### PR TITLE
added fadeIn, faceOut and shift to ws2812 module

### DIFF
--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -135,13 +135,14 @@ The number of given bytes must match the number of bytesPerLed of the buffer
 buffer:fill(0, 0, 0) -- fill the buffer with black for a RGB strip
 ```
 ## ws2812.buffer:fade()
-Divide each byte of each led by the given value. Useful for a fading effect. Equal to ws2812.buffer:fadeOut().
+Fade in or out. Defaults to out. Multiply or divide each byte of each led with/by the given value. Useful for a fading effect. 
 
 #### Syntax
-`buffer:fade(value)`
+`buffer:fade(value [, direction])`
 
 #### Parameters
- - `value` value by which to divide each byte
+ - `value` value by which to divide or multiply each byte
+ - `direction` ws2812.FADE_IN or ws2812.FADE_OUT. Defaults to ws2812.FADE_OUT
 
 #### Returns
 `nil`
@@ -149,47 +150,16 @@ Divide each byte of each led by the given value. Useful for a fading effect. Equ
 #### Example
 ```lua
 buffer:fade(2)
+buffer:fade(2, ws2812.FADE_IN)
 ```
-## ws2812.buffer:fadeIn()
-Multiply each byte of each led by the given value. Useful for a fading effect
+## ws2812.buffer:rotate()
+Rotate the content of the buffer in positive or negative direction. This allows simple animation effects.
 
 #### Syntax
-`buffer:fadeIn(value)`
+`buffer:rotate(value)`
 
 #### Parameters
- - `value` value by which to multiply each byte
-
-#### Returns
-`nil`
-
-#### Example
-```lua
-buffer:fadeIn(2)
-```
-## ws2812.buffer:fadeOut()
-Divide each byte of each led by the given value. Useful for a fading effect.
-
-#### Syntax
-`buffer:fadeOut(value)`
-
-#### Parameters
- - `value` value by which to divide each byte
-
-#### Returns
-`nil`
-
-#### Example
-```lua
-buffer:fadeOut(2)
-```
-## ws2812.buffer:shift()
-Shift the content of the buffer in positive or negative direction. This allows simple animation effects.
-
-#### Syntax
-`buffer:shift(value)`
-
-#### Parameters
- - `value` number of pixels by which to shift the buffer. Positive values shift forwards, negative values backwards. Bytes falling out on one side are inserted again on the other, like in a ring. 
+ - `value` number of pixels by which to rotate the buffer. Positive values rotate forwards, negative values backwards. Bytes falling out on one side are inserted again on the other, like in a ring. 
 
 #### Returns
 `nil`

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -135,13 +135,13 @@ The number of given bytes must match the number of bytesPerLed of the buffer
 buffer:fill(0, 0, 0) -- fill the buffer with black for a RGB strip
 ```
 ## ws2812.buffer:fade()
-Divide each byte of each led by the given value. Useful for a fading effect
+Divide each byte of each led by the given value. Useful for a fading effect. Equal to ws2812.buffer:fadeOut().
 
 #### Syntax
 `buffer:fade(value)`
 
 #### Parameters
- - `value` value by which divide each byte
+ - `value` value by which to divide each byte
 
 #### Returns
 `nil`
@@ -150,6 +150,55 @@ Divide each byte of each led by the given value. Useful for a fading effect
 ```lua
 buffer:fade(2)
 ```
+## ws2812.buffer:fadeIn()
+Multiply each byte of each led by the given value. Useful for a fading effect
+
+#### Syntax
+`buffer:fadeIn(value)`
+
+#### Parameters
+ - `value` value by which to multiply each byte
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+buffer:fadeIn(2)
+```
+## ws2812.buffer:fadeOut()
+Divide each byte of each led by the given value. Useful for a fading effect.
+
+#### Syntax
+`buffer:fadeOut(value)`
+
+#### Parameters
+ - `value` value by which to divide each byte
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+buffer:fadeOut(2)
+```
+## ws2812.buffer:shift()
+Shift the content of the buffer in positive or negative direction. This allows simple animation effects.
+
+#### Syntax
+`buffer:shift(value)`
+
+#### Parameters
+ - `value` number of pixels by which to shift the buffer. Positive values shift forwards, negative values backwards. Bytes falling out on one side are inserted again on the other, like in a ring. 
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+buffer:shift(3)
+```
+
 ## ws2812.buffer:write()
 Output the buffer to the led strip
 

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -142,7 +142,7 @@ Fade in or out. Defaults to out. Multiply or divide each byte of each led with/b
 
 #### Parameters
  - `value` value by which to divide or multiply each byte
- - `direction` ws2812.FADE_IN or ws2812.FADE_OUT. Defaults to ws2812.FADE_OUT
+ - `direction` ws2812.FADE\_IN or ws2812.FADE\_OUT. Defaults to ws2812.FADE\_OUT
 
 #### Returns
 `nil`
@@ -152,14 +152,15 @@ Fade in or out. Defaults to out. Multiply or divide each byte of each led with/b
 buffer:fade(2)
 buffer:fade(2, ws2812.FADE_IN)
 ```
-## ws2812.buffer:rotate()
-Rotate the content of the buffer in positive or negative direction. This allows simple animation effects.
+## ws2812.buffer:shift()
+Shift the content of the buffer in positive or negative direction. This allows simple animation effects.
 
 #### Syntax
-`buffer:rotate(value)`
+`buffer:shift(value [, mode])`
 
 #### Parameters
- - `value` number of pixels by which to rotate the buffer. Positive values rotate forwards, negative values backwards. Bytes falling out on one side are inserted again on the other, like in a ring. 
+ - `value` number of pixels by which to rotate the buffer. Positive values rotate forwards, negative values backwards. 
+ - `mode` is the shift mode to use. Can be one of `ws2812.SHIFT_LOGICAL` or `ws2812.SHIFT_CIRCULAR`. In case of SHIFT\_LOGICAL, the freed pixels are set to 0 (off). In case of SHIFT\_CIRCULAR, the buffer is treated like a ring buffer, inserting the pixels falling out on one end again on the other end. Defaults to SHIFT\_LOGICAL. 
 
 #### Returns
 `nil`


### PR DESCRIPTION
Fixes #1342.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This PR adds a shift (forward and backward) to the ws2812 buffer. It simply circulates the data like in a ring. It also adds a fadeIn (and for consistency fadeOut) method. The fade method has been kept for backward compatibility.

Committers supporting this PR: @marcelstoer