### PR TITLE
Revert "documentation-only change: fixed wrong word in bme280 module doc"

### DIFF
--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -23,8 +23,8 @@ altitude in meters of measurement point
 
 ## bme280.baro()
 
-Reads the sensor and returns the air pressure in hectopascals as an integer multiplied with 1000 or `nil` when readout is not successful.
-Current temperature is needed to calculate the air pressure so temperature reading is performed prior reading pressure data. Second returned variable is therefore current air temperature.
+Reads the sensor and returns the air temperature in hectopascals as an integer multiplied with 1000 or `nil` when readout is not successful.
+Current temperature is needed to calculate the air pressure so temperature reading is performed prior reading pressure data. Second returned variable is therefore current temperature.
 
 #### Syntax
 `bme280.baro()`


### PR DESCRIPTION
Reverts nodemcu/nodemcu-firmware#1437