### PR TITLE
Change dhcp_msg struct to avoid crash

### DIFF
--- a/app/include/lwip/app/dhcpserver.h
+++ b/app/include/lwip/app/dhcpserver.h
@@ -7,6 +7,7 @@ typedef struct dhcps_state{
         sint16_t state;
 } dhcps_state;
 
+//#define OPTIONS_HARDCODE
 // ����dhcpclient�Զ����һ��DHCP msg�ṹ��
 typedef struct dhcps_msg {
         uint8_t op, htype, hlen, hops;
@@ -19,7 +20,12 @@ typedef struct dhcps_msg {
         uint8_t chaddr[16];
         uint8_t sname[64];
         uint8_t file[128];
-        uint8_t options[312];
+
+#ifdef OPTIONS_HARDCODE
+        uint8_t options[532]; // = (3 * 256) - 236   -> to avoid crash in dhcp big packages
+#else
+        uint8_t *options;
+#endif
 }dhcps_msg;
 
 #ifndef LWIP_OPEN_SRC

--- a/app/include/lwip/app/dhcpserver.h
+++ b/app/include/lwip/app/dhcpserver.h
@@ -7,7 +7,7 @@ typedef struct dhcps_state{
         sint16_t state;
 } dhcps_state;
 
-//#define OPTIONS_HARDCODE
+//#define DHCP_OPTIONS_HARDCODE
 // ����dhcpclient�Զ����һ��DHCP msg�ṹ��
 typedef struct dhcps_msg {
         uint8_t op, htype, hlen, hops;
@@ -21,8 +21,9 @@ typedef struct dhcps_msg {
         uint8_t sname[64];
         uint8_t file[128];
 
-#ifdef OPTIONS_HARDCODE
-        uint8_t options[532]; // = (3 * 256) - 236   -> to avoid crash in dhcp big packages
+
+#ifdef DHCP_OPTIONS_HARDCODE
+        uint8_t options[532]; // 312
 #else
         uint8_t *options;
 #endif

--- a/app/lwip/app/dhcpserver.c
+++ b/app/lwip/app/dhcpserver.c
@@ -13,6 +13,8 @@
 
 #include "user_interface.h"
 
+#include "../../libc/c_stdio.h"
+
 #ifdef MEMLEAK_DEBUG
 static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
 #endif
@@ -34,6 +36,8 @@ static uint8 offer = 0xFF;
 static bool renew = false;
 #define DHCPS_LEASE_TIME_DEF	(120)
 uint32 dhcps_lease_time = DHCPS_LEASE_TIME_DEF;  //minute
+
+uint16 sizeAux = 404;
 /******************************************************************************
  * FunctionName : node_insert_to_list
  * Description  : insert the node to the list
@@ -112,7 +116,6 @@ void ICACHE_FLASH_ATTR node_remove_from_list(list_node **phead, list_node* pdele
 ///////////////////////////////////////////////////////////////////////////////////
 static uint8_t* ICACHE_FLASH_ATTR add_msg_type(uint8_t *optptr, uint8_t type)
 {
-
         *optptr++ = DHCP_OPTION_MSG_TYPE;
         *optptr++ = 1;
         *optptr++ = type;
@@ -238,7 +241,6 @@ static uint8_t* ICACHE_FLASH_ATTR add_offer_options(uint8_t *optptr)
 ///////////////////////////////////////////////////////////////////////////////////
 static uint8_t* ICACHE_FLASH_ATTR add_end(uint8_t *optptr)
 {
-
         *optptr++ = DHCP_OPTION_END;
         return optptr;
 }
@@ -247,7 +249,7 @@ static uint8_t* ICACHE_FLASH_ATTR add_end(uint8_t *optptr)
 static void ICACHE_FLASH_ATTR create_msg(struct dhcps_msg *m)
 {
         struct ip_addr client;
-
+        c_printf("\ncreate_msg");
         client.addr = *( (uint32_t *) &client_address);
 
         m->op = DHCP_REPLY;
@@ -284,13 +286,18 @@ static void ICACHE_FLASH_ATTR send_offer(struct dhcps_msg *m)
 	    u16_t cnt=0;
 	    u16_t i;
 		err_t SendOffer_err_t;
+		c_printf("\nsend_offer");
         create_msg(m);
 
         end = add_msg_type(&m->options[4], DHCPOFFER);
         end = add_offer_options(end);
         end = add_end(end);
-
+#ifdef OPTIONS_HARDCODE
+	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) + sizeAux, PBUF_RAM);
+#else
 	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg), PBUF_RAM);
+#endif
+
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_offer>>p->ref = %d\n", p->ref);
 #endif
@@ -351,12 +358,17 @@ static void ICACHE_FLASH_ATTR send_nak(struct dhcps_msg *m)
 	    u16_t cnt=0;
 	    u16_t i;
 		err_t SendNak_err_t;
+		c_printf("\nsend_nack");
         create_msg(m);
 
         end = add_msg_type(&m->options[4], DHCPNAK);
         end = add_end(end);
-
+#ifdef OPTIONS_HARDCODE
+	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) + sizeAux, PBUF_RAM);
+#else
 	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg), PBUF_RAM);
+#endif
+
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_nak>>p->ref = %d\n", p->ref);
 #endif
@@ -417,13 +429,18 @@ static void ICACHE_FLASH_ATTR send_ack(struct dhcps_msg *m)
 	    u16_t cnt=0;
 	    u16_t i;
 		err_t SendAck_err_t;
+		c_printf("\nsend_ack");
         create_msg(m);
 
         end = add_msg_type(&m->options[4], DHCPACK);
         end = add_offer_options(end);
         end = add_end(end);
 	    
+#ifdef OPTIONS_HARDCODE
+	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) + sizeAux, PBUF_RAM);
+#else
 	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg), PBUF_RAM);
+#endif
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_ack>>p->ref = %d\n", p->ref);
 #endif
@@ -481,28 +498,33 @@ static void ICACHE_FLASH_ATTR send_ack(struct dhcps_msg *m)
 ///////////////////////////////////////////////////////////////////////////////////
 static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
 {
+    c_printf("\nhdcp_options:addr(options) = %d(0x%x)", optptr, optptr);
         struct ip_addr client;
     	bool is_dhcp_parse_end = false;
     	struct dhcps_state s;
-
         client.addr = *( (uint32_t *) &client_address);// Ҫ�����DHCP�ͻ��˵�IP
-
         u8_t *end = optptr + len;
         u16_t type = 0;
 
         s.state = DHCPS_STATE_IDLE;
 
-        while (optptr < end) {
+        while (optptr < end)
+        {
+
 #if DHCPS_DEBUG
         	os_printf("dhcps: (sint16_t)*optptr = %d\n", (sint16_t)*optptr);
 #endif
-        	switch ((sint16_t) *optptr) {
+        	c_printf("\noptptr = %d(%x)", optptr,optptr);
+        	switch ((sint16_t) *optptr)
+        	{
 
                 case DHCP_OPTION_MSG_TYPE:	//53
+                	c_printf("\nMSG_TYPE");
                         type = *(optptr + 2);
                         break;
 
                 case DHCP_OPTION_REQ_IPADDR://50
+                	c_printf("\nREQ_IPADDR");
                         if( os_memcmp( (char *) &client.addr, (char *) optptr+2,4)==0 ) {
 #if DHCPS_DEBUG
                     		os_printf("dhcps: DHCP_OPTION_REQ_IPADDR = 0 ok\n");
@@ -516,6 +538,7 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
                         }
                         break;
                 case DHCP_OPTION_END:
+                	c_printf("\nOPTION_END");
 			            {
 			                is_dhcp_parse_end = true;
 			            }
@@ -523,13 +546,16 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
             }
 
 		    if(is_dhcp_parse_end){
+		    	c_printf("\nBREAK");
 		            break;
 		    }
-
+		    c_printf("\noptptr = %d(%x)", optptr,optptr);
             optptr += optptr[1] + 2;
         }
+        c_printf("\nswitch");
 
-        switch (type){
+        switch (type)
+        {
         
         	case DHCPDISCOVER://1
                 s.state = DHCPS_STATE_OFFER;
@@ -556,7 +582,8 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
 #if DHCPS_DEBUG
             	os_printf("dhcps: DHCPD_STATE_IDLE\n");
 #endif
-                break;
+                break;  //c_printf("dhcp_parse_reply:OUT");
+
 
         	case DHCPRELEASE://7
                 s.state = DHCPS_STATE_RELEASE;
@@ -574,157 +601,126 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
 ///////////////////////////////////////////////////////////////////////////////////
 static sint16_t ICACHE_FLASH_ATTR parse_msg(struct dhcps_msg *m, u16_t len)
 {
-		if(os_memcmp((char *)m->options,
-              &magic_cookie,
-              sizeof(magic_cookie)) == 0){
+	c_printf("\nparse_msg:addr(m) = %d(0x%x)", m, m);
+	c_printf("\nparse_msg:addr(options) = %d(0x%x)", m->options, m->options);
+	c_printf("\nmagic_cookie: 0x%x%x%x%x = 0x63538263", m->options[3], m->options[2], m->options[1], m->options[0]);
+	if(os_memcmp((char *)&m->options, &magic_cookie, sizeof(magic_cookie)) == 0)
+	{
 #if DHCPS_DEBUG
-        	os_printf("dhcps: len = %d\n", len);
+		os_printf("dhcps: len = %d\n", len);
 #endif
-	        /*
-         	 * ��¼��ǰ��xid���ﴦ���?
-         	 * �˺�ΪDHCP�ͻ����������û�ͳһ��ȡIPʱ��
-         	*/
-//	        if((old_xid[0] == 0) &&
-//	           (old_xid[1] == 0) &&
-//	           (old_xid[2] == 0) &&
-//	           (old_xid[3] == 0)){
-//	            /*
-//	             * old_xidδ��¼�κ����?
-//	             * �϶��ǵ�һ��ʹ��
-//	            */
-//	            os_memcpy((char *)old_xid, (char *)m->xid, sizeof(m->xid));
-//	        }else{
-//	            /*
-//	             * ���δ����DHCP msg��Я���xid���ϴμ�¼�Ĳ�ͬ��
-//	             * �϶�Ϊ��ͬ��DHCP�ͻ��˷��ͣ���ʱ����Ҫ����Ŀͻ���IP
-//	             * ���� 192.168.4.100(0x6404A8C0) <--> 192.168.4.200(0xC804A8C0)
-//	             *
-//	            */
-//	            if(os_memcmp((char *)old_xid, (char *)m->xid, sizeof(m->xid)) != 0){
-	                /*
-                 	 * ��¼���ε�xid�ţ�ͬʱ�����IP����
-                 	*/
-	                struct ip_addr addr_tmp;    
-//	                os_memcpy((char *)old_xid, (char *)m->xid, sizeof(m->xid));
+		struct ip_addr addr_tmp;
+		struct dhcps_pool *pdhcps_pool = NULL;
+		list_node *pnode = NULL;
+		list_node *pback_node = NULL;
+		struct ip_addr first_address;
+		bool flag = false;
 
-//	                {
-						struct dhcps_pool *pdhcps_pool = NULL;
-						list_node *pnode = NULL;
-						list_node *pback_node = NULL;
-						struct ip_addr first_address;
-						bool flag = false;
+		first_address.addr = dhcps_lease.start_ip.addr;
+		client_address.addr = client_address_plus.addr;
+		renew = false;
 
-//						POOL_START:
-						first_address.addr = dhcps_lease.start_ip.addr;
-						client_address.addr = client_address_plus.addr;
-						renew = false;
-//							addr_tmp.addr =  htonl(client_address_plus.addr);
-//							addr_tmp.addr++;
-//							client_address_plus.addr = htonl(addr_tmp.addr);
-						for (pback_node = plist; pback_node != NULL;pback_node = pback_node->pnext) {
-							pdhcps_pool = pback_node->pnode;
-							if (os_memcmp(pdhcps_pool->mac, m->chaddr, sizeof(pdhcps_pool->mac)) == 0){
-//									os_printf("the same device request ip\n");
-								if (os_memcmp(&pdhcps_pool->ip.addr, m->ciaddr, sizeof(pdhcps_pool->ip.addr)) == 0) {
-								    renew = true;
-								}
-								client_address.addr = pdhcps_pool->ip.addr;
-								pdhcps_pool->lease_timer = DHCPS_LEASE_TIMER;
-								pnode = pback_node;
-								goto POOL_CHECK;
-							} else if (pdhcps_pool->ip.addr == client_address_plus.addr){
-//									client_address.addr = client_address_plus.addr;
-//									os_printf("the ip addr has been request\n");
-								addr_tmp.addr = htonl(client_address_plus.addr);
-								addr_tmp.addr++;
-								client_address_plus.addr = htonl(addr_tmp.addr);
-								client_address.addr = client_address_plus.addr;
-							}
+		for (pback_node = plist; pback_node != NULL;pback_node = pback_node->pnext)
+		{
+			pdhcps_pool = pback_node->pnode;
+			if (os_memcmp(pdhcps_pool->mac, m->chaddr, sizeof(pdhcps_pool->mac)) == 0){
+				if (os_memcmp(&pdhcps_pool->ip.addr, m->ciaddr, sizeof(pdhcps_pool->ip.addr)) == 0) {
+					renew = true;
+				}
+				client_address.addr = pdhcps_pool->ip.addr;
+				pdhcps_pool->lease_timer = DHCPS_LEASE_TIMER;
+				pnode = pback_node;
+				goto POOL_CHECK;
+			} else if (pdhcps_pool->ip.addr == client_address_plus.addr){
+				addr_tmp.addr = htonl(client_address_plus.addr);
+				addr_tmp.addr++;
+				client_address_plus.addr = htonl(addr_tmp.addr);
+				client_address.addr = client_address_plus.addr;
+			}
 
-							if(flag == false) { // search the fisrt unused ip
-                                if(first_address.addr < pdhcps_pool->ip.addr) {
-                                    flag = true;
-                                } else {
-                                    addr_tmp.addr = htonl(first_address.addr);
-                                    addr_tmp.addr++;
-                                    first_address.addr = htonl(addr_tmp.addr);
-                                }
-							}
-						}
-						if (client_address_plus.addr > dhcps_lease.end_ip.addr) {
-						    client_address.addr = first_address.addr;
-						}
-						if (client_address.addr > dhcps_lease.end_ip.addr) {
-						    client_address_plus.addr = dhcps_lease.start_ip.addr;
-						    pdhcps_pool = NULL;
-						    pnode = NULL;
-						} else {
-						    pdhcps_pool = (struct dhcps_pool *)os_zalloc(sizeof(struct dhcps_pool));
-						    pdhcps_pool->ip.addr = client_address.addr;
-						    os_memcpy(pdhcps_pool->mac, m->chaddr, sizeof(pdhcps_pool->mac));
-						    pdhcps_pool->lease_timer = DHCPS_LEASE_TIMER;
-						    pnode = (list_node *)os_zalloc(sizeof(list_node ));
-						    pnode->pnode = pdhcps_pool;
-						    pnode->pnext = NULL;
-						    node_insert_to_list(&plist,pnode);
-						    if (client_address.addr == dhcps_lease.end_ip.addr) {
-						        client_address_plus.addr = dhcps_lease.start_ip.addr;
-						    } else {
-                                addr_tmp.addr = htonl(client_address.addr);
-                                addr_tmp.addr++;
-                                client_address_plus.addr = htonl(addr_tmp.addr);
-						    }
-						}
+			if(flag == false) { // search the fisrt unused ip
+				if(first_address.addr < pdhcps_pool->ip.addr) {
+					flag = true;
+				} else {
+					addr_tmp.addr = htonl(first_address.addr);
+					addr_tmp.addr++;
+					first_address.addr = htonl(addr_tmp.addr);
+				}
+			}
+		}
 
-						POOL_CHECK:
-						if ((client_address.addr > dhcps_lease.end_ip.addr) || (ip_addr_isany(&client_address))){
-                            os_printf("client_address_plus.addr %x %d\n", client_address_plus.addr, system_get_free_heap_size());
-						    if(pnode != NULL) {
-						        node_remove_from_list(&plist,pnode);
-						        os_free(pnode);
-						        pnode = NULL;
-						    }
+		if (client_address_plus.addr > dhcps_lease.end_ip.addr) {
+			client_address.addr = first_address.addr;
+		}
+		if (client_address.addr > dhcps_lease.end_ip.addr) {
+			client_address_plus.addr = dhcps_lease.start_ip.addr;
+			pdhcps_pool = NULL;
+			pnode = NULL;
+		} else {
+			pdhcps_pool = (struct dhcps_pool *)os_zalloc(sizeof(struct dhcps_pool));
+			pdhcps_pool->ip.addr = client_address.addr;
+			os_memcpy(pdhcps_pool->mac, m->chaddr, sizeof(pdhcps_pool->mac));
+			pdhcps_pool->lease_timer = DHCPS_LEASE_TIMER;
+			pnode = (list_node *)os_zalloc(sizeof(list_node ));
+			pnode->pnode = pdhcps_pool;
+			pnode->pnext = NULL;
+			node_insert_to_list(&plist,pnode);
+			if (client_address.addr == dhcps_lease.end_ip.addr) {
+				client_address_plus.addr = dhcps_lease.start_ip.addr;
+			} else {
+				addr_tmp.addr = htonl(client_address.addr);
+				addr_tmp.addr++;
+				client_address_plus.addr = htonl(addr_tmp.addr);
+			}
+		}
 
-						    if (pdhcps_pool != NULL) {
-						        os_free(pdhcps_pool);
-						        pdhcps_pool = NULL;
-						    }
-//							client_address_plus.addr = dhcps_lease.start_ip.addr;
-							return 4;
-						}
+		POOL_CHECK:
+		if ((client_address.addr > dhcps_lease.end_ip.addr) || (ip_addr_isany(&client_address))){
+			os_printf("client_address_plus.addr %x %d\n", client_address_plus.addr, system_get_free_heap_size());
+			if(pnode != NULL) {
+				node_remove_from_list(&plist,pnode);
+				os_free(pnode);
+				pnode = NULL;
+			}
 
-						sint16_t ret = parse_options(&m->options[4], len);;
+			if (pdhcps_pool != NULL) {
+				os_free(pdhcps_pool);
+				pdhcps_pool = NULL;
+			}
+			return 4;
+		}
 
-						if(ret == DHCPS_STATE_RELEASE) {
-						    if(pnode != NULL) {
-						        node_remove_from_list(&plist,pnode);
-						        os_free(pnode);
-						        pnode = NULL;
-						    }
+		sint16_t ret = parse_options(&m->options[4], len);
 
-						    if (pdhcps_pool != NULL) {
-						        os_free(pdhcps_pool);
-						        pdhcps_pool = NULL;
-						    }
-						    os_memset(&client_address,0x0,sizeof(client_address));
-						}
+		if(ret == DHCPS_STATE_RELEASE)
+		{
+			if(pnode != NULL) {
+				node_remove_from_list(&plist,pnode);//ret
+				os_free(pnode);
+				pnode = NULL;
+			}
 
-						if (wifi_softap_set_station_info(m->chaddr, &client_address) == false) {
-						    return 0;
-						}
-//	                }
+			if (pdhcps_pool != NULL) {
+				os_free(pdhcps_pool);
+				pdhcps_pool = NULL;
+			}
+			os_memset(&client_address,0x0,sizeof(client_address));
+		}
+
+		if (wifi_softap_set_station_info(m->chaddr, &client_address) == false)
+		{
+			return 0;
+		}
 
 #if DHCPS_DEBUG
-	                os_printf("dhcps: xid changed\n");
-	                os_printf("dhcps: client_address.addr = %x\n", client_address.addr);
+				os_printf("dhcps: xid changed\n");
+				os_printf("dhcps: client_address.addr = %x\n", client_address.addr);
 #endif
-	               
-//	            }
-	            
-//	        }
-	        return ret;
-	    }
-        return 0;
+
+		return ret;
+	}
+	c_printf("\nparse_msg; 11");
+	return 0;
 }
 ///////////////////////////////////////////////////////////////////////////////////
 /*
@@ -750,47 +746,68 @@ static void ICACHE_FLASH_ATTR handle_dhcp(void *arg,
 	    u16_t dhcps_msg_cnt = 0;
 	    u8_t *p_dhcps_msg = NULL;
 	    u8_t *data = NULL;
+	    u8_t Aux[4];
+	    u16_t j;
+	    u16_t dhcpHeaderLen;
 
 #if DHCPS_DEBUG
     	os_printf("dhcps: handle_dhcp-> receive a packet\n");
 #endif
-	    if (p==NULL) return;
-
-	    pmsg_dhcps = (struct dhcps_msg *)os_zalloc(sizeof(struct dhcps_msg));
-	    if (NULL == pmsg_dhcps){
-	    	pbuf_free(p);
+	    if (p==NULL)
 	    	return;
-	    }
-	    p_dhcps_msg = (u8_t *)pmsg_dhcps;
-		tlen = p->tot_len;
-	    data = p->payload;
+	    tlen = p->tot_len;
+	    sizeAux = tlen;
+#ifdef OPTIONS_HARDCODE
+		pmsg_dhcps = (struct dhcps_msg *)os_zalloc(sizeof(struct dhcps_msg));
+#else
+		pmsg_dhcps = (struct dhcps_msg *)os_zalloc(sizeof(struct dhcps_msg) + tlen);
+		pmsg_dhcps->options = (uint8_t*)&pmsg_dhcps->file[128];
+#endif
+		c_printf("\nhandle_hdcp:addr(pmsg_dhcps) = %d(0x%x)", pmsg_dhcps, pmsg_dhcps);
+		c_printf("\nhandle_hdcp:addr(options)    = %d(0x%x)", pmsg_dhcps->options, pmsg_dhcps->options);
+		dhcpHeaderLen = sizeof(struct dhcps_msg) - sizeof(pmsg_dhcps->options);
+
+		if (NULL == pmsg_dhcps)
+		{
+			pbuf_free(p);
+			return;
+		}
+
+
+		p_dhcps_msg = (u8_t *)pmsg_dhcps;
+		data = p->payload;
 
 #if DHCPS_DEBUG
-	    os_printf("dhcps: handle_dhcp-> p->tot_len = %d\n", tlen);
-	    os_printf("dhcps: handle_dhcp-> p->len = %d\n", p->len);
-#endif		
+		os_printf("dhcps: handle_dhcp-> p->tot_len = %d\n", tlen);
+		os_printf("dhcps: handle_dhcp-> p->len = %d\n", p->len);
+#endif
 
-	    for(i=0; i<p->len; i++){
-	        p_dhcps_msg[dhcps_msg_cnt++] = data[i];
-#if DHCPS_DEBUG					
+		/*for(i = 0; i < p->len ; i++)
+		{
+			p_dhcps_msg[dhcps_msg_cnt++] = data[i];
+#if DHCPS_DEBUG
 			os_printf("%02x ",data[i]);
 			if((i+1)%16 == 0){
 				os_printf("\n");
 			}
 #endif
-	    }
-		
-		if(p->next != NULL) {
+		}*/
+		os_memcpy(p_dhcps_msg, data, dhcpHeaderLen);
+		os_memcpy(pmsg_dhcps->options, &data[dhcpHeaderLen], p->len - dhcpHeaderLen);
+
+		if(p->next != NULL)
+		{
 #if DHCPS_DEBUG
-	        os_printf("dhcps: handle_dhcp-> p->next != NULL\n");
-	        os_printf("dhcps: handle_dhcp-> p->next->tot_len = %d\n",p->next->tot_len);
-	        os_printf("dhcps: handle_dhcp-> p->next->len = %d\n",p->next->len);
+			os_printf("dhcps: handle_dhcp-> p->next != NULL\n");
+			os_printf("dhcps: handle_dhcp-> p->next->tot_len = %d\n",p->next->tot_len);
+			os_printf("dhcps: handle_dhcp-> p->next->len = %d\n",p->next->len);
 #endif
-			
-	        data = p->next->payload;
-	        for(i=0; i<p->next->len; i++){
-	            p_dhcps_msg[dhcps_msg_cnt++] = data[i];
-#if DHCPS_DEBUG					
+
+			data = p->next->payload;
+			for(i = 0; i < p->next->len; i++)
+			{
+				p_dhcps_msg[dhcps_msg_cnt++] = data[i];
+#if DHCPS_DEBUG
 				os_printf("%02x ",data[i]);
 				if((i+1)%16 == 0){
 					os_printf("\n");
@@ -798,43 +815,47 @@ static void ICACHE_FLASH_ATTR handle_dhcp(void *arg,
 #endif
 			}
 		}
-
 		/*
-	     * DHCP �ͻ���������Ϣ����
-	    */
+		 * DHCP �ͻ���������Ϣ����
+		*/
 #if DHCPS_DEBUG
-    	os_printf("dhcps: handle_dhcp-> parse_msg(p)\n");
+		os_printf("dhcps: handle_dhcp-> parse_msg(p)\n");
 #endif
-		
-        switch(parse_msg(pmsg_dhcps, tlen - 240)) {
-
-	        case DHCPS_STATE_OFFER://1
-#if DHCPS_DEBUG            
-            	 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_OFFER\n");
-#endif			
-	             send_offer(pmsg_dhcps);
-	             break;
-	        case DHCPS_STATE_ACK://3
+		c_printf("\nhandle_hdcp:magic_cookie = 0x%x%x%x%x", pmsg_dhcps->file[131], pmsg_dhcps->file[130],pmsg_dhcps->file[129],pmsg_dhcps->file[128]);
+		//pmsg_dhcps->options = (uint8_t*)&pmsg_dhcps->file[128];
+		//c_printf("\nhandle_hdcp:magic_cookie = 0x%x%x%x%x", pmsg_dhcps->file[131], pmsg_dhcps->file[130],pmsg_dhcps->file[129],pmsg_dhcps->file[128]);
+		c_printf("\nhandle_hdcp:addr(options) = %d(0x%x)", pmsg_dhcps->options, pmsg_dhcps->options);
+		c_printf("\nhandle_hdcp:options = (0x%x%x%x%x)", pmsg_dhcps->options[3], pmsg_dhcps->options[2], pmsg_dhcps->options[1], pmsg_dhcps->options[0]);
+		switch(parse_msg(pmsg_dhcps, tlen - 240))
+		{
+			case DHCPS_STATE_OFFER://1
 #if DHCPS_DEBUG
-            	 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_ACK\n");
-#endif			
-	             send_ack(pmsg_dhcps);
-	             break;
-	        case DHCPS_STATE_NAK://4
-#if DHCPS_DEBUG            
-            	 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_NAK\n");
+				 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_OFFER\n");
 #endif
-	             send_nak(pmsg_dhcps);
-	             break;
+				 send_offer(pmsg_dhcps);
+				 break;
+			case DHCPS_STATE_ACK://3
+#if DHCPS_DEBUG
+				 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_ACK\n");
+#endif
+				 send_ack(pmsg_dhcps);
+				 break;
+			case DHCPS_STATE_NAK://4
+#if DHCPS_DEBUG
+				 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_NAK\n");
+#endif
+				 send_nak(pmsg_dhcps);
+				 break;
 			default :
 				 break;
-        }
+		}
 #if DHCPS_DEBUG
-    	os_printf("dhcps: handle_dhcp-> pbuf_free(p)\n");
+		os_printf("dhcps: handle_dhcp-> pbuf_free(p)\n");
 #endif
-        pbuf_free(p);
-        os_free(pmsg_dhcps);
-        pmsg_dhcps = NULL;
+		pbuf_free(p);
+		os_free(pmsg_dhcps);
+		pmsg_dhcps = NULL;
+
 }
 ///////////////////////////////////////////////////////////////////////////////////
 static void ICACHE_FLASH_ATTR wifi_softap_init_dhcps_lease(uint32 ip)
@@ -883,7 +904,6 @@ static void ICACHE_FLASH_ATTR wifi_softap_init_dhcps_lease(uint32 ip)
 void ICACHE_FLASH_ATTR dhcps_start(struct ip_info *info)
 {
 	struct netif * apnetif = (struct netif *)eagle_lwip_getif(0x01);
-    
 	if(apnetif->dhcps_pcb != NULL) {
         udp_remove(apnetif->dhcps_pcb);
     }
@@ -912,7 +932,6 @@ void ICACHE_FLASH_ATTR dhcps_start(struct ip_info *info)
 void ICACHE_FLASH_ATTR dhcps_stop(void)
 {
 	struct netif * apnetif = (struct netif *)eagle_lwip_getif(0x01);
-
 	udp_disconnect(pcb_dhcps);
 //	dhcps_lease_flag = true;
     if(apnetif->dhcps_pcb != NULL) {
@@ -950,7 +969,6 @@ bool ICACHE_FLASH_ATTR wifi_softap_set_dhcps_lease(struct dhcps_lease *please)
 	uint32 end_ip = 0;
 
 	uint8 opmode = wifi_get_opmode();
-
 	if (opmode == STATION_MODE || opmode == NULL_MODE) {
 		return false;
 	}
@@ -1000,7 +1018,6 @@ bool ICACHE_FLASH_ATTR wifi_softap_set_dhcps_lease(struct dhcps_lease *please)
 bool ICACHE_FLASH_ATTR wifi_softap_get_dhcps_lease(struct dhcps_lease *please)
 {
 	uint8 opmode = wifi_get_opmode();
-
 	if (opmode == STATION_MODE || opmode == NULL_MODE) {
 		return false;
 	}
@@ -1109,7 +1126,6 @@ bool ICACHE_FLASH_ATTR wifi_softap_set_dhcps_offer_option(uint8 level, void* opt
 bool ICACHE_FLASH_ATTR wifi_softap_set_dhcps_lease_time(uint32 minute)
 {
     uint8 opmode = wifi_get_opmode();
-
     if (opmode == STATION_MODE || opmode == NULL_MODE) {
         return false;
     }
@@ -1128,7 +1144,6 @@ bool ICACHE_FLASH_ATTR wifi_softap_set_dhcps_lease_time(uint32 minute)
 bool ICACHE_FLASH_ATTR wifi_softap_reset_dhcps_lease_time(void)
 {
     uint8 opmode = wifi_get_opmode();
-
     if (opmode == STATION_MODE || opmode == NULL_MODE) {
         return false;
     }


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

The struct dhcp_msg was changed, because when the ESP receives a  big dhcp package it crashes. The original code, reservs only 312 byte to DHCP OPTIONS. I found many devices that send more than 236+312 bytes.
To fix this problem, I used dinamical allocation for uint8_t *options;

Committers supporting this PR: leave blank