### PR TITLE
Update u8glib to v1.19.1 and add setContrast()

### DIFF
--- a/app/modules/u8g.c
+++ b/app/modules/u8g.c
@@ -238,6 +238,19 @@ static int lu8g_getMode( lua_State *L )
     return 1;
 }
 
+// Lua: u8g.setContrast( self, constrast )
+static int lu8g_setContrast( lua_State *L )
+{
+    lu8g_userdata_t *lud;
+
+    if ((lud = get_lud( L )) == NULL)
+        return 0;
+
+    u8g_SetContrast( LU8G, luaL_checkinteger( L, 2 ) );
+
+    return 0;
+}
+
 // Lua: u8g.setColorIndex( self, color )
 static int lu8g_setColorIndex( lua_State *L )
 {
@@ -1086,6 +1099,7 @@ static const LUA_REG_TYPE lu8g_display_map[] = {
   { LSTRKEY( "getStrWidth" ),                  LFUNCVAL( lu8g_getStrWidth ) },
   { LSTRKEY( "getWidth" ),                     LFUNCVAL( lu8g_getWidth ) },
   { LSTRKEY( "nextPage" ),                     LFUNCVAL( lu8g_nextPage ) },
+  { LSTRKEY( "setContrast" ),                  LFUNCVAL( lu8g_setContrast ) },
   { LSTRKEY( "setColorIndex" ),                LFUNCVAL( lu8g_setColorIndex ) },
   { LSTRKEY( "setDefaultBackgroundColor" ),    LFUNCVAL( lu8g_setDefaultBackgroundColor ) },
   { LSTRKEY( "setDefaultForegroundColor" ),    LFUNCVAL( lu8g_setDefaultForegroundColor ) },

--- a/app/u8glib/u8g.h
+++ b/app/u8glib/u8g.h
@@ -134,15 +134,15 @@ typedef uint8_t u8g_fntpgm_uint8_t;
    typedef uint8_t u8g_fntpgm_uint8_t;
 #  define u8g_pgm_read(adr) (*(const u8g_pgm_uint8_t *)(adr)) 
 #  define U8G_PSTR(s) ((u8g_pgm_uint8_t *)(s))
+#endif
 
-#else
+#ifndef U8G_PROGMEM
 #  define U8G_PROGMEM
 #  define PROGMEM
-   typedef uint8_t u8g_pgm_uint8_t;
-   typedef uint8_t u8g_fntpgm_uint8_t;
+typedef uint8_t u8g_pgm_uint8_t;
+typedef uint8_t u8g_fntpgm_uint8_t;
 #  define u8g_pgm_read(adr) (*(const u8g_pgm_uint8_t *)(adr)) 
 #  define U8G_PSTR(s) ((u8g_pgm_uint8_t *)(s))
-
 #endif
   
 /*===============================================================*/
@@ -414,6 +414,7 @@ extern u8g_dev_t u8g_dev_ssd1325_nhd27oled_bw_hw_spi;
 extern u8g_dev_t u8g_dev_ssd1325_nhd27oled_bw_parallel;
 extern u8g_dev_t u8g_dev_ssd1325_nhd27oled_gr_sw_spi;
 extern u8g_dev_t u8g_dev_ssd1325_nhd27oled_gr_hw_spi;
+extern u8g_dev_t u8g_dev_ssd1325_nhd27oled_gr_parallel;
 
 extern u8g_dev_t u8g_dev_ssd1325_nhd27oled_2x_bw_sw_spi;
 extern u8g_dev_t u8g_dev_ssd1325_nhd27oled_2x_bw_hw_spi;
@@ -699,11 +700,18 @@ uint8_t u8g_com_atmega_st7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val
 uint8_t u8g_com_atmega_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
 uint8_t u8g_com_atmega_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);    /* u8g_com_atmega_parallel.c */
 
+uint8_t u8g_com_atxmega_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);      /* u8g_com_atxmega_hw_spi.c */
+uint8_t u8g_com_atxmega_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr); /* u8g_com_atxmega_st7920_spi.c */
+
 uint8_t u8g_com_msp430_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);      /* u8g_com_msp430_hw_spi.c */
 
 uint8_t u8g_com_raspberrypi_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);                /* u8g_com_rasperrypi_hw_spi.c */
 uint8_t u8g_com_raspberrypi_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);		/* u8g_com_raspberrypi_ssd_i2c.c */
 
