### PR TITLE
Skip passing port in Host header if standard port.

### DIFF
--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -181,7 +181,7 @@ static void ICACHE_FLASH_ATTR http_connect_callback( void * arg )
 	HTTPCLIENT_DEBUG( "Connected\n" );
 	struct espconn	* conn	= (struct espconn *) arg;
 	request_args_t	* req	= (request_args_t *) conn->reverse;
-
+	int len;
 	espconn_regist_recvcb( conn, http_receive_callback );
 	espconn_regist_sentcb( conn, http_send_callback );
 
@@ -200,16 +200,29 @@ static void ICACHE_FLASH_ATTR http_connect_callback( void * arg )
 
 	char buf[69 + strlen( req->method ) + strlen( req->path ) + strlen( req->hostname ) +
 		 strlen( req->headers ) + strlen( post_headers )];
-	int len = os_sprintf( buf,
-			      "%s %s HTTP/1.1\r\n"
-			      "Host: %s:%d\r\n"
-			      "Connection: close\r\n"
-			      "User-Agent: ESP8266\r\n"
-			      "%s"
-			      "%s"
-			      "\r\n",
-			      req->method, req->path, req->hostname, req->port, req->headers, post_headers );
 
+	if ((req->port == 80) || ((req->port == 443) && ( req->secure )))
+	{
+		len = os_sprintf( buf,
+		  		"%s %s HTTP/1.1\r\n"
+			    "Host: %s\r\n"
+			    "Connection: close\r\n"
+			    "User-Agent: ESP8266\r\n"
+			    "%s"
+			    "%s"
+			    "\r\n",
+			    req->method, req->path, req->hostname, req->headers, post_headers );
+	} else {
+		len = os_sprintf( buf,
+				"%s %s HTTP/1.1\r\n"
+				"Host: %s:%d\r\n"
+				"Connection: close\r\n"
+				"User-Agent: ESP8266\r\n"
+				"%s"
+				"%s"
+				"\r\n",
+				req->method, req->path, req->hostname, req->port, req->headers, post_headers );
+	}
 	if ( req->secure )
 		espconn_secure_send( conn, (uint8_t *) buf, len );
 	else


### PR DESCRIPTION
Fixes #1361.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Rationale: Current HTTP module sends port in `Host` header even if using standard 80 and 443 ports. This fixes the behavior with the exception of HTTPS on port 80 and HTTP on port 443. A more thorough fix would take a bit of rework of the module.

Committers supporting this PR: leave blank