### PR TITLE
Fix apa102 docs

### DIFF
--- a/docs/en/modules/apa102.md
+++ b/docs/en/modules/apa102.md
@@ -19,13 +19,13 @@ Send ABGR data in 8 bits to a APA102 chain.
 - `data_pin` any GPIO pin 0, 1, 2, ...
 - `clock_pin` any GPIO pin 0, 1, 2, ...
 - `string` payload to be sent to one or more APA102 LEDs.
-  It should be composed from a AGRB quadruplet per element.
+  It should be composed from a ABGR quadruplet per element.
     - `A1` the first pixel's Intensity channel (0-31)
     - `B1` the first pixel's Blue channel (0-255)<br />
     - `G1` the first pixel's Green channel (0-255)
     - `R1` the first pixel's Red channel (0-255)
     ... You can connect a lot of APA102 ...
-    - `A2`, `G2`, `R2`, `B2` are the next APA102s Intensity, Blue, Green and channel parameters
+    - `A2`, `B2`, `G2`, `R2` are the next APA102s Intensity, Blue, Green and Red channel parameters
 
 #### Returns
 `nil`
@@ -33,9 +33,9 @@ Send ABGR data in 8 bits to a APA102 chain.
 #### Example
 ```lua
 a = 31
+b = 0
 g = 0
 r = 255
-b = 0
-led_abgr = string.char(a, g, r, b, a, g, r, b) 
+led_abgr = string.char(a, b, g, r, a, b, g, r) 
 apa102.write(2, 3, leds_abgr) -- turn two APA102s to red, connected to data_pin 2 and clock_pin 3
 ```


### PR DESCRIPTION
Fixes #1469 

Documentation for APA102 says module expect channel information in AGRB order but module expects information in ABGR.
This PR change the documentation to reflect actual behaviour of the module.

- [X] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md)
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

Committers supporting this PR: 