### PR TITLE
Change 'formatting file system' message

### DIFF
--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -101,7 +101,7 @@ void nodemcu_init(void)
 #if defined ( BUILD_SPIFFS )
     if (!fs_mount()) {
         // Failed to mount -- try reformat
-	c_printf("Formatting file system.\n");
+	c_printf("Formatting file system. Please wait...\n");
         if (!fs_format()) {
             NODE_ERR( "\n*** ERROR ***: unable to format. FS might be compromised.\n" );
             NODE_ERR( "It is advised to re-flash the NodeMCU image.\n" );


### PR DESCRIPTION
The message currently printed to console when the fs is formatted is not ideal IMO. If the system just prints "Formatting file system." and then acts like it's actually stuck with no indication whatsoever (console progress ticker, device LED blinking, etc.) some users may cancel and reboot.

A quick-fix is either to print "Formatting file system..." to indicate that it's a currently running process or to say something like "Formatting file system. Don't abort, may take a while.". An alternative would be to also print a success message explicitly like so:

```
print "Formatting file system..."
success = fs_format()
if (success) {
  print "done"
} else {
  // print error msg
}
```