### PR TITLE
Virtual u8g display driver for RFB/VNC support

### DIFF
--- a/app/include/u8g_config.h
+++ b/app/include/u8g_config.h
@@ -78,7 +78,7 @@
 
 // Special display device to provide run-length encoded framebuffer contents
 // to a Lua callback:
-#define U8G_DISPLAY_FB_RLE
+//#define U8G_DISPLAY_FB_RLE
 //
 // ***************************************************************************
 

--- a/app/include/u8g_config.h
+++ b/app/include/u8g_config.h
@@ -75,6 +75,10 @@
     U8G_DISPLAY_TABLE_ENTRY(ssd1306_128x64_hw_spi)              \
 
 #undef U8G_DISPLAY_TABLE_ENTRY
+
+// Special display device to provide run-length encoded framebuffer contents
+// to a Lua callback:
+#define U8G_DISPLAY_FB_RLE
 //
 // ***************************************************************************
 

--- a/app/modules/u8g_glue.c
+++ b/app/modules/u8g_glue.c
@@ -1,0 +1,136 @@
+/*
+  Functions for integrating U8glib into the nodemcu platform.
+*/
+
+#include "lauxlib.h"
+
+#include "c_stdlib.h"
+
+#include "u8g.h"
+#include "u8g_glue.h"
+
+
+// ***************************************************************************
+// Generic framebuffer device and RLE comm driver
+//
+uint8_t u8g_dev_gen_fb_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg)
+{
+  switch(msg)
+  {
+    case U8G_DEV_MSG_PAGE_FIRST:
+      // tell comm driver to start new framebuffer
+      u8g_SetChipSelect(u8g, dev, 1);
+      break;
+    case U8G_DEV_MSG_PAGE_NEXT:
+      {
+        u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
+        if ( u8g_pb_WriteBuffer(pb, u8g, dev) == 0 )
+          return 0;
+      }
+      break;
+  }
+
+  return u8g_dev_pb8v1_base_fn(u8g, dev, msg, arg);
+}
+
+static int bit_at( uint8_t *buf, int line, int x )
+{
+    uint8_t byte = buf[x];
+
+    return buf[x] & (1 << line) ? 1 : 0;
+}
+
+struct _lu8g_fbrle_item
+{
+    uint8_t start_x;
+    uint8_t len;
+};
+
+struct _lu8g_fbrle_line
+{
+    uint8_t num_valid;
+    struct _lu8g_fbrle_item items[0];
+};
+
+uint8_t u8g_com_esp8266_fbrle_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr)
+{
+    struct _lu8g_userdata_t *lud = (struct _lu8g_userdata_t *)u8g;
+
+    switch(msg)
+    {
+    case U8G_COM_MSG_INIT:
+        // allocate memory -> done
+        // init buffer
+        break;
+
+    case U8G_COM_MSG_CHIP_SELECT:
+        if (arg_val == 1) {
+            // new frame starts
+            if (lud->cb_ref != LUA_NOREF) {
+                // fire callback with nil argument
+                lua_State *L = lua_getstate();
+                lua_rawgeti( L, LUA_REGISTRYINDEX, lud->cb_ref );
+                lua_pushnil( L );
+                lua_call( L, 1, 0 );
+            }
+        }
+        break;
+
+    case U8G_COM_MSG_WRITE_SEQ:
+    case U8G_COM_MSG_WRITE_SEQ_P:
+        {
+            uint8_t xwidth = u8g->pin_list[U8G_PI_EN];
+            size_t fbrle_line_size = sizeof( struct _lu8g_fbrle_line ) + sizeof( struct _lu8g_fbrle_item ) * (xwidth/2);
+            int num_lines = arg_val / (xwidth/8);
+            uint8_t *buf = (uint8_t *)arg_ptr;
+
+            struct _lu8g_fbrle_line *fbrle_line;
+            if (!(fbrle_line = (struct _lu8g_fbrle_line *)c_malloc( fbrle_line_size ))) {
+                break;
+            }
+
+            for (int line = 0; line < num_lines; line++) {
+                int start_run = -1;
+                fbrle_line->num_valid = 0;
+
+                for (int x = 0; x < xwidth; x++) {
+                    if (bit_at( buf, line, x ) == 0) {
+                        if (start_run >= 0) {
+                            // inside run, end it and enter result
+                            fbrle_line->items[fbrle_line->num_valid].start_x = start_run;
+                            fbrle_line->items[fbrle_line->num_valid++].len = x - start_run;
+                            //NODE_ERR( "         line: %d x: %d len: %d\n", line, start_run, x - start_run );
+                            start_run = -1;
+                        }
+                    } else {
+                        if (start_run < 0) {
+                            // outside run, start it
+                            start_run = x;
+                        }
+                    }
+
+                    if (fbrle_line->num_valid >= xwidth/2) break;
+                }
+
+                // active run?
+                if (start_run >= 0 && fbrle_line->num_valid < xwidth/2) {
+                    fbrle_line->items[fbrle_line->num_valid].start_x = start_run;
+                    fbrle_line->items[fbrle_line->num_valid++].len = xwidth - start_run;
+                }
+
+                // line done, trigger callback
+                if (lud->cb_ref != LUA_NOREF) {
+                    lua_State *L = lua_getstate();
+
+                    lua_rawgeti( L, LUA_REGISTRYINDEX, lud->cb_ref );
+                    lua_pushlstring( L, (const char *)fbrle_line, fbrle_line_size );
+                    lua_call( L, 1, 0 );
+                }
+            }
+
+            c_free( fbrle_line );
+        }
+        break;
+    }
+    return 1;
+}