+uint8_t u8g_com_linux_ssd_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);             /* u8g_com_linux_ssd_i2c.c */
+
+uint8_t u8g_com_psoc5_ssd_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);   /* u8g_com_psoc5_ssd_hw_spi.c */
+uint8_t u8g_com_psoc5_ssd_hw_parallel_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);   /* u8g_com_psoc5_ssd_hw_parallel.c */
 
 /* 
   Translation of system specific com drives to generic com names
@@ -762,7 +770,10 @@ defined(__18CXX) || defined(__PIC32MX)
 #endif
 /* ==== HW SPI, not Arduino ====*/
 #ifndef U8G_COM_HW_SPI
-#if defined(__AVR__)
+#if defined(__AVR_XMEGA__)
+#define U8G_COM_HW_SPI u8g_com_atxmega_hw_spi_fn
+#define U8G_COM_ST7920_HW_SPI u8g_com_atxmega_st7920_hw_spi_fn
+#elif defined(__AVR__)
 #define U8G_COM_HW_SPI u8g_com_atmega_hw_spi_fn
 #define U8G_COM_ST7920_HW_SPI u8g_com_atmega_st7920_hw_spi_fn
 #endif
@@ -861,12 +872,18 @@ defined(__18CXX) || defined(__PIC32MX)
 #define U8G_COM_SSD_I2C u8g_com_raspberrypi_ssd_i2c_fn
 #endif
 #endif
-
 #ifndef U8G_COM_SSD_I2C
+#if defined(U8G_LINUX)
+#define U8G_COM_SSD_I2C u8g_com_linux_ssd_i2c_fn
+#endif
 #if defined(__XTENSA__)
 // ESP8266
 #define U8G_COM_SSD_I2C u8g_com_esp8266_ssd_i2c_fn
 #endif
+#endif
+#if defined(U8G_CYPRESS_PSOC5)
+#define U8G_COM_HW_SPI u8g_com_psoc5_ssd_hw_spi_fn
+#define U8G_COM_FAST_PARALLEL u8g_com_psoc5_ssd_hw_parallel_fn
 #endif
 
 #ifndef U8G_COM_SSD_I2C

--- a/app/u8glib/u8g_clip.c
+++ b/app/u8glib/u8g_clip.c
@@ -62,7 +62,7 @@
 #define U8G_ALWAYS_INLINE __inline__ __attribute__((always_inline))
 #else
 #define U8G_ALWAYS_INLINE
- #endif 
+#endif 
 
 /*
   intersection assumptions:

--- a/app/u8glib/u8g_com_i2c.c
+++ b/app/u8glib/u8g_com_i2c.c
@@ -67,8 +67,8 @@ uint8_t u8g_i2c_get_err_pos(void)
 }
 
 
-
-#if defined(__AVR__)
+#if defined(__AVR_XMEGA__)
+#elif defined(__AVR__)
 
 static void u8g_i2c_set_error(uint8_t code, uint8_t pos)
 {

--- a/app/u8glib/u8g_com_io.c
+++ b/app/u8glib/u8g_com_io.c
@@ -65,6 +65,83 @@ uint8_t u8g_Pin(uint8_t port, uint8_t bitpos)
   return port;
 }
 
+#if defined(__AVR_XMEGA__)
+
+const IO_PTR u8g_avr_ddr_P[] PROGMEM = {
+#ifdef PORTA
+  &PORTA.DIR,
+#else
+  0,
+#endif
+  &PORTB.DIR,
+#ifdef PORTC
+  &PORTC.DIR,
+#ifdef PORTD
+  &PORTD.DIR,
+#ifdef PORTE
+  &PORTE.DIR,
+#ifdef PORTF
+  &PORTF.DIR,
+#ifdef PORTR
+  &PORTR.DIR,
+#endif
+#endif
+#endif
+#endif
+#endif
+};
+
+
+const IO_PTR u8g_avr_port_P[] PROGMEM = {
+#ifdef PORTA
+  &PORTA.OUT,
+#else
+  0,
+#endif
+  &PORTB.OUT,
+#ifdef PORTC
+  &PORTC.OUT,
+#ifdef PORTD
+  &PORTD.OUT,
+#ifdef PORTE
+  &PORTE.OUT,
+#ifdef PORTF
+  &PORTF.OUT,
+#ifdef PORTR
+  &PORTR.OUT,
+#endif
+#endif
+#endif
+#endif
+#endif
+};
+
+const IO_PTR u8g_avr_pin_P[] PROGMEM = {
+#ifdef PORTA
+  &PORTA.IN,
+#else
+  0,
+#endif
+  &PORTB.IN,
+#ifdef PORTC
+  &PORTC.IN,
+#ifdef PORTD
+  &PORTD.IN,
+#ifdef PORTE
+  &PORTE.IN,
+#ifdef PORTF
+  &PORTF.IN,
+#ifdef PORTR
+  &PORTR.IN,
+#endif
+#endif
+#endif
+#endif
+#endif
+};
+
+
+#else
 const IO_PTR u8g_avr_ddr_P[] PROGMEM = {
 #ifdef DDRA
   &DDRA,
@@ -146,6 +223,7 @@ const IO_PTR u8g_avr_pin_P[] PROGMEM = {
 #endif
 #endif
 };
+#endif
 
 static volatile uint8_t *u8g_get_avr_io_ptr(const IO_PTR *base, uint8_t offset)
 {

--- a/app/u8glib/u8g_delay.c
+++ b/app/u8glib/u8g_delay.c
@@ -52,6 +52,11 @@
 #    include <Arduino.h> 
 #  endif
 
+/* issue 353 */
+#if defined(ARDUINO_ARCH_SAMD)
+#    include <delay.h>
+#endif
+
 #  if defined(__AVR__)
 #    define USE_AVR_DELAY
 #  elif defined(__PIC32MX)
