### PR TITLE
Enable debug for PR builds

### DIFF
--- a/tools/pr-build.sh
+++ b/tools/pr-build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "Running PR build (all modules, SSL disabled)"
+echo "Running PR build (all modules, SSL enabled, debug enabled)"
 (
 cd "$TRAVIS_BUILD_DIR"/app/include || exit
 # uncomment disabled modules e.g. '//#define LUA_USE_MODULES_UCG' -> '#define LUA_USE_MODULES_UCG'
@@ -11,6 +11,9 @@ cat user_modules.h
 
 # enable SSL
 sed -i.bak 's@//#define CLIENT_SSL_ENABLE@#define CLIENT_SSL_ENABLE@' user_config.h
+
+# enable debug
+sed -E -i.bak 's@// ?#define DEVELOP_VERSION@#define DEVELOP_VERSION@' user_config.h
 
 # enable FATFS
 sed -i 's@//#define BUILD_FATFS@#define BUILD_FATFS@' user_config.h


### PR DESCRIPTION
As we've seen with https://github.com/nodemcu/nodemcu-firmware/pull/1487 it may be helpful to run PR builds with debug enabled.