### PR TITLE
Fixes the spiffsimg issues (#1502)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ endif
 .PHONY: spiffs-image-remove
 
 spiffs-image-remove:
-	$(MAKE) -C tools remove-image
+	$(MAKE) -C tools remove-image spiffsimg/spiffsimg
 
 .PHONY: spiffs-image
 

--- a/docs/en/spiffs.md
+++ b/docs/en/spiffs.md
@@ -27,11 +27,11 @@ spiffsimg -f <filename>
 
 ### Supported operations:
 
-  * `-f` specifies the filename for the disk image. '%x' will be replaced by the calculated offset of the file system.
-  * `-o` specifies the file which is to contain the calculated offset.
-  * `-S` specifies the size of the flash chip. `32m` is 32 mbits, `1MB` is 1 megabyte.
-  * `-U` specifies the amount of flash used by the firmware. Decimal or Hex bytes.
-  * `-c` Create a blank disk image of the given size.
+  * `-f` specifies the filename for the disk image. '%x' will be replaced by the calculated offset of the file system (`-U` must also be specified to calculate the offset).
+  * `-o` specifies the filename which is to contain the calculated offset.
+  * `-S` specifies the size of the flash chip. `32m` is 32 mbits, `4MB` is 4 megabytes.
+  * `-U` specifies the amount of flash used by the firmware. Decimal or Hex bytes (if starts with 0x).
+  * `-c` Create a blank disk image of the given size. Decimal or Hex bytes (if starts with 0x).
   * `-l` List the contents of the given disk image.
   * `-i` Interactive commands.
   * `-r` Scripted commands from filename.

--- a/docs/en/spiffs.md
+++ b/docs/en/spiffs.md
@@ -92,6 +92,8 @@ The disk image file is placed into the `bin` directory and it is named `0x<offse
 flashed, and the size is the size of the flash part. It is quite valid (and quicker) to flash the 512k image into a 4M part. However, there will probably be
 limited space in the file system for creating new files.
 
+The default configuration will try and build three different file systems for 512KB, 1MB and 4MB flash sizes. The 1MB size is suitable for the ESP8285. This can be overridden by specifying the FLASHSIZE parameter to the makefile.
+
 If the `local/fs` directory is empty, then no flash images will be created (and the ones from the last build will be removed). The `spiffsimg` tool can 
 then be used to build an image as required. 
 

--- a/docs/en/spiffs.md
+++ b/docs/en/spiffs.md
@@ -73,7 +73,8 @@ f    880 http/favicon.ico
 # Technical Details
 
 The SPIFFS configuration is 4k sectors (the only size supported by the SDK) and 8k blocks. 256 byte pages. Magic is enabled and magic_len is also enabled. This allows the firmware to find the start of the filesystem (and also the size).
-One of the goals is to make the filsystem more persistent across reflashing of the firmware.
+One of the goals is to make the filsystem more persistent across reflashing of the firmware. However, there are still cases
+where spiffs detects a filesystem and uses it when it isn't valid. If you are getting weirdness with the filesystem, then just reformat it.
 
 There are two significant sizes of flash -- the 512K and 4M (or bigger). 
 
@@ -82,13 +83,17 @@ not much spare space, so a newly formatted file system will start as low as poss
 file system will start on a 64k boundary. A newly formatted file system will start between 64k and 128k from the end of the firmware. This means that the file 
 system will survive lots of reflashing and at least 64k of firmware growth. 
 
-The spiffsimg tool can also be built (from source) in the nodemcu-firmware build tree. If there is any data in the `local/fs` directory tree, then it will
-be copied into the flash disk image. Two images will normally be created -- one for the 512k flash part and the other for the 4M flash part. If the data doesn't 
+The standard build process for the firmware builds the `spiffsimg` tool (found in the `tools/spiffsimg` subdirectory).
+The top level Makfile also checks if
+there is any data in the `local/fs` directory tree, and it will then copy these files
+into the flash disk image. Two images will normally be created -- one for the 512k flash part and the other for the 4M flash part. If the data doesn't 
 fit into the 512k part after the firmware is included, then the file will not be generated.
-
 The disk image file is placed into the `bin` directory and it is named `0x<offset>-<size>.bin` where the offset is the location where it should be 
 flashed, and the size is the size of the flash part. It is quite valid (and quicker) to flash the 512k image into a 4M part. However, there will probably be
 limited space in the file system for creating new files.
+
+If the `local/fs` directory is empty, then no flash images will be created (and the ones from the last build will be removed). The `spiffsimg` tool can 
+then be used to build an image as required. 
 
 If no file system is found during platform boot, then a new file system will be formatted. This can take some time on the first boot.
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -28,8 +28,10 @@ FLASH_USED_END = $$((0x`$(OBJDUMP) -t ../app/.output/eagle/debug/image/eagle.app
 
 all:	spiffsscript
 
-spiffsscript: remove-image
+spiffsimg/spiffsimg:
 	$(MAKE) -C spiffsimg CC=gcc
+
+spiffsscript: remove-image spiffsimg/spiffsimg
 	rm -f ./spiffsimg/spiffs.lst
 	echo "" >> ./spiffsimg/spiffs.lst
 	@$(foreach f, $(SPIFFSFILES), echo "import $(FSSOURCE)$(f) $(f)" >> ./spiffsimg/spiffs.lst ;)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -5,6 +5,7 @@
 FSSOURCE ?= ../local/fs/
 FLASHSIZE ?= 4mb 32mb 8mb
 SUBDIRS = 
+HOSTCC ?= gcc
 
 OBJDUMP = $(or $(shell which objdump),xtensa-lx106-elf-objdump)
 
@@ -36,7 +37,7 @@ spiffsimg: spiffsimg/spiffsimg
 	@echo Built spiffsimg in spiffsimg/spiffsimg
 
 spiffsimg/spiffsimg: 
-	@$(MAKE) -C spiffsimg CC=gcc
+	@$(MAKE) -C spiffsimg CC=$(HOSTCC)
 
 spiffsscript: remove-image spiffsimg/spiffsimg
 	rm -f ./spiffsimg/spiffs.lst

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -28,7 +28,9 @@ FLASH_USED_END = $$((0x`$(OBJDUMP) -t ../app/.output/eagle/debug/image/eagle.app
 
 all:	spiffsscript
 
-spiffsimg/spiffsimg:
+.PHONY: spiffsimg/spiffsimg
+
+spiffsimg/spiffsimg: 
 	$(MAKE) -C spiffsimg CC=gcc
 
 spiffsscript: remove-image spiffsimg/spiffsimg

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -28,10 +28,15 @@ FLASH_USED_END = $$((0x`$(OBJDUMP) -t ../app/.output/eagle/debug/image/eagle.app
 
 all:	spiffsscript
 
+.PHONY: spiffsimg
+
 .PHONY: spiffsimg/spiffsimg
 
+spiffsimg: spiffsimg/spiffsimg
+	@echo Built spiffsimg in spiffsimg/spiffsimg
+
 spiffsimg/spiffsimg: 
-	$(MAKE) -C spiffsimg CC=gcc
+	@$(MAKE) -C spiffsimg CC=gcc
 
 spiffsscript: remove-image spiffsimg/spiffsimg
 	rm -f ./spiffsimg/spiffs.lst

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,7 @@
 #
 
 FSSOURCE ?= ../local/fs/
-FLASHSIZE ?= 4mb 32mb
+FLASHSIZE ?= 4mb 32mb 8mb
 SUBDIRS = 
 
 OBJDUMP = $(or $(shell which objdump),xtensa-lx106-elf-objdump)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -3,7 +3,7 @@
 #
 
 FSSOURCE ?= ../local/fs/
-FLASHSIZE ?= 4mb 32mb 8mb
+FLASHSIZE ?= 4mb 32mb
 SUBDIRS = 
 
 OBJDUMP = $(or $(shell which objdump),xtensa-lx106-elf-objdump)

--- a/tools/spiffsimg/Makefile
+++ b/tools/spiffsimg/Makefile
@@ -2,7 +2,7 @@ SRCS=\
 	main.c \
   ../../app/spiffs/spiffs_cache.c  ../../app/spiffs/spiffs_check.c  ../../app/spiffs/spiffs_gc.c  ../../app/spiffs/spiffs_hydrogen.c  ../../app/spiffs/spiffs_nucleus.c
 
-CFLAGS=-g -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -I. -I../../app/spiffs -DNODEMCU_SPIFFS_NO_INCLUDE --include spiffs_typedefs.h
+CFLAGS=-g -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -I. -I../../app/spiffs -I../../app/include -DNODEMCU_SPIFFS_NO_INCLUDE --include spiffs_typedefs.h
 
 spiffsimg: $(SRCS)
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@

--- a/tools/spiffsimg/main.c
+++ b/tools/spiffsimg/main.c
@@ -282,6 +282,12 @@ int main (int argc, char *argv[])
     }
     sz &= ~(0x1fff);
 
+    if (used == 0) {
+      if (strchr(fname, '%')) {
+	die("Unable to calculate where to put the flash image, and % present in filename");
+      }
+    }
+
     char fnamebuff[1024];
 
     sprintf(fnamebuff, fname, used);


### PR DESCRIPTION
Fixes #1502 

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This fixes the bugs reported in #1502. In particular, now that the stadard docker container includes the
local `gcc`, the `spiffsimg` tool is always built. This will prevent any future breakage of the tool (as it will fail the build). `spiffsimg` now fails if you try and specify %x in the filename and it cannot calculate the offset.

The documentation was also improved. 

Committers supporting this PR: leave blank