@@ -71,6 +76,8 @@
 #  define USE_AVR_DELAY
 #elif defined(__18CXX)
 #  define USE_PIC18_DELAY
+#elif defined(U8G_CYPRESS_PSOC5)
+#define USE_PSOC5_DELAY
 #elif defined(__arm__) || defined(__XTENSA__)
 /* do not define anything, all procedures are expected to be defined outside u8glib */
 
@@ -292,6 +299,12 @@ void u8g_10MicroDelay(void)
 {
   __delay_cycles(F_CPU/100000UL);
 }
+#endif
+#if defined USE_PSOC5_DELAY
+  #include <project.h>
+  void u8g_Delay(uint16_t val)  {CyDelay(val);};
+  void u8g_MicroDelay(void)     {CyDelay(1);};
+  void u8g_10MicroDelay(void)   {CyDelay(10);};  
 #endif
 
 

--- a/app/u8glib/u8g_dev_lc7981_160x80.c
+++ b/app/u8glib/u8g_dev_lc7981_160x80.c
@@ -75,7 +75,7 @@ static const uint8_t u8g_dev_lc7981_160x80_init_seq[] PROGMEM = {
   U8G_ESC_ADR(1),               /* instruction mode */
   0x003,                                /* time division */
   U8G_ESC_ADR(0),               /* data mode */
-  0x07f,                                /*  */
+  0x050,                                /* Oct 2015: Changed from 7f to 50 (1/80 duty cycle) */
 
   U8G_ESC_ADR(1),               /* instruction mode */
   0x008,                                /* display start low */

--- a/app/u8glib/u8g_dev_ssd1306_128x32.c
+++ b/app/u8glib/u8g_dev_ssd1306_128x32.c
@@ -230,6 +230,13 @@ uint8_t u8g_dev_ssd1306_128x32_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void 
         u8g_SetChipSelect(u8g, dev, 0);
       }
       break;
+    case U8G_DEV_MSG_CONTRAST:
+      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
+      u8g_WriteByte(u8g, dev, 0x081);
+      u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) ); /* 11 Jul 2015: fixed contrast calculation */
+      u8g_SetChipSelect(u8g, dev, 0);      
+      return 1; 
     case U8G_DEV_MSG_SLEEP_ON:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_on);    
       return 1;
@@ -268,6 +275,13 @@ uint8_t u8g_dev_ssd1306_128x32_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, vo
         u8g_SetChipSelect(u8g, dev, 0);
       }
       break;
+    case U8G_DEV_MSG_CONTRAST:
+      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
+      u8g_WriteByte(u8g, dev, 0x081);
+      u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) ); /* 11 Jul 2015: fixed contrast calculation */
+      u8g_SetChipSelect(u8g, dev, 0);      
+      return 1; 
     case U8G_DEV_MSG_SLEEP_ON:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_on);    
       return 1;

