### PR TITLE
Fix start-up race between UART & start_lua.

### DIFF
--- a/app/driver/uart.c
+++ b/app/driver/uart.c
@@ -330,7 +330,6 @@ uart_init(UartBautRate uart0_br, UartBautRate uart1_br, os_signal_t sig_input)
     uart_config(UART0);
     UartDev.baut_rate = uart1_br;
     uart_config(UART1);
-    ETS_UART_INTR_ENABLE();
 #ifdef BIT_RATE_AUTOBAUD
     uart_init_autobaud(0);
 #endif


### PR DESCRIPTION
Fixes #1517.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`. **N/A**

\<Description of and rational behind this PR\>
Input during startup (especially while doing initial filesystem format)
ran the risk of filling up the task queue, preventing the start_lua task
from being queued, and hence NodeMCU would not start up that time.
We now don't enable UART interrupts until we've started up fully.

Also, I removed some left-over cruft in user_main while I was there, and added an explicit error message in case we ever fail to post the start_lua task in the future.