### PR TITLE
Update to SDK 1.5.4.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,21 @@
 .NOTPARALLEL:
 
 # SDK version NodeMCU is locked to
-SDK_VER:=1.5.4
-SDK_FILE_VER:=$(SDK_VER)_16_05_20
+SDK_VER:=1.5.4.1
+
+# no patch: SDK_BASE_VER equals SDK_VER and sdk dir depends on sdk_extracted
+#SDK_BASE_VER:=SDK_VER
+#SDK_DIR_DEPENDS:=sdk_extracted
+# with patch: SDK_BASE_VER differs from SDK_VER and sdk dir depends on sdk_patched
+SDK_BASE_VER:=1.5.4
+SDK_DIR_DEPENDS:=sdk_patched
+
+SDK_FILE_VER:=$(SDK_BASE_VER)_16_05_20
 SDK_FILE_ID:=1469
 SDK_FILE_SHA1:=868784bd37d47f31d52b81f133aa1fb70c58e17d
+SDK_PATCH_VER:=$(SDK_VER)_patch_20160704
+SDK_PATCH_ID:=1572
+SDK_PATCH_SHA1:=388d9e91df74e3b49fca126da482cf822cf1ebf1
 # Ensure we search "our" SDK before the tool-chain's SDK (if any)
 TOP_DIR:=$(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 SDK_DIR:=$(TOP_DIR)/sdk/esp_iot_sdk_v$(SDK_VER)
@@ -179,16 +190,25 @@ $(BINODIR)/%.bin: $(IMAGEODIR)/%.out
 # Should be done in top-level makefile only
 #
 
-all:	sdk_extracted pre_build .subdirs $(OBJS) $(OLIBS) $(OIMAGES) $(OBINS) $(SPECIAL_MKTARGETS)
+all:	$(SDK_DIR_DEPENDS) pre_build .subdirs $(OBJS) $(OLIBS) $(OIMAGES) $(OBINS) $(SPECIAL_MKTARGETS)
 
 .PHONY: sdk_extracted
+.PHONY: sdk_patched
 
-sdk_extracted: $(TOP_DIR)/sdk/.extracted-$(SDK_VER)
+sdk_extracted: $(TOP_DIR)/sdk/.extracted-$(SDK_BASE_VER)
+sdk_patched: sdk_extracted $(TOP_DIR)/sdk/.patched-$(SDK_VER)
 
-$(TOP_DIR)/sdk/.extracted-$(SDK_VER): $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip
+$(TOP_DIR)/sdk/.extracted-$(SDK_BASE_VER): $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip
 	mkdir -p "$(dir $@)"
-	(cd "$(dir $@)" && rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK && unzip $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_VER)*.zip ESP8266_NONOS_SDK/lib/* ESP8266_NONOS_SDK/ld/eagle.rom.addr.v6.ld ESP8266_NONOS_SDK/include/* )
+	(cd "$(dir $@)" && rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK && unzip $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip ESP8266_NONOS_SDK/lib/* ESP8266_NONOS_SDK/ld/eagle.rom.addr.v6.ld ESP8266_NONOS_SDK/include/* )
 	mv $(dir $@)/ESP8266_NONOS_SDK $(dir $@)/esp_iot_sdk_v$(SDK_VER)
+	rm -f $(SDK_DIR)/lib/liblwip.a
+	touch $@
+
+$(TOP_DIR)/sdk/.patched-$(SDK_VER): $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_PATCH_VER).zip
+	mkdir -p "$(dir $@)/patch"
+	(cd "$(dir $@)/patch" && unzip $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_PATCH_VER)*.zip *.a && mv *.a $(SDK_DIR)/lib/)
+	rmdir $(dir $@)/patch
 	rm -f $(SDK_DIR)/lib/liblwip.a
 	touch $@
 
@@ -196,6 +216,11 @@ $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip:
 	mkdir -p "$(dir $@)"
 	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused http://bbs.espressif.com/download/file.php?id=$(SDK_FILE_ID) -O $@ || { rm -f "$@"; exit 1; }
 	(echo "$(SDK_FILE_SHA1)  $@" | sha1sum -c -) || { rm -f "$@"; exit 1; }
+
+$(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_PATCH_VER).zip:
+	mkdir -p "$(dir $@)"
+	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused http://bbs.espressif.com/download/file.php?id=$(SDK_PATCH_ID) -O $@ || { rm -f "$@"; exit 1; }
+	(echo "$(SDK_PATCH_SHA1)  $@" | sha1sum -c -) || { rm -f "$@"; exit 1; }
 
 clean:
 	$(foreach d, $(SUBDIRS), $(MAKE) -C $(d) clean;)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **NodeMCU 1.5.4** #
+# **NodeMCU 1.5.4.1** #
 
 [![Join the chat at https://gitter.im/nodemcu/nodemcu-firmware](https://img.shields.io/gitter/room/badges/shields.svg)](https://gitter.im/nodemcu/nodemcu-firmware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/nodemcu/nodemcu-firmware.svg)](https://travis-ci.org/nodemcu/nodemcu-firmware)
@@ -7,7 +7,7 @@
 
 ### A Lua based firmware for ESP8266 WiFi SOC
 
-NodeMCU is an [eLua](http://www.eluaproject.net/) based firmware for the [ESP8266 WiFi SOC from Espressif](http://espressif.com/en/products/esp8266/). The firmware is based on the [Espressif NON-OS SDK 1.5.4](http://bbs.espressif.com/viewtopic.php?f=46&t=2198) and uses a file system based on [spiffs](https://github.com/pellepl/spiffs). The code repository consists of 98.1% C-code that glues the thin Lua veneer to the SDK.
+NodeMCU is an [eLua](http://www.eluaproject.net/) based firmware for the [ESP8266 WiFi SOC from Espressif](http://espressif.com/en/products/esp8266/). The firmware is based on the [Espressif NON-OS SDK 1.5.4.1](http://bbs.espressif.com/viewtopic.php?f=46&t=2376) and uses a file system based on [spiffs](https://github.com/pellepl/spiffs). The code repository consists of 98.1% C-code that glues the thin Lua veneer to the SDK.
 
 The NodeMCU *firmware* is a companion project to the popular [NodeMCU dev kits](https://github.com/nodemcu/nodemcu-devkit-v1.0), ready-made open source development boards with ESP8266-12E chips.
 
@@ -90,7 +90,7 @@ Edit `app/include/user_modules.h` and comment-out the `#define` statement for mo
 Identify your firmware builds by editing `app/include/user_version.h`
 
 ```c
-#define NODE_VERSION    "NodeMCU 1.5.4+myname"
+#define NODE_VERSION    "NodeMCU 1.5.4.1+myname"
 #ifndef BUILD_DATE
 #define BUILD_DATE      "YYYYMMDD"
 #endif

--- a/app/include/user_version.h
+++ b/app/include/user_version.h
@@ -4,9 +4,9 @@
 #define NODE_VERSION_MAJOR		1U
 #define NODE_VERSION_MINOR		5U
 #define NODE_VERSION_REVISION	4U
-#define NODE_VERSION_INTERNAL   0U
+#define NODE_VERSION_INTERNAL   1U
 
-#define NODE_VERSION	"NodeMCU 1.5.4"
+#define NODE_VERSION	"NodeMCU 1.5.4.1"
 #ifndef BUILD_DATE
 #define BUILD_DATE	  "unspecified"
 #endif

--- a/app/platform/cpu_esp8266.h
+++ b/app/platform/cpu_esp8266.h
@@ -1,11 +1,13 @@
 #ifndef __CPU_ESP8266_H__
 #define __CPU_ESP8266_H__
 
+#ifndef NO_CPU_ESP8266_INCLUDE
 #include "os_type.h"
 #include "spi_flash.h"
 #include "pin_map.h"
 #include "user_config.h"
 #include "flash_api.h"
+#endif
 // Number of resources (0 if not available/not implemented)
 #define NUM_GPIO              GPIO_PIN_NUM
 #define NUM_SPI               2

--- a/app/platform/cpu_esp8266.h
+++ b/app/platform/cpu_esp8266.h
@@ -38,7 +38,8 @@
 #else
 #define FLASH_SEC_NUM 	0x80
 #endif
-#define SYS_PARAM_SEC_NUM 4
+// SDK 1.5.4.1 added 1 sector for rf_cal
+#define SYS_PARAM_SEC_NUM 5
 #define SYS_PARAM_SEC_START (FLASH_SEC_NUM - SYS_PARAM_SEC_NUM)
 
 #define INTERNAL_FLASH_SECTOR_SIZE      SPI_FLASH_SEC_SIZE

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -55,7 +55,7 @@ static bool myspiffs_set_location(spiffs_config *cfg, int align, int offset, int
   cfg->phys_addr = (cfg->phys_addr + align - 1) & ~(align - 1);
 #endif
 #ifdef SPIFFS_SIZE_1M_BOUNDARY
-  cfg->phys_size = ((0x100000 - 16384 - ( ( u32_t )cfg->phys_addr )) & ~(block_size - 1)) & 0xfffff;
+  cfg->phys_size = ((0x100000 - (SYS_PARAM_SEC_NUM * INTERNAL_FLASH_SECTOR_SIZE) - ( ( u32_t )cfg->phys_addr )) & ~(block_size - 1)) & 0xfffff;
 #else
   cfg->phys_size = (INTERNAL_FLASH_SIZE - ( ( u32_t )cfg->phys_addr )) & ~(block_size - 1);
 #endif

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -126,6 +126,51 @@ void user_rf_pre_init(void)
 #endif
 
 /******************************************************************************
+ * FunctionName : user_rf_cal_sector_set
+ * Description  : SDK just reversed 4 sectors, used for rf init data and paramters.
+ *                We add this function to force users to set rf cal sector, since
+ *                we don't know which sector is free in user's application.
+ *                sector map for last several sectors : ABCCC
+ *                A : rf cal
+ *                B : rf init data
+ *                C : sdk parameters
+ * Parameters   : none
+ * Returns      : rf cal sector
+*******************************************************************************/
+uint32
+user_rf_cal_sector_set(void)
+{
+    enum flash_size_map size_map = system_get_flash_size_map();
+    uint32 rf_cal_sec = 0;
+
+    switch (size_map) {
+        case FLASH_SIZE_4M_MAP_256_256:
+            rf_cal_sec = 128 - 5;
+            break;
+
+        case FLASH_SIZE_8M_MAP_512_512:
+            rf_cal_sec = 256 - 5;
+            break;
+
+        case FLASH_SIZE_16M_MAP_512_512:
+        case FLASH_SIZE_16M_MAP_1024_1024:
+            rf_cal_sec = 512 - 5;
+            break;
+
+        case FLASH_SIZE_32M_MAP_512_512:
+        case FLASH_SIZE_32M_MAP_1024_1024:
+            rf_cal_sec = 1024 - 5;
+            break;
+
+        default:
+            rf_cal_sec = 0;
+            break;
+    }
+
+    return rf_cal_sec;
+}
+
+/******************************************************************************
  * FunctionName : user_init
  * Description  : entry of user application, init user function here
  * Parameters   : none

--- a/docs/en/flash.md
+++ b/docs/en/flash.md
@@ -58,12 +58,13 @@ If upgrading from [SPIFFS](https://github.com/pellepl/spiffs) version 0.3.2 to 0
 
 If you flash a recent NodeMCU firmware for the first time, it's advisable that you get all accompanying files right. A typical case that often fails is when a module is upgraded from a 0.9.x firmware to the latest version built from the [NodeMCU build service](http://nodemcu-build.com). It might look like the brand new firmware is broken, but the reason for the missing Lua prompt is related to the big jump in SDK versions: Espressif changes the `esp_init_data_default.bin` for their devices along the way with the SDK. So things break when a NodeMCU firmware with a certain SDK is flashed to a module which contains init data from a previous SDK.
 
-Download SDK patch 1.5.4.1 (http://bbs.espressif.com/download/file.php?id=1572) and extract `esp_init_data_default.bin` from there. *Use this file together with the new firmware during flashing*.
+Download SDK patch 1.5.4.1 (http://bbs.espressif.com/download/file.php?id=1572) and extract `esp_init_data_default.bin` from there. *Use this file together with the new firmware during flashing*. This SDK release introduced an additional sector for RF calibration data. Espressif recommends to clear this one as well in the [release notes](http://bbs.espressif.com/viewtopic.php?f=46&t=2376). The simplest way to set up the flash from scratch is to erase the complete flash before upgrading (or downgrading) SDK versions.
 
 **esptool**
 
 For [esptool](https://github.com/themadinventor/esptool) you specify another file to download at the command line.
 ```
+esptool.py erase_flash
 esptool.py write_flash <flash options> 0x00000 <nodemcu-firmware>.bin 0x7c000 esp_init_data_default.bin
 ```
 

--- a/docs/en/flash.md
+++ b/docs/en/flash.md
@@ -58,7 +58,7 @@ If upgrading from [SPIFFS](https://github.com/pellepl/spiffs) version 0.3.2 to 0
 
 If you flash a recent NodeMCU firmware for the first time, it's advisable that you get all accompanying files right. A typical case that often fails is when a module is upgraded from a 0.9.x firmware to the latest version built from the [NodeMCU build service](http://nodemcu-build.com). It might look like the brand new firmware is broken, but the reason for the missing Lua prompt is related to the big jump in SDK versions: Espressif changes the `esp_init_data_default.bin` for their devices along the way with the SDK. So things break when a NodeMCU firmware with a certain SDK is flashed to a module which contains init data from a previous SDK.
 
-Download SDK 1.5.4 (http://bbs.espressif.com/download/file.php?id=1469) and extract `esp_init_data_default.bin` from there. *Use this file together with the new firmware during flashing*.
+Download SDK patch 1.5.4.1 (http://bbs.espressif.com/download/file.php?id=1572) and extract `esp_init_data_default.bin` from there. *Use this file together with the new firmware during flashing*.
 
 **esptool**
 

--- a/tools/spiffsimg/main.c
+++ b/tools/spiffsimg/main.c
@@ -42,6 +42,8 @@
 #include <sys/mman.h>
 #include <errno.h>
 #include "spiffs.h"
+#define NO_CPU_ESP8266_INCLUDE
+#include "../platform/cpu_esp8266.h"
 
 static spiffs fs;
 static uint8_t *flash;
@@ -267,7 +269,7 @@ int main (int argc, char *argv[])
       if (!flashsize || !used) {
 	die("Missing flashSize or Used");
       }
-      sz = flashsize - used - 4 * 4096;   // This leaves space for the parameter area
+      sz = flashsize - used - SYS_PARAM_SEC_NUM * 4096;   // This leaves space for the parameter area
       if (sz < 0x4000) {
 	die("Not enough space");
       }
@@ -276,7 +278,7 @@ int main (int argc, char *argv[])
       } else {
 	used = (used + 0x1fff) & ~0x1fff;
       }
-      sz = flashsize - used - 4 * 4096;
+      sz = flashsize - used - SYS_PARAM_SEC_NUM * 4096;
     }
     sz &= ~(0x1fff);
 


### PR DESCRIPTION
Fixes #1377.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Espressif recently announced [a patch to upgrade SDK to 1.5.4.1](http://bbs.espressif.com/viewtopic.php?f=46&t=2407):

> At the first boot up of SDK, the chip internally performs automatic RF calibration according to the conditions of the peripheral components such as the antenna. The RF calibration parameters will be retained in the predetermined sector. A lack of SDK upgrade would decrease the reliability of RF performance. Espressif strongly recommends that users upgrade the SDK to the latest version and install all the patches. The upgrade will not affect any features developed based on the original SDK.

The RF calibration data allocates an additional sector at the end of the flash. I've adjusted the `INTERNAL_FLASH_SIZE` calculation in `cpu_esp8266.h` accordingly.

On the downside **this most likely breaks 64m and 128m flash support by #1367** since these sizes are not considered by `system_get_flash_size_map()` and Espressif's recommended new user_main hook `user_rf_cal_sector_set`. I'd be happy to extend `enum flash_size_map` in `user_interface.h` accordingly if somebody confirmed how.