### PR TITLE
Write function in ws2812.buffer module

### DIFF
--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -108,7 +108,7 @@ Write data to buffer. Similar to `buffer.write()` function, string or data from 
 - `data` - payload to be write to `ws2812.buffer`
 
 Payload type could be:
-- `string` representing bytes to send, should not be longer then dimensions (`numberOfLeds` * `bytesPerLed`) of destination `ws2812.buffer`
+- `string` representing bytes to write, string should not be longer then dimensions (`numberOfLeds` * `bytesPerLed`) of destination `ws2812.buffer`
 - `ws2812.buffer` see [Buffer module](#buffer-module), its dimensions should be the same as of destination buffer.
 
 #### Returns
@@ -117,7 +117,7 @@ Payload type could be:
 #### Example
 ```lua
 exBuffer  = ws2812.newBuffer(3, 3)
-exBuffer:write(string.char(255, 0, 0, 255, 0, 0, 255, 0, 0)) -- write three red pixels to exBuffer
+exBuffer:write(string.char(255, 0, 0, 255, 0, 0, 255, 0, 0)) -- write three green pixels to exBuffer
 ```
 
 ```lua

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -98,6 +98,34 @@ Allocate a new memory buffer to store led values.
 #### Returns
 `ws2812.buffer`
 
+## ws2812.buffer:write()
+Write data to buffer. Similar to `buffer.write()` function, string or data from other `ws2812.buffer` can be passed as arguments. In case of `ws2812.buffer`, its dimensions (`numberOfLeds` and `bytesPerLed`) should be the same as of destination buffer.
+
+#### Syntax
+`ws2812.write(data)`
+
+#### Parameters
+- `data` - payload to be write to `ws2812.buffer`
+
+Payload type could be:
+- `string` representing bytes to send, should not be longer then dimensions (`numberOfLeds` * `bytesPerLed`) of destination `ws2812.buffer`
+- `ws2812.buffer` see [Buffer module](#buffer-module), its dimensions should be the same as of destination buffer.
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+exBuffer  = ws2812.newBuffer(3, 3)
+exBuffer:write(string.char(255, 0, 0, 255, 0, 0, 255, 0, 0)) -- write three red pixels to exBuffer
+```
+
+```lua
+firstBuffer  = ws2812.newBuffer(64, 3)
+secondBuffer  = ws2812.newBuffer(64, 3)
+firstBuffer:write(secondBuffer) -- copy second buffer to first buffer
+```
+
 ## ws2812.buffer:get()
 Return the value at the given position
 


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This new function allows to write string to ws2812.buffer or copy data from another ws2812.buffer,
String writing could be very useful while creating animation from saved data or from data coming from network.

Copying data from another ws2812.buffer is very useful while creating advanced animated effects, transition from one frame to other etc,

#### Format
`ws2812.buffer:write(data)`
where `data'` is `string` or another `ws2812.buffer`

#### Returns
`nil`

Committers supporting this PR: leave blank