### PR TITLE
Fixed `STA_DISCONNECT` typo

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -1036,7 +1036,7 @@ T: Table returned by event.
 	- `SSID`: SSID of access point.  
 	- `BSSID`: BSSID of access point.  
 	- `channel`: The channel the access point is on.  
-- `wifi.eventmon.STA_DISCONNECT`: Station was disconnected from access point.  
+- `wifi.eventmon.STA_DISCONNECTED`: Station was disconnected from access point.  
 	- `SSID`: SSID of access point.  
 	- `BSSID`: BSSID of access point.  
 	- `REASON`: See [wifi.eventmon.reason](#wifieventmonreason) below.  


### PR DESCRIPTION
Fixes n/a

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Simple typo fix in `wifi.md` documentation. `wifi.eventmon.STA_DISCONNECT` changed to `wifi.eventmon.STA_DISCONNECTED`

Committers supporting this PR: n/a