--- a/app/modules/u8g_glue.h
+++ b/app/modules/u8g_glue.h
@@ -1,0 +1,20 @@
+
+#ifndef _U8G_GLUE_H_
+#define _U8G_GLUE_H_
+
+#include "u8g.h"
+
+struct _lu8g_userdata_t
+{
+    u8g_t u8g;
+    int cb_ref;
+};
+typedef struct _lu8g_userdata_t lu8g_userdata_t;
+
+// shorthand macro for the u8g structure inside the userdata
+#define LU8G (&(lud->u8g))
+
+uint8_t u8g_com_esp8266_fbrle_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+uint8_t u8g_dev_gen_fb_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg);
+
+#endif

--- a/app/modules/u8g_glue.h
+++ b/app/modules/u8g_glue.h
@@ -7,6 +7,8 @@
 struct _lu8g_userdata_t
 {
     u8g_t u8g;
+    uint8_t i2c_addr;
+    uint8_t use_delay;
     int cb_ref;
 };
 typedef struct _lu8g_userdata_t lu8g_userdata_t;

--- a/app/u8glib/u8g.h
+++ b/app/u8glib/u8g.h
@@ -1178,9 +1178,6 @@ struct _u8g_t
   u8g_state_cb state_cb;
   
   u8g_box_t current_page;		/* current box of the visible page */
-
-  uint8_t i2c_addr;
-  uint8_t use_delay;
 };
 
 #define u8g_GetFontAscent(u8g) ((u8g)->font_ref_ascent)

--- a/docs/en/modules/u8g.md
+++ b/docs/en/modules/u8g.md
@@ -202,6 +202,30 @@ disp = u8g.ssd1306_128x64_hw_spi(cs, dc, res)
 #### See also
 [I²C Display Drivers](#i2c-display-drivers)
 
+## u8g.fb_rle
+Initialize a virtual display that provides run-length encoded framebuffer contents to a Lua callback.
+
+The callback function can be used to process the framebuffer line by line. It's called with either `nil` as parameter to indicate the start of a new frame or with a string containing a line of the framebuffer with run-length encoding. First byte in the string specifies how many pairs of (x, len) follow, while each pair defines the start (leftmost x-coordinate) and length of a sequence of lit pixels. All other pixels in the line are dark.
+
+```lua
+n = struct.unpack("B", rle_line)
+print(n.." pairs")
+for i = 0,n-1 do
+  print(string.format("  x: %d len: %d", struct.unpack("BB", rle_line, 1+1 + i*2)))
+end
+```
+
+#### Syntax
+`u8g.fb_rle(cb_fn, width, height)`
+
+#### Parameters
+- `cb_fn([rle_line])` callback function. `rle_line` is a string containing a run-length encoded framebuffer line, or `nil` to indicate start of frame.
+- `width` of display. Must be a multiple of 8, less than or equal to 248.
+- `height` of display. Must be a multiple of 8, less than or equal to 248.
+
+#### Returns
+u8g display object
+
 ___
 
 ## Constants


### PR DESCRIPTION
- [x] This PR is compliant with the [contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This PR adds a virtual framebuffer display `fb_rle` to the `u8g` module for integration with the Lua [VNC server framework](https://github.com/devsaurus/nodemcu-vncserver). It doesn't use I2C or SPI for communication but forwards display data in run-length encoded format to a user callback. Subsequent RFB protocol processing is beyond the scope of `fb_rle` and needs to be handled by Lua code as shown in the example provided with nodemcu-vncserver.

Reasons for introducing a dedicated display type:
- provide access to framebuffer contents
- off-load Lua code from expensive bit shift operations

The PR furthermore moves the existing comm drivers and other u8glib-related glue code to new file `u8g_glue.c` for better separation from the Lua bindings.

Committers supporting this PR: 
