### PR TITLE
Fix repeat reboot bug when rfinit data is filled with 0xff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ sdk_patched: sdk_extracted $(TOP_DIR)/sdk/.patched-$(SDK_VER)
 
 $(TOP_DIR)/sdk/.extracted-$(SDK_BASE_VER): $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip
 	mkdir -p "$(dir $@)"
-	(cd "$(dir $@)" && rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK && unzip $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip ESP8266_NONOS_SDK/lib/* ESP8266_NONOS_SDK/ld/eagle.rom.addr.v6.ld ESP8266_NONOS_SDK/include/* )
+	(cd "$(dir $@)" && rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK && unzip $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip ESP8266_NONOS_SDK/lib/* ESP8266_NONOS_SDK/ld/eagle.rom.addr.v6.ld ESP8266_NONOS_SDK/include/* ESP8266_NONOS_SDK/bin/esp_init_data_default.bin)
 	mv $(dir $@)/ESP8266_NONOS_SDK $(dir $@)/esp_iot_sdk_v$(SDK_VER)
 	rm -f $(SDK_DIR)/lib/liblwip.a
 	touch $@
@@ -253,14 +253,7 @@ initdata:
 ifndef PDIR
 	$(MAKE) -C ./app initdata
 else
-	@printf "\005\000\004\002\005\005\005\002\005\000\004\005\005\004\005\005">$(FIRMWAREDIR)$(INITDATAADDR).bin
-	@printf "\004\376\375\377\360\360\360\340\340\340\341\012\377\377\370\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
-	@printf "\370\370\122\116\112\104\100\070\000\000\001\001\002\003\004\005">>$(FIRMWAREDIR)$(INITDATAADDR).bin
-	@printf "\001\000\000\000\000\000\002\000\000\000\000\000\000\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
-	@printf "\341\012\000\000\000\000\000\000\000\000\001\223\103\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
-	@printf "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
-	@printf "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
-	@printf "\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
+	@cp -f $(SDK_DIR)/bin/esp_init_data_default.bin $(FIRMWAREDIR)$(INITDATAADDR).bin
 endif
 
 .subdirs:

--- a/Makefile
+++ b/Makefile
@@ -237,16 +237,30 @@ flash:
 	@echo "  make flash4m   - for ESP with   4MB flash size"
 
 flash512k:
-	$(MAKE) -e FLASHOPTIONS="-fm qio -fs  4m -ff 40m" flashinternal
+	$(MAKE) -e FLASHOPTIONS="-fm qio -fs  4m -ff 40m" -e INITDATAADDR="0x7c000" flashinternal
 
 flash4m:
-	$(MAKE) -e FLASHOPTIONS="-fm dio -fs 32m -ff 40m" flashinternal
+	$(MAKE) -e FLASHOPTIONS="-fm dio -fs 32m -ff 40m" -e INITDATAADDR="0x3fc000" flashinternal
 
-flashinternal:
+flashinternal: initdata
 ifndef PDIR
 	$(MAKE) -C ./app flashinternal
 else
-	$(ESPTOOL) --port $(ESPPORT) write_flash $(FLASHOPTIONS) 0x00000 $(FIRMWAREDIR)0x00000.bin 0x10000 $(FIRMWAREDIR)0x10000.bin
+	$(ESPTOOL) --port $(ESPPORT) write_flash $(FLASHOPTIONS) 0x00000 $(FIRMWAREDIR)0x00000.bin 0x10000 $(FIRMWAREDIR)0x10000.bin $(INITDATAADDR) $(FIRMWAREDIR)$(INITDATAADDR).bin
+endif
+
+initdata:
+ifndef PDIR
+	$(MAKE) -C ./app initdata
+else
+	@printf "\005\000\004\002\005\005\005\002\005\000\004\005\005\004\005\005">$(FIRMWAREDIR)$(INITDATAADDR).bin
+	@printf "\004\376\375\377\360\360\360\340\340\340\341\012\377\377\370\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
+	@printf "\370\370\122\116\112\104\100\070\000\000\001\001\002\003\004\005">>$(FIRMWAREDIR)$(INITDATAADDR).bin
+	@printf "\001\000\000\000\000\000\002\000\000\000\000\000\000\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
+	@printf "\341\012\000\000\000\000\000\000\000\000\001\223\103\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
+	@printf "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
+	@printf "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
+	@printf "\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000">>$(FIRMWAREDIR)$(INITDATAADDR).bin
 endif
 
 .subdirs:

--- a/docs/en/flash.md
+++ b/docs/en/flash.md
@@ -46,15 +46,25 @@ Otherwise, if you built your own firmware from source code:
 - `bin/0x00000.bin` to 0x00000
 - `bin/0x10000.bin` to 0x10000
 
-If you're using 512k bytes flash, you should flash:
+Also, in some special circumstances, such as:
 
-- `bin/0x7c000.bin` to 0x7c000
+- this is your first time using esp8266 based hardware
+- you want upgrade firmware
+- you want downgrade firmware
+- you want change firmware
+- you got ``rf_cal[0] !=0x05,is 0xFF`` error when boot
+- the boards reboot again and again
+- you can not connect some AP that you have successfully connected
 
-If you're using 4M bytes flash, you should flash:
+you may need to flash `esp_init_data_default.bin`(RF & SoC configuration) to various addresses on the flash (depending on flash size and type), see [below](#upgrading-firmware).
 
-- `bin/0x3fc000.bin` to 0x3fc000
+And, in below circumstances, such as:
 
-Also, in some special circumstances, you may need to flash `blank.bin` or `esp_init_data_default.bin` to various addresses on the flash (depending on flash size and type), see [below](#upgrading-from-sdk-09x-firmware).
+- you want upgrade firmware
+- you want downgrade firmware
+- you want let esp8266 forget Wi-Fi SSID and PASSWORD
+
+you may need to flash `blank.bin`(Wi-Fi configuration) to various addresses on the flash (depending on flash size and type), see [below](#upgrading-firmware).
 
 ## Upgrading Firmware
 
@@ -86,12 +96,26 @@ esptool.py --port <serial-port-of-ESP8266> write_flash <flash options> 0x00000 <
 
 !!! note "Note:"
 
-    The address for `esp_init_data_default.bin` depends on the size of your module's flash. 
+    The address for `esp_init_data_default.bin`(RF & SoC configuration) depends on the size of your module's flash. 
     
     - `0x7c000` for 512 kB, modules like ESP-01, -03, -07 etc.
     - `0xfc000` for 1 MB, modules like ESP8285, PSF-A85
     - `0x1fc000` for 2 MB
     - `0x3fc000` for 4 MB, modules like ESP-12E, NodeMCU devkit 1.0, WeMos D1 mini
+
+    The address for `blank.bin`(Wi-Fi configuration) depends on the size of your module's flash.
+
+    - `0x7e000` for 512 kB, modules like ESP-01, -03, -07 etc.
+    - `0xfe000` for 1 MB, modules like ESP8285, PSF-A85
+    - `0x1fe000` for 2 MB
+    - `0x3fe000` for 4 MB, modules like ESP-12E, NodeMCU devkit 1.0, WeMos D1 mini
+
+    |Flash bytes |Flash bits  |RF & SoC configuration|Wi-Fi configuration|
+    |------------|------------|------------------------|-------------------|
+    |512 kB      |4  Mb       |0x7c000                 |0x7e000            |
+    |1   MB      |8  Mb       |0xfc000                 |0xfe000            |
+    |2   MB      |16 Mb       |0x1fc000                |0x1fe000           |
+    |4   MB      |32 Mb       |0x3fc000                |0x3fe000           |
 
 **NodeMCU Flasher**
 

--- a/docs/en/flash.md
+++ b/docs/en/flash.md
@@ -46,6 +46,14 @@ Otherwise, if you built your own firmware from source code:
 - `bin/0x00000.bin` to 0x00000
 - `bin/0x10000.bin` to 0x10000
 
+If you're using 512k bytes flash, you should flash:
+
+- `bin/0x7c000.bin` to 0x7c000
+
+If you're using 4M bytes flash, you should flash:
+
+- `bin/0x3fc000.bin` to 0x3fc000
+
 Also, in some special circumstances, you may need to flash `blank.bin` or `esp_init_data_default.bin` to various addresses on the flash (depending on flash size and type), see [below](#upgrading-from-sdk-09x-firmware).
 
 ## Upgrading Firmware


### PR DESCRIPTION
Fix repeat reboot bug when rfinit data is filled with 0xff.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

-----

When erase a flash or fill flash with 0xff, using latest https://github.com/nodemcu/nodemcu-firmware/commit/19f80abb3260e689b4f41c54eece8e7ebdd4d4cf will cause reboot repeatly. 

To verify this, I use these command below:

```shell
# erase flash
../tools/esptool.py --port /dev/ttyUSB0 erase_flash
```
```shell
# programming firmware
../tools/esptool.py --port /dev/ttyUSB0 write_flash -fm dio -fs 32m -ff 40m 0x00000 ../bin/0x00000.bin 0x10000 ../bin/0x10000.bin
```

After then I got repeatly reboot, so I changed baudrate to 74880 and listen the serial port:

```shell
cat /dev/ttyUSB0
```

and the mesage is output again and again:

```
 ets Jan  8 2013,rst cause:2, boot mode:(3,6)

load 0x40100000, len 26420, room 16 
tail 4
chksum 0xea
load 0x3ffe8000, len 2200, room 4 
tail 4
chksum 0x83
load 0x3ffe8898, len 8, room 4 
tail 4
chksum 0x1f
csum 0x1f
rf_cal[0] !=0x05,is 0xFF
```

The reason is printed at 74880 baud when reboot:
``rf_cal[0] !=0x05,is 0xFF``


So we should not believe ``esp_init_data_default.bin`` is optional in espressif's data sheet, the rf init data __must__ write to flash before run nodemcu firmware.

This change will write rf init data to flash when do ``make flash512k`` and``make flash4m``, and fix it.