### PR TITLE
add map ids for flash sizes 32m-c2, 64m, 128m in user_rf_cal_sector_s…

### DIFF
--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -177,7 +177,7 @@ void user_rf_pre_init(void)
 uint32
 user_rf_cal_sector_set(void)
 {
-    enum flash_size_map size_map = system_get_flash_size_map();
+    enum ext_flash_size_map size_map = system_get_flash_size_map();
     uint32 rf_cal_sec = 0;
 
     switch (size_map) {
@@ -196,7 +196,16 @@ user_rf_cal_sector_set(void)
 
         case FLASH_SIZE_32M_MAP_512_512:
         case FLASH_SIZE_32M_MAP_1024_1024:
+        case FLASH_SIZE_32M_MAP_2048_2048:
             rf_cal_sec = 1024 - 5;
+            break;
+
+        case FLASH_SIZE_64M_MAP:
+            rf_cal_sec = 2048 - 5;
+            break;
+
+        case FLASH_SIZE_128M_MAP:
+            rf_cal_sec = 4096 - 5;
             break;
 
         default:

--- a/sdk-overrides/include/user_interface.h
+++ b/sdk-overrides/include/user_interface.h
@@ -6,5 +6,11 @@
 bool wifi_softap_deauth(uint8 mac[6]);
 uint8 get_fpm_auto_sleep_flag(void);
 
+enum ext_flash_size_map {
+    FLASH_SIZE_32M_MAP_2048_2048 = 7,
+    FLASH_SIZE_64M_MAP = 8,
+    FLASH_SIZE_128M_MAP = 9
+};
+
 
 #endif /* SDK_OVERRIDES_INCLUDE_USER_INTERFACE_H_ */


### PR DESCRIPTION
Fixes #1390.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.

Short after adding support for 64Mbit and 128Mbit flashes with #1367, the update to SDK 1.5.4.1 presumably broke them again when the rf_cal sector was introduced. This PR adds the missing rf_cal handling for 64m and 128m flash layouts.
I can't test the code for any improvement on these devices due to a lack of hardware, but expect that issues with new module designs like the [WEMOS D1 mini pro](https://www.wemos.cc/product/d1-mini-pro.html) will show up in the near future. Would be great if someone with a 16 Mbyte module could test drive this patch. Otherwise I'll do it myself once hardware is at my desk.

Note my clumsy approach to extend the `flash_size_map` enum in `user_interface.h`. I'd be happy to swap it against a more elegant method.