### PR TITLE
[ws2812] Removes buffer:write() as ws2812.write() handles buffers.

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -396,17 +396,6 @@ static int ws2812_buffer_size(lua_State* L) {
   return 1;
 }
 
-static int ws2812_buffer_write(lua_State* L) {
-  ws2812_buffer * buffer = (ws2812_buffer*)lua_touserdata(L, 1);
-
-  luaL_argcheck(L, buffer && buffer->canary == CANARY_VALUE, 1, "ws2812.buffer expected");
-
-  // Send the buffer
-  ws2812_write_data(buffer->values, buffer->colorsPerLed*buffer->size, 0, 0);
-
-  return 0;
-}
-
 static const LUA_REG_TYPE ws2812_buffer_map[] =
 {
   { LSTRKEY( "fade" ),    LFUNCVAL( ws2812_buffer_fade )},
@@ -415,7 +404,6 @@ static const LUA_REG_TYPE ws2812_buffer_map[] =
   { LSTRKEY( "set" ),     LFUNCVAL( ws2812_buffer_set )},
   { LSTRKEY( "size" ),    LFUNCVAL( ws2812_buffer_size )},
   { LSTRKEY( "shift" ),   LFUNCVAL( ws2812_buffer_shift )},
-  { LSTRKEY( "write" ),   LFUNCVAL( ws2812_buffer_write )},
   { LSTRKEY( "__index" ), LROVAL( ws2812_buffer_map )},
   { LNILKEY, LNILVAL}
 };

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -77,11 +77,11 @@ For this purpose, the ws2812 library offers a read/write buffer.
 Led chaser with a RGBW strip
 ```lua
 ws2812.init()
-local i, b = 0, ws2812.newBuffer(300, 4); b:fill(0, 0, 0, 0); tmr.alarm(0, 50, 1, function()
+local i, buffer = 0, ws2812.newBuffer(300, 4); buffer:fill(0, 0, 0, 0); tmr.alarm(0, 50, 1, function()
         i=i+1
-        b:fade(2)
-        b:set(i%b:size()+1, 0, 0, 0, 255)
-        ws2812.write(b)
+        buffer:fade(2)
+        buffer:set(i%buffer:size()+1, 0, 0, 0, 255)
+        ws2812.write(buffer)
 end)
 ```
 
@@ -112,8 +112,11 @@ Return the value at the given position
 
 #### Example
 ```lua
-buffer:get(2) -- return the color of the second led
+buffer = ws2812.newBuffer(32, 4)
+print(buffer:get(1))
+0	0	0	0
 ```
+
 ## ws2812.buffer:set()
 Set the value at the given position
 
@@ -122,21 +125,29 @@ Set the value at the given position
 
 #### Parameters
  - `index` position in the buffer (1 for the first led)
- - `color` bytes of the color
+ - `color` payload of the color
+
+Payload could be:
+- `number, number, ...` you should pass as many arguments as `bytesPerLed`
+- `table` should contains `bytesPerLed` numbers
+- `string` should contains `bytesPerLed` bytes
 
 #### Returns
 `nil`
 
 #### Example
 ```lua
+buffer = ws2812.newBuffer(32, 3)
 buffer:set(1, 255, 0, 0) -- set the first led green for a RGB strip
 ```
 
 ```lua
-buffer:set(1, {255, 0, 0}) -- set the first led green for a RGB strip
+buffer = ws2812.newBuffer(32, 4)
+buffer:set(1, {0, 0, 0, 255}) -- set the first led white for a RGBW strip
 ```
 
 ```lua
+buffer = ws2812.newBuffer(32, 3)
 buffer:set(1, string.char(255, 0, 0)) -- set the first led green for a RGB strip
 ```
 
@@ -160,7 +171,7 @@ The number of given bytes must match the number of bytesPerLed of the buffer
 `buffer:fill(color)`
 
 #### Parameters
- - `color` bytes of the color
+ - `color` bytes of the color, you should pass as many arguments as `bytesPerLed`
 
 #### Returns
 `nil`
@@ -169,6 +180,7 @@ The number of given bytes must match the number of bytesPerLed of the buffer
 ```lua
 buffer:fill(0, 0, 0) -- fill the buffer with black for a RGB strip
 ```
+
 ## ws2812.buffer:fade()
 Fade in or out. Defaults to out. Multiply or divide each byte of each led with/by the given value. Useful for a fading effect. 
 
@@ -204,15 +216,3 @@ Shift the content of the buffer in positive or negative direction. This allows s
 ```lua
 buffer:shift(3)
 ```
-
-## ws2812.buffer:write()
-Output the buffer to the led strip
-
-#### Syntax
-`buffer:write()`
-
-#### Parameters
-none
-
-#### Returns
-`nil`


### PR DESCRIPTION
Fixes #1310

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.