### PR TITLE
gpio.serout going asynchronous

### DIFF
--- a/app/modules/gpio.c
+++ b/app/modules/gpio.c
@@ -1,4 +1,5 @@
 // Module for interfacing with GPIO
+//#define NODE_DEBUG
 
 #include "module.h"
 #include "lauxlib.h"
@@ -8,6 +9,7 @@
 #include "c_types.h"
 #include "c_string.h"
 #include "gpio.h"
+#include "hw_timer.h"
 
 #define PULLUP PLATFORM_GPIO_PULLUP
 #define FLOAT PLATFORM_GPIO_FLOAT
@@ -160,8 +162,7 @@ static int lgpio_write( lua_State* L )
 
 #define DELAY_TABLE_MAX_LEN 256
 #define delayMicroseconds os_delay_us
-// Lua: serout( pin, firstLevel, delay_table, [repeatNum] )
-// -- serout( pin, firstLevel, delay_table, [repeatNum] )
+// Lua: serout( pin, firstLevel, delay_table[, repeat_num[, callback]])
 // gpio.mode(1,gpio.OUTPUT,gpio.PULLUP)
 // gpio.serout(1,1,{30,30,60,60,30,30})  -- serial one byte, b10110010
 // gpio.serout(1,1,{30,70},8)  -- serial 30% pwm 10k, lasts 8 cycles
@@ -170,42 +171,95 @@ static int lgpio_write( lua_State* L )
 // gpio.mode(1,gpio.OUTPUT,gpio.PULLUP)
 // gpio.serout(1,0,{20,10,10,20,10,10,10,100}) -- sim uart one byte 0x5A at about 100kbps
 // gpio.serout(1,1,{8,18},8) -- serial 30% pwm 38k, lasts 8 cycles
+
+typedef struct
+{
+  unsigned pin;
+  unsigned level;
+  uint32 index;
+  uint32 repeats;
+  uint32 *delay_table;
+  uint32 tablelen;
+  lua_State* L;
+  int lua_done_ref; // callback when transmission is done
+} serout_t;
+static serout_t serout;
+static const os_param_t TIMER_OWNER = 0x6770696f; // "gpio"
+
+static void seroutasync_done (task_param_t arg)
+{
+  lua_rawgeti (serout.L, LUA_REGISTRYINDEX, serout.lua_done_ref);
+  lua_call (serout.L, 0, 0);
+  luaL_unref (serout.L, LUA_REGISTRYINDEX, serout.lua_done_ref);
+}
+
+static void ICACHE_RAM_ATTR seroutasync_cb(os_param_t p) {
+  (void) p;
+  NODE_DBG("%d\t%d\t%d\t%d\t%d\t%d\t%d\n", serout.repeats, serout.index, serout.level, serout.pin, serout.tablelen, serout.delay_table[serout.index], system_get_time()); // timing is delayed for short timings when debug output is enabled
+  if (serout.index < serout.tablelen) {
+    GPIO_OUTPUT_SET(GPIO_ID_PIN(pin_num[serout.pin]), serout.level);
+    serout.level = serout.level==LOW ? HIGH : LOW;
+    platform_hw_timer_arm_us(TIMER_OWNER, serout.delay_table[serout.index]);
+    serout.index++;
+    if (serout.repeats && serout.index>=serout.tablelen) {serout.index=0; serout.repeats--;}
+  } else {
+    platform_hw_timer_close(TIMER_OWNER);
+    luaM_freearray(serout.L, serout.delay_table, serout.tablelen, uint32);
+    if (serout.lua_done_ref != LUA_NOREF && serout.lua_done_ref != LUA_REFNIL) {
+      task_post_low (task_get_id((task_callback_t) seroutasync_done), (task_param_t)0);
+    }
+  }
+}
+
 static int lgpio_serout( lua_State* L )
 {
-  unsigned clocks_per_us = system_get_cpu_freq();
-  unsigned pin = luaL_checkinteger( L, 1 );
-  unsigned level = luaL_checkinteger( L, 2 );
-  unsigned repeats = luaL_optint( L, 4, 1 );
-  unsigned table_len, i, j;
+  serout.L = L;
+  serout.pin = luaL_checkinteger( L, 1 );
+  serout.level = luaL_checkinteger( L, 2 );
+  serout.repeats = luaL_optint( L, 4, 1 )-1;
+  if (!lua_isnoneornil(L, 5)) {
+    if (lua_isnumber(L, 5)) {
+      serout.lua_done_ref = LUA_REFNIL;
+    } else {
+      lua_pushvalue(L, 5);
+      serout.lua_done_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    }
+  } else {
+    serout.lua_done_ref = LUA_NOREF;
+  }
 
-  luaL_argcheck(L, platform_gpio_exists(pin), 1, "Invalid pin");
-  luaL_argcheck(L, level==HIGH || level==LOW, 2, "Wrong arg type" );
+  luaL_argcheck(L, platform_gpio_exists(serout.pin), 1, "Invalid pin");
+  luaL_argcheck(L, serout.level==HIGH || serout.level==LOW, 2, "Wrong level type" );
   luaL_argcheck(L, lua_istable( L, 3 ) &&
-                   ((table_len = lua_objlen( L, 3 )<DELAY_TABLE_MAX_LEN)), 3, "Invalid table" );
-  luaL_argcheck(L, repeats<256, 4, "repeats >= 256" );
+                   ((serout.tablelen = lua_objlen( L, 3 )) < DELAY_TABLE_MAX_LEN), 3, "Invalid delay_times" );
 
