### PR TITLE
Make struct.unpack wrapped in setlist actually work

### DIFF
--- a/app/lua/lvm.c
+++ b/app/lua/lvm.c
@@ -759,7 +759,6 @@ void luaV_execute (lua_State *L, int nexeccalls) {
         fixedstack(L);
         if (n == 0) {
           n = cast_int(L->top - ra) - 1;
-          L->top = L->ci->top;
         }
         if (c == 0) c = cast_int(*pc++);
         runtime_check(L, ttistable(ra));
@@ -772,6 +771,7 @@ void luaV_execute (lua_State *L, int nexeccalls) {
           setobj2t(L, luaH_setnum(L, h, last--), val);
           luaC_barriert(L, h, val);
         }
+	L->top = L->ci->top;
         unfixedstack(L);
         continue;
       }

--- a/app/modules/struct.c
+++ b/app/modules/struct.c
@@ -309,7 +309,7 @@ static int b_unpack (lua_State *L) {
     size_t size = optsize(L, opt, &fmt);
     pos += gettoalign(pos, &h, opt, size);
     luaL_argcheck(L, pos+size <= ld, 2, "data string too short");
-    luaL_checkstack(L, 1, "too many results");
+    luaL_checkstack(L, 2, "too many results");
     switch (opt) {
       case 'b': case 'B': case 'h': case 'H':
       case 'l': case 'L': case 'T': case 'i':  case 'I': {  /* integer types */


### PR DESCRIPTION
Fixes #1434.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This fixes the issue identified in the struct module (it reserves one too few entries on the stack). Also backported a fix from lua-5.2 to the op_setlist vm opcode so that the top of stack is not moved until all the entries have been copied off.

No documentation needs changing.

Committers supporting this PR: leave blank
