### PR TITLE
removed default flash rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,11 +231,22 @@ clobber: $(SPECIAL_CLOBBER)
 	$(foreach d, $(SUBDIRS), $(MAKE) -C $(d) clobber;)
 	$(RM) -r $(ODIR)
 
-flash: 
+flash:
+	@echo "use one of the following targets to flash the firmware"
+	@echo "  make flash512k - for ESP with 512kB flash size"
+	@echo "  make flash4m   - for ESP with   4MB flash size"
+
+flash512k:
+	$(MAKE) -e FLASHOPTIONS="-fm qio -fs  4m -ff 40m" flashinternal
+
+flash4m:
+	$(MAKE) -e FLASHOPTIONS="-fm dio -fs 32m -ff 40m" flashinternal
+
+flashinternal:
 ifndef PDIR
-	$(MAKE) -C ./app flash
+	$(MAKE) -C ./app flashinternal
 else
-	$(ESPTOOL) --port $(ESPPORT) write_flash 0x00000 $(FIRMWAREDIR)0x00000.bin 0x10000 $(FIRMWAREDIR)0x10000.bin
+	$(ESPTOOL) --port $(ESPPORT) write_flash $(FLASHOPTIONS) 0x00000 $(FIRMWAREDIR)0x00000.bin 0x10000 $(FIRMWAREDIR)0x10000.bin
 endif
 
 .subdirs:


### PR DESCRIPTION
Fixes #1428

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

When flashing the firmware by using the rule ```flash``` in the ```Makefile``` can lead to an unstable behavior as observed in #1428. 

In order to avoid in the future the use of esptool.py without options, this PR exchanges the rule ```flash``` to an output of an Information as to which rules are instead to use.

Committers supporting this PR: leave blank