--- a/app/u8glib/u8g_dev_ssd1306_128x64.c
+++ b/app/u8glib/u8g_dev_ssd1306_128x64.c
@@ -240,6 +240,15 @@ uint8_t u8g_dev_ssd1306_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void 
     case U8G_DEV_MSG_SLEEP_OFF:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_off);    
       return 1;
+    case U8G_DEV_MSG_CONTRAST:
+    {
+	u8g_SetChipSelect(u8g, dev, 1);
+	u8g_SetAddress(u8g, dev, 0); /* instruction mode */
+	u8g_WriteByte(u8g, dev, 0x81);
+	u8g_WriteByte(u8g, dev, *(uint8_t *) arg);
+	u8g_SetChipSelect(u8g, dev, 0);
+	return 1;
+    }
   }
   return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);
 }
@@ -271,6 +280,15 @@ uint8_t u8g_dev_ssd1306_adafruit_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
     case U8G_DEV_MSG_SLEEP_OFF:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_off);    
       return 1;
+    case U8G_DEV_MSG_CONTRAST:
+    {
+	u8g_SetChipSelect(u8g, dev, 1);
+	u8g_SetAddress(u8g, dev, 0); /* instruction mode */
+	u8g_WriteByte(u8g, dev, 0x81);
+	u8g_WriteByte(u8g, dev, *(uint8_t *) arg);
+	u8g_SetChipSelect(u8g, dev, 0);
+	return 1;
+    }
   }
   return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);
 }
@@ -302,6 +320,15 @@ uint8_t u8g_dev_sh1106_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *
     case U8G_DEV_MSG_SLEEP_OFF:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_off);    
       return 1;
+    case U8G_DEV_MSG_CONTRAST:
+    {
+	u8g_SetChipSelect(u8g, dev, 1);
+	u8g_SetAddress(u8g, dev, 0); /* instruction mode */
+	u8g_WriteByte(u8g, dev, 0x81);
+	u8g_WriteByte(u8g, dev, *(uint8_t *) arg);
+	u8g_SetChipSelect(u8g, dev, 0);
+	return 1;
+    }
   }
   return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);
 }
@@ -340,6 +367,15 @@ uint8_t u8g_dev_ssd1306_128x64_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, vo
     case U8G_DEV_MSG_SLEEP_OFF:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_off);    
       return 1;
+    case U8G_DEV_MSG_CONTRAST:
+    {
+	u8g_SetChipSelect(u8g, dev, 1);
+	u8g_SetAddress(u8g, dev, 0); /* instruction mode */
+	u8g_WriteByte(u8g, dev, 0x81);
+	u8g_WriteByte(u8g, dev, *(uint8_t *) arg);
+	u8g_SetChipSelect(u8g, dev, 0);
+	return 1;
+    }
   }
   return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
 }
@@ -377,6 +413,15 @@ uint8_t u8g_dev_sh1106_128x64_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
     case U8G_DEV_MSG_SLEEP_OFF:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_off);    
       return 1;
+    case U8G_DEV_MSG_CONTRAST:
+    {
+	u8g_SetChipSelect(u8g, dev, 1);
+	u8g_SetAddress(u8g, dev, 0); /* instruction mode */
+	u8g_WriteByte(u8g, dev, 0x81);
+	u8g_WriteByte(u8g, dev, *(uint8_t *) arg);
+	u8g_SetChipSelect(u8g, dev, 0);
+	return 1;
+    }
   }
   return u8g_dev_pb16v1_base_fn(u8g, dev, msg, arg);
 }

--- a/app/u8glib/u8g_dev_ssd1306_64x48.c
+++ b/app/u8glib/u8g_dev_ssd1306_64x48.c
@@ -128,6 +128,13 @@ uint8_t u8g_dev_ssd1306_64x48_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *
         u8g_SetChipSelect(u8g, dev, 0);
       }
       break;
+    case U8G_DEV_MSG_CONTRAST:
+      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
+      u8g_WriteByte(u8g, dev, 0x081);
+      u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) ); /* 11 Jul 2015: fixed contrast calculation */
+      u8g_SetChipSelect(u8g, dev, 0);      
+      return 1; 
     case U8G_DEV_MSG_SLEEP_ON:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_on);    
       return 1;
