### PR TITLE
Typo in HMC5883L module example

### DIFF
--- a/docs/en/modules/hmc5883l.md
+++ b/docs/en/modules/hmc5883l.md
@@ -18,7 +18,7 @@ temperature multiplied with 10 (integer)
 
 #### Example
 ```lua
-hmc5883.init(1, 2)
+hmc5883l.init(1, 2)
 local x,y,z = hmc5883l.read()
 print(string.format("x = %d, y = %d, z = %d", x, y, z))
 ```


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rational behind this PR\>

Committers supporting this PR: leave blank
