### PR TITLE
Enable SSL for Travis all-modules build

### DIFF
--- a/tools/pr-build.sh
+++ b/tools/pr-build.sh
@@ -9,13 +9,13 @@ cd "$TRAVIS_BUILD_DIR"/app/include || exit
 sed -E -i.bak 's@(//.*)(#define *LUA_USE_MODULES_.*)@\2@g' user_modules.h
 cat user_modules.h
 
-# disable SSL
-sed -i.bak 's@#define CLIENT_SSL_ENABLE@//#define CLIENT_SSL_ENABLE@' user_config.h
+# enable SSL
+sed -i.bak 's@//#define CLIENT_SSL_ENABLE@#define CLIENT_SSL_ENABLE@' user_config.h
 cat user_config.h
 
 cd "$TRAVIS_BUILD_DIR"/ld || exit
 # increase irom0_0_seg size for all modules build
-sed -E -i.bak 's@(.*irom0_0_seg *:.*len *=) *[^,]*(.*)@\1 0x90000\2@' nodemcu.ld
+sed -E -i.bak 's@(.*irom0_0_seg *:.*len *=) *[^,]*(.*)@\1 0xA0000\2@' nodemcu.ld
 cat nodemcu.ld
 
 # change to "root" directory no matter where the script was started from


### PR DESCRIPTION
- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

Enable SSL for the all-module build with Travis and extend irom0 once more.

Committers supporting this PR: 