@@ -166,6 +173,13 @@ uint8_t u8g_dev_ssd1306_64x48_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, voi
         u8g_SetChipSelect(u8g, dev, 0);
       }
       break;
+    case U8G_DEV_MSG_CONTRAST:
+      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
+      u8g_WriteByte(u8g, dev, 0x081);
+      u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) ); /* 11 Jul 2015: fixed contrast calculation */
+      u8g_SetChipSelect(u8g, dev, 0);      
+      return 1; 
     case U8G_DEV_MSG_SLEEP_ON:
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_ssd13xx_sleep_on);    
       return 1;

--- a/app/u8glib/u8g_dev_ssd1325_nhd27oled_gr_new.c
+++ b/app/u8glib/u8g_dev_ssd1325_nhd27oled_gr_new.c
@@ -220,6 +220,7 @@ static uint8_t u8g_dev_ssd1325_nhd27oled_2x_gr_fn(u8g_t *u8g, u8g_dev_t *dev, ui
 
 U8G_PB_DEV(u8g_dev_ssd1325_nhd27oled_gr_sw_spi , WIDTH, HEIGHT, 4, u8g_dev_ssd1325_nhd27oled_gr_fn, U8G_COM_SW_SPI);
 U8G_PB_DEV(u8g_dev_ssd1325_nhd27oled_gr_hw_spi , WIDTH, HEIGHT, 4, u8g_dev_ssd1325_nhd27oled_gr_fn, U8G_COM_HW_SPI);
+U8G_PB_DEV(u8g_dev_ssd1325_nhd27oled_gr_parallel , WIDTH, HEIGHT, 4, u8g_dev_ssd1325_nhd27oled_gr_fn, U8G_COM_FAST_PARALLEL);
 
 uint8_t u8g_dev_ssd1325_nhd27oled_2x_buf[WIDTH*2] U8G_NOCOMMON ; 
 u8g_pb_t u8g_dev_ssd1325_nhd27oled_2x_pb = { {8, HEIGHT, 0, 0, 0},  WIDTH, u8g_dev_ssd1325_nhd27oled_2x_buf}; 

--- a/app/u8glib/u8g_dev_uc1611_dogm240.c
+++ b/app/u8glib/u8g_dev_uc1611_dogm240.c
@@ -43,8 +43,16 @@
 
 
 static const uint8_t u8g_dev_uc1611_dogm240_init_seq[] PROGMEM = {
-  U8G_ESC_CS(1),             // enable chip
+  U8G_ESC_CS(0),             /* disable chip */
+  U8G_ESC_ADR(0),           /* instruction mode */
+  U8G_ESC_RST(1),           /* do reset low pulse with (1*16)+2 milliseconds */
+  U8G_ESC_DLY(200),
+   U8G_ESC_CS(1),             // enable chip
   U8G_ESC_ADR(0),           // instruction mode
+  0xe2,	// system reset
+  U8G_ESC_DLY(1),
+  0x2f,	// enable internal charge pump
+  
   0xF1,     // set last COM electrode
   0x3F,     // 64-1=63
   0xF2,     // set display start line
@@ -96,16 +104,16 @@ uint8_t u8g_dev_uc1611_dogm240_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void 
       u8g_SetAddress(u8g, dev, 1);     /* data mode */
       if ( u8g_pb_WriteBuffer(pb, u8g, dev) == 0 )
         return 0;
-      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetChipSelect(u8g, dev, 0);
       }
       break;
     case U8G_DEV_MSG_CONTRAST:
-      u8g_SetChipSelect(u8g, dev, 0);
+      u8g_SetChipSelect(u8g, dev, 1);
       u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
       u8g_WriteByte(u8g, dev, 0x81);
       /* 11 Jul 2015: bugfix, github issue 339 */
       u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) );	/* set contrast from, keep gain at 0 */
-      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetChipSelect(u8g, dev, 0);
       return 1;
   }
   return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);

