### PR TITLE
Reimplemented esp_init_data_default.

### DIFF
--- a/app/include/rom.h
+++ b/app/include/rom.h
@@ -149,5 +149,7 @@ void uart_div_modify(int no, unsigned int freq);
 
 /* Returns 0 on success, 1 on failure */
 uint8_t SPIRead(uint32_t src_addr, uint32_t *des_addr, uint32_t size);
+uint8_t SPIWrite(uint32_t dst_addr, const uint32_t *src, uint32_t size);
+uint8_t SPIEraseSector(uint32_t sector);
 
 #endif


### PR DESCRIPTION
Fixes #1500.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rational behind this PR\>
Reimplemented esp_init_data_default to work around the pesky "rf_cal[0] !=0x05" hang when booting on a chip which doesn't have esp_init_data written to it.

It is no longer possible to do the writing of the esp_init_data_default
from within nodemcu_init(), as the SDK now hangs long before it gets
there.  As such, I've had to reimplement this in our user_start_trampoline
and get it all done before the SDK has a chance to look for the init data.
It's unfortunate that we have to spend IRAM on this, but I see no better
alternative at this point.

With this patch, NodeMCU should finally be back to "it just works" when flashed onto a fresh(ly erased) ESP, and the previously documented approach should be correct once more.

I'd really appreciate it if a few more people could try this PR before considering merging - while it's working fine for me, I'm always a bit hesitant messing with the early boot stuff.