### PR TITLE
Free headers and post_data memory in disconnect callback

### DIFF
--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -233,6 +233,22 @@ static void ICACHE_FLASH_ATTR http_connect_callback( void * arg )
 	HTTPCLIENT_DEBUG( "Sending request header\n" );
 }
 
+static void http_free_req( request_args_t * req)
+{
+	if (req->buffer) {
+		os_free( req->buffer );
+	}
+	if (req->post_data) {
+		os_free( req->post_data );
+	}
+	if (req->headers) {
+		os_free( req->headers );
+	}
+	os_free( req->hostname );
+	os_free( req->method );
+	os_free( req->path );
+	os_free( req );
+}
 
 static void ICACHE_FLASH_ATTR http_disconnect_callback( void * arg )
 {
@@ -301,19 +317,7 @@ static void ICACHE_FLASH_ATTR http_disconnect_callback( void * arg )
 		{
 			req->callback_handle( body, http_status, req->buffer );
 		}
-		if (req->buffer) {
-			os_free( req->buffer );
-		}
-		if (req->post_data) {
-			os_free( req->post_data );
-		}
-		if (req->headers) {
-			os_free( req->headers );
-		}
-		os_free( req->hostname );
-		os_free( req->method );
-		os_free( req->path );
-		os_free( req );
+		http_free_req( req );
 	}
 	/* Fix memory leak. */
 	espconn_delete( conn );
@@ -360,7 +364,7 @@ static void ICACHE_FLASH_ATTR http_dns_callback( const char * hostname, ip_addr_
 		{
 			req->callback_handle( "", -1, "" );
 		}
-		os_free( req );
+		http_free_req( req );
 	}
 	else  
 	{

--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -302,7 +302,13 @@ static void ICACHE_FLASH_ATTR http_disconnect_callback( void * arg )
 			req->callback_handle( body, http_status, req->buffer );
 		}
 		if (req->buffer) {
-		  os_free( req->buffer );
+			os_free( req->buffer );
+		}
+		if (req->post_data) {
+			os_free( req->post_data );
+		}
+		if (req->headers) {
+			os_free( req->headers );
 		}
 		os_free( req->hostname );
 		os_free( req->method );


### PR DESCRIPTION
Presumably fixes #1383.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

`http_disconnect_callback()` misses to free heap for the `headers` and `post_data` members. This can lead to memory leaks in scenarios where these haven't been sent to the server prior to the disconnect event, eg. when server is unavailable.

Note: I've created the PR based on code review only. It sill needs to be proven that the reported leak is fixed now and there's no other spill.

Committers supporting this PR: 
