### PR TITLE
Smaller lua buffer -- reducing stack requirements

### DIFF
--- a/app/lua/liolib.c
+++ b/app/lua/liolib.c
@@ -343,28 +343,19 @@ static int read_line (lua_State *L, int f) {
 static int read_line (lua_State *L, int f) {
   luaL_Buffer b;
   luaL_buffinit(L, &b);
-  char *p = luaL_prepbuffer(&b);
-  signed char c = EOF;
-  int i = 0;
-  do{
+  signed char c;
+  do {
     c = (signed char)vfs_getc(f);
-    if(c==EOF){
+    if (c==EOF) {
       break;
     }
-    p[i++] = c;
-  }while((c!=EOF) && (c!='\n') && (i<LUAL_BUFFERSIZE) );
+    if (c != '\n') {
+      luaL_addchar(&b, c);
+    }
+  } while (c != '\n');
 
-  if(i>0 && p[i-1] == '\n')
-    i--;    /* do not include `eol' */
-
-  if(i==0){
-    luaL_pushresult(&b);  /* close buffer */
-    return (lua_objlen(L, -1) > 0);  /* check whether read something */
-  }
-
-  luaL_addsize(&b, i);
   luaL_pushresult(&b);  /* close buffer */
-  return 1;  /* read at least an `eol' */ 
+  return (lua_objlen(L, -1) > 0);  /* check whether read something */
 }
 #endif
 

--- a/app/lua/luaconf.h
+++ b/app/lua/luaconf.h
@@ -556,7 +556,7 @@ extern int readline4lua(const char *prompt, char *buffer, int length);
 ** For example: If set to 4K a call to string.gsub will need more than 
 ** 5k C stack space.
 */
-#define LUAL_BUFFERSIZE		BUFSIZ
+#define LUAL_BUFFERSIZE		256
 
 /* }================================================================== */
 

--- a/app/modules/ow.c
+++ b/app/modules/ow.c
@@ -134,6 +134,8 @@ static int ow_read_bytes( lua_State *L )
   if( size == 0 )
     return 0;
 
+  luaL_argcheck(L, size <= LUAL_BUFFERSIZE, 2, "Attempt to read too many characters");
+
   luaL_Buffer b;
   luaL_buffinit( L, &b );
   char *p = luaL_prepbuffer(&b);

--- a/docs/en/modules/ow.md
+++ b/docs/en/modules/ow.md
@@ -84,7 +84,7 @@ Reads multi bytes.
 
 #### Parameters
 - `pin` 1~12, I/O index
-- `size` number of bytes to be read from slave device
+- `size` number of bytes to be read from slave device (up to 256)
 
 #### Returns
 `string` bytes read from slave device


### PR DESCRIPTION
Fixes #1523 



- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Essentially this just changes the #define for the size of the internal LUA buffer used in luaL_Buffer objects. I only found one uses where the input size was uncontrolled. The onewire case was fixed by limiting the number of bytes to read to be the same as LUAL_BUFFERSIZE. 

The other case interesting case is in read_line in liolib.c It did limit the read to the buffer size (which is now smaller). However, the callers would not be happy with a shorter line if it wasn't properly terminated. I fixed this function to read to the end of the line and return the resulting string. It isn't clear that that is the right solution. 

I tried running the code and it *appeared* to work the same way as before. In particular I could reverse long strings (much bigger than 1k). 