### PR TITLE
Feature: HTTP following redirects

### DIFF
--- a/app/http/httpclient.h
+++ b/app/http/httpclient.h
@@ -51,15 +51,15 @@ typedef void (* http_callback_t)(char * response_body, int http_status, char * f
 /*
  * Call this function to skip URL parsing if the arguments are already in separate variables.
  */
-void ICACHE_FLASH_ATTR http_raw_request(const char * hostname, int port, bool secure, const char * method, const char * path, const char * headers, const char * post_data, http_callback_t callback_handle);
+void ICACHE_FLASH_ATTR http_raw_request(const char * hostname, int port, bool secure, const char * method, const char * path, const char * headers, const char * post_data, http_callback_t callback_handle, int redirect_follow_count);
 
 /*
  * Request data from URL use custom method.
  * The data should be encoded as any format.
  * Try:
- * http_request("http://httpbin.org/post", "OPTIONS", "Content-type: text/plain", "Hello world", http_callback_example);
+ * http_request("http://httpbin.org/post", "OPTIONS", "Content-type: text/plain", "Hello world", http_callback_example, 0);
  */
-void ICACHE_FLASH_ATTR http_request(const char * url, const char * method, const char * headers, const char * post_data, http_callback_t callback_handle);
+void ICACHE_FLASH_ATTR http_request(const char * url, const char * method, const char * headers, const char * post_data, http_callback_t callback_handle, int redirect_follow_count);
 
 /*
  * Post data to a web form.

--- a/app/modules/http.c
+++ b/app/modules/http.c
@@ -76,7 +76,7 @@ static int http_lapi_request( lua_State *L )
     http_callback_registry = luaL_ref(L, LUA_REGISTRYINDEX);
   }
 
-  http_request(url, method, headers, body, http_callback);
+  http_request(url, method, headers, body, http_callback, 0);
   return 0;
 }
 

--- a/docs/en/modules/http.md
+++ b/docs/en/modules/http.md
@@ -13,6 +13,8 @@ Each request method takes a callback which is invoked when the response has been
 
 For each operation it is possible to provide custom HTTP headers or override standard headers. By default the `Host` header is deduced from the URL and `User-Agent` is `ESP8266`. Note, however, that the `Connection` header *can not* be overridden! It is always set to `close`.
 
+HTTP redirects (HTTP status 300-308) are followed automatically up to a limit of 20 to avoid the dreaded redirect loops.
+
 **SSL/TLS support**
 
 Take note of constraints documented in the [net module](net.md). 


### PR DESCRIPTION
Fixes #1366 .

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Maybe the HTTP module should be configurable globally. As in `http.config(config_data)`, where you could set the user agent and wether or not to follow redirections.

Committers supporting this PR: leave blank