### PR TITLE
Fix math.floor for negative integers, fixes #1453

### DIFF
--- a/app/libc/c_math.c
+++ b/app/libc/c_math.c
@@ -4,7 +4,7 @@
 
 double floor(double x)
 {
-    return (double) (x < 0.f ? (((int) x) - 1) : ((int) x));
+    return (double) (x < 0.f ? ((int) x == x ? x : (((int) x) - 1)) : ((int) x)); 
 }
 
 #define MAXEXP 2031     /* (MAX_EXP * 16) - 1           */


### PR DESCRIPTION
Proposed fix makes sense. Tests:

**float firmware**
```
> print(math.floor(-2))
-2
> print (-2 % 2)
0
> print(math.floor(2))
2
> print (2 % 2)
0
> print(math.floor(0))
0
> print(math.floor(-2.4))
-3
> print(math.floor(-2.5))
-3
> print(math.floor(2.4))
2
> print(math.floor(2.5))
2
```
**integer firmware**
```
print(math.floor(-2))
-2
> print (-2 % 2)
0
> print(math.floor(2))
2
> print (2 % 2)
0
> print(math.floor(0))
0
```