-  uint32 *delay_table = luaM_newvector(L, table_len*repeats, uint32);
-  for( i = 1; i <= table_len; i++ )  {
+  serout.delay_table = luaM_newvector(L, serout.tablelen, uint32);
+  for(unsigned i = 0; i < serout.tablelen; i++ )  {
     lua_rawgeti( L, 3, i + 1 );
     unsigned delay = (unsigned) luaL_checkinteger( L, -1 );
-    if (delay > 1000000) return luaL_error( L, "delay %u must be < 1,000,000 us", i );
-    delay_table[i-1] = delay;
+    serout.delay_table[i] = delay;
     lua_pop( L, 1 );
   }
 
-  for( i = 0; i <= repeats; i++ )  {
-    if (!i)    // skip the first loop (presumably this is some form of icache priming??).
-      continue;
-
-    for( j = 0;j < table_len; j++ ){
-      /* Direct Write is a ROM function which already disables interrupts for the atomic bit */
-      GPIO_OUTPUT_SET(GPIO_ID_PIN(pin_num[pin]), level);
-      delayMicroseconds(delay_table[j]);
-      level = level==LOW ? HIGH : LOW;
+  if (serout.lua_done_ref != LUA_NOREF) { // async version for duration above 15 mSec
+    if (!platform_hw_timer_init(TIMER_OWNER, FRC1_SOURCE, TRUE)) {
+      // Failed to init the timer
+      luaL_error(L, "Unable to initialize timer");
     }
+    platform_hw_timer_set_func(TIMER_OWNER, seroutasync_cb, 0);
+    serout.index = 0;
+    seroutasync_cb(0);
+  } else { // sync version for sub-50 µs resolution & total duration < 15 mSec
+    do { 
+      for( serout.index = 0;serout.index < serout.tablelen; serout.index++ ){
+        NODE_DBG("%d\t%d\t%d\t%d\t%d\t%d\t%d\n", serout.repeats, serout.index, serout.level, serout.pin, serout.tablelen, serout.delay_table[serout.index], system_get_time()); // timings is delayed for short timings when debug output is enabled
+        GPIO_OUTPUT_SET(GPIO_ID_PIN(pin_num[serout.pin]), serout.level);
+        serout.level = serout.level==LOW ? HIGH : LOW;
+        delayMicroseconds(serout.delay_table[serout.index]);
+      }
+    } while (serout.repeats--);
+    luaM_freearray(L, serout.delay_table, serout.tablelen, uint32);
   }
-
-  luaM_freearray(L, delay_table, table_len, uint32);
   return 0;
 }
 #undef DELAY_TABLE_MAX_LEN


### PR DESCRIPTION
Fixes issues of `gpio.serout` discussed in #1339.
- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This PR is adding an asynchronous mode to `gpio.serout` function. The existing implementation is synchronous and therefore blocks the stack. Transmission of a signal lasting more than 15 ms was obviously causing reboots. Now the transmission can be asynchronous with delays up to the limit of hw timer and virtually unrestricted duration.
The implementation is backwards compatible. The synchronous version is to be used for signal with sub-50 µs resolution (but restricted to max. overall duration).
Whether the function goes async is determined by `callback` parameter. If present the function goes async. Please see the updated documentation for details.

Hardware timer is used so this function cannot be used simultaneously with other modules using hw timer (e.g. `pcm`).

This PR also replaces PR #1327 which should be dropped (proposed changes are included in this PR too).

Committers supporting this PR: 