### PR TITLE
Add function `wifi.nullmodesleep()`

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -128,6 +128,21 @@ physical mode after setup
 #### See also
 [`wifi.getphymode()`](#wifigetphymode)
 
+## wifi.nullmodesleep()
+
+Configures whether or not WiFi automatically goes to sleep in NULL_MODE. Enabled by default. 
+
+#### Syntax
+`wifi.nullmodesleep(enable)`
+
+#### Parameters
+- `enable` 
+  - true: Enable WiFi auto sleep in NULL_MODE. (Default setting)
+  - false: Disable WiFi auto sleep in NULL_MODE. 
+
+#### Returns
+Current/new NULL_MODE sleep setting.
+
 ## wifi.sleeptype()
 
 Configures the WiFi modem sleep type.

--- a/sdk-overrides/include/user_interface.h
+++ b/sdk-overrides/include/user_interface.h
@@ -4,5 +4,7 @@
 #include_next "user_interface.h"
 
 bool wifi_softap_deauth(uint8 mac[6]);
+uint8 get_fpm_auto_sleep_flag(void);
+
 
 #endif /* SDK_OVERRIDES_INCLUDE_USER_INTERFACE_H_ */


### PR DESCRIPTION
This PR adds the function `wifi.nullmodesleep()` which allows the application developer to enable/disable auto sleep in NULL_MODE. This feature will be enabled by default.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Committers supporting this PR: 