--- a/app/u8glib/u8g_dev_uc1611_dogxl240.c
+++ b/app/u8glib/u8g_dev_uc1611_dogxl240.c
@@ -43,8 +43,17 @@
 
 
 static const uint8_t u8g_dev_uc1611_dogxl240_init_seq[] PROGMEM = {
+  U8G_ESC_CS(0),             /* disable chip */
+  U8G_ESC_ADR(0),           /* instruction mode */
+  U8G_ESC_RST(1),           /* do reset low pulse with (1*16)+2 milliseconds */
+  U8G_ESC_DLY(200),
   U8G_ESC_CS(1),             // enable chip
   U8G_ESC_ADR(0),           // instruction mode
+  
+  0xe2,	// system reset
+  U8G_ESC_DLY(1),
+  0x2f,	// enable internal charge pump
+  
   0xF1,     // set last COM electrode
   0x7F,     // DOGXL240
   0xF2,     // set display start line
@@ -96,16 +105,16 @@ static uint8_t u8g_dev_uc1611_dogxl240_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t ms
       u8g_SetAddress(u8g, dev, 1);     /* data mode */
       if ( u8g_pb_WriteBuffer(pb, u8g, dev) == 0 )
         return 0;
-      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetChipSelect(u8g, dev, 0);
       }
       break;
     case U8G_DEV_MSG_CONTRAST:
-      u8g_SetChipSelect(u8g, dev, 0);
+      u8g_SetChipSelect(u8g, dev, 1);
       u8g_SetAddress(u8g, dev, 0);          /* instruction mode */
       u8g_WriteByte(u8g, dev, 0x81);
       /* 11 Jul 2015: bugfix, github issue 339 */
       u8g_WriteByte(u8g, dev, (*(uint8_t *)arg) );	/* set contrast from, keep gain at 0 */
-      u8g_SetChipSelect(u8g, dev, 1);
+      u8g_SetChipSelect(u8g, dev, 0);
       return 1;
   }
   return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);

--- a/app/u8glib/u8g_rot.c
+++ b/app/u8glib/u8g_rot.c
@@ -40,7 +40,7 @@ uint8_t u8g_dev_rot90_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
 uint8_t u8g_dev_rot180_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
 uint8_t u8g_dev_rot270_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
 
-uint8_t u8g_dev_rot_dummy_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
+uint8_t u8g_dev_rot_dummy_fn(u8g_t *u8g, u8g_dev_t*dev, uint8_t msg, void *arg)
 {
   return 0;
 }

--- a/app/u8glib/u8g_state.c
+++ b/app/u8glib/u8g_state.c
@@ -75,7 +75,8 @@ uint8_t global_SREG_backup;
 /*===============================================================*/
 /* AVR */
 
-#if defined(__AVR__)
+#if defined(__AVR_XMEGA__)
+#elif defined(__AVR__)
 #define U8G_ATMEGA_HW_SPI
 
 /* remove the definition for attiny */

--- a/docs/en/modules/u8g.md
+++ b/docs/en/modules/u8g.md
@@ -28,7 +28,7 @@ SPI only:
 - uc1611 - dogm240 and dogxl240 variants
 - uc1701 - dogs102 and mini12864 variants
 
-This integration is based on [v1.18.1](https://github.com/olikraus/U8glib_Arduino/releases/tag/1.18.1).
+This integration is based on [v1.19.1](https://github.com/olikraus/U8glib_Arduino/releases/tag/1.19.1).
 
 ## Overview
 ### I²C Connection
@@ -347,6 +347,9 @@ See [u8glib nextPage()](https://github.com/olikraus/u8glib/wiki/userreference#ne
 ## u8g.disp:setColorIndex()
 See [u8glib setColorIndex()](https://github.com/olikraus/u8glib/wiki/userreference#setcolortndex).
 
+## u8g.disp:setContrast()
+See [u8glib setContrast()](https://github.com/olikraus/u8glib/wiki/userreference#setcontrast).
+
 ## u8g.disp:setDefaultBackgroundColor()
 See [u8glib setDefaultBackgroundColor()](https://github.com/olikraus/u8glib/wiki/userreference#setdefaultbackgroundcolor).
 
@@ -437,7 +440,6 @@ See [u8glib undoScale()](https://github.com/olikraus/u8glib/wiki/userreference#u
 	- setCursorPos()
 	- setCursorStyle()
 - General functions
-	- setContrast()
 	- setPrintPos()
 	- setHardwareBackup()
 	- setRGB()


### PR DESCRIPTION
Fixes #1335.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Upstream u8glib saw [release 1.19.1](https://github.com/olikraus/U8glib_Arduino/releases/tag/1.19.1) which added support for contrast control on SSD1306 displays. This PR updates our u8glib integration to this release and adds the respective binding `setContrast()`.

Committers supporting this PR: Marcel
