### PR TITLE
Implement object model for files

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -76,6 +76,9 @@ extern void luaL_assertfail(const char *file, int line, const char *message);
 // maximum length of a filename
 #define FS_OBJ_NAME_LEN 31
 
+// maximum number of open files for SPIFFS
+#define SPIFFS_MAX_OPEN_FILES 4
+
 // Uncomment this next line for fastest startup 
 // It reduces the format time dramatically
 // #define SPIFFS_MAX_FILESYSTEM_SIZE	32768

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -2,6 +2,8 @@
 #include "platform.h"
 #include "spiffs.h"
 
+#include "spiffs_nucleus.h"
+
 spiffs fs;
 
 #define LOG_PAGE_SIZE       	256
@@ -10,9 +12,9 @@ spiffs fs;
 #define MIN_BLOCKS_FS		4
   
 static u8_t spiffs_work_buf[LOG_PAGE_SIZE*2];
-static u8_t spiffs_fds[32*4];
+static u8_t spiffs_fds[sizeof(spiffs_fd) * SPIFFS_MAX_OPEN_FILES];
 #if SPIFFS_CACHE
-static u8_t spiffs_cache[(LOG_PAGE_SIZE+32)*2];
+static u8_t myspiffs_cache[(LOG_PAGE_SIZE+32)*2];
 #endif
 
 static s32_t my_spiffs_read(u32_t addr, u32_t size, u8_t *dst) {
@@ -168,8 +170,8 @@ static bool myspiffs_mount_internal(bool force_mount) {
     spiffs_fds,
     sizeof(spiffs_fds),
 #if SPIFFS_CACHE
-    spiffs_cache,
-    sizeof(spiffs_cache),
+    myspiffs_cache,
+    sizeof(myspiffs_cache),
 #else
     0, 0,
 #endif

--- a/docs/en/modules/file.md
+++ b/docs/en/modules/file.md
@@ -7,8 +7,6 @@ The file module provides access to the file system and its individual files.
 
 The file system is a flat file system, with no notion of subdirectories/folders.
 
-Only one file can be open at any given time.
-
 Besides the SPIFFS file system on internal flash, this module can also access FAT partitions on an external SD card is [FatFS is enabled](../sdcard.md).
 
 ```lua
@@ -331,9 +329,13 @@ if src then
 end
 ```
 
-+!!! Attention
-+
-+    It is recommended to use only one single model within the application. Concurrent use of both models within can yield unpredictable behavior: Closing the default file from basic model will also close the correspoding file object. Closing a file from object model will also close the default file if they are the same file.
+!!! Attention
+
+    It is recommended to use only one single model within the application. Concurrent use of both models can yield unpredictable behavior: Closing the default file from basic model will also close the correspoding file object. Closing a file from object model will also close the default file if they are the same file.
+
+!!! Note
+
+    The maximum number of open files on SPIFFS is determined at compile time by `SPIFFS_MAX_OPEN_FILES` in `user_config.h`.
 
 ## file.close()
 ## file.obj:close()

--- a/docs/en/modules/file.md
+++ b/docs/en/modules/file.md
@@ -43,30 +43,6 @@ Current directory defaults to the root of internal SPIFFS (`/FLASH`) after syste
 #### Returns
 `true` on success, `false` otherwise
 
-## file.close()
-
-Closes the open file, if any.
-
-#### Syntax
-`file.close()`
-
-#### Parameters
-none
-
-#### Returns
-`nil`
-
-#### Example
-```lua
--- open 'init.lua', print the first line.
-if file.open("init.lua", "r") then
-  print(file.readline())
-  file.close()
-end
-```
-#### See also
-[`file.open()`](#fileopen)
-
 ## file.exists()
 
 Determines whether the specified file exists.
@@ -94,34 +70,6 @@ end
 ```
 #### See also
 [`file.list()`](#filelist)
-
-## file.flush()
-
-Flushes any pending writes to the file system, ensuring no data is lost on a restart. Closing the open file using [`file.close()`](#fileclose) performs an implicit flush as well.
-
-#### Syntax
-`file.flush()`
-
-#### Parameters
-none
-
-#### Returns
-`nil`
-
-#### Example
-```lua
--- open 'init.lua' in 'a+' mode
-if file.open("init.lua", "a+") then
-  -- write 'foo bar' to the end of the file
-  file.write('foo bar')
-  file.flush()
-  -- write 'baz' too
-  file.write('baz')
-  file.close()
-end
-```
-#### See also
-[`file.close()`](#fileclose)
 
 ## file.format()
 
@@ -280,9 +228,9 @@ When done with the file, it must be closed using `file.close()`.
     - "a+": append update mode, previous data is preserved, writing is only allowed at the end of file
 
 #### Returns
-`nil` if file not opened, or not exists (read modes).  `true` if file opened ok.
+file object if file opened ok. `nil` if file not opened, or not exists (read modes).
 
-#### Example
+#### Example (basic model)
 ```lua
 -- open 'init.lua', print the first line.
 if file.open("init.lua", "r") then
@@ -290,74 +238,19 @@ if file.open("init.lua", "r") then
   file.close()
 end
 ```
-#### See also
-- [`file.close()`](#fileclose)
-- [`file.readline()`](#filereadline)
-
-## file.read()
-
-Read content from the open file.
-
-!!! note
-
-    The function temporarily allocates 2 * (number of requested bytes) on the heap for buffering and processing the read data. Default chunk size (`FILE_READ_CHUNK`) is 1024 bytes and is regarded to be safe. Pushing this by 4x or more can cause heap overflows depending on the application. Consider this when selecting a value for parameter `n_or_char`.
-
-#### Syntax
-`file.read([n_or_char])`
-
-#### Parameters
-- `n_or_char`:
-	- if nothing passed in, then read up to `FILE_READ_CHUNK` bytes or the entire file (whichever is smaller).
-	- if passed a number `n`, then read up to `n` bytes or the entire file (whichever is smaller).
-	- if passed a string containing the single character `char`, then read until `char` appears next in the file, `FILE_READ_CHUNK` bytes have been read, or EOF is reached.
-
-#### Returns
-File content as a string, or nil when EOF
-
-#### Example
+#### Example (object model)
 ```lua
--- print the first line of 'init.lua'
-if file.open("init.lua", "r") then
-  print(file.read('\n'))
-  file.close()
-end
-
--- print the first 5 bytes of 'init.lua'
-if file.open("init.lua", "r") then
-  print(file.read(5))
-  file.close()
+-- open 'init.lua', print the first line.
+fd = file.open("init.lua", "r")
+if fd then
+  print(fd:readline())
+  fd:close(); fd = nil
 end
 ```
 
 #### See also
-- [`file.open()`](#fileopen)
-- [`file.readline()`](#filereadline)
-
-## file.readline()
-
-Read the next line from the open file. Lines are defined as zero or more bytes ending with a EOL ('\n') byte. If the next line is longer than 1024, this function only returns the first 1024 bytes.
-
-#### Syntax
-`file.readline()`
-
-#### Parameters
-none
-
-#### Returns
-File content in string, line by line, including EOL('\n'). Return `nil` when EOF.
-
-#### Example
-```lua
--- print the first line of 'init.lua'
-if file.open("init.lua", "r") then
-  print(file.readline())
-  file.close()
-end
-```
-#### See also
-- [`file.open()`](#fileopen)
 - [`file.close()`](#fileclose)
-- [`file.read()`](#filereade)
+- [`file.readline()`](#filereadline)
 
 ## file.remove()
 
@@ -402,11 +295,183 @@ Renames a file. If a file is currently open, it will be closed first.
 file.rename("temp.lua","init.lua")
 ```
 
+# File access functions
+
+The `file` module provides several functions to access the content of a file after it has been opened with [`file.open()`](#fileopen). They can be used as part of a basic model or an object model:
+
+## Basic model
+In the basic model there is max one file opened at a time. The file access functions operate on this file per default. If another file is opened, the previous default file needs to be closed beforehand.
+
+```lua
+-- open 'init.lua', print the first line.
+if file.open("init.lua", "r") then
+  print(file.readline())
+  file.close()
+end
+```
+
+## Object model
+Files are represented by file objects which are created by `file.open()`. File access functions are available as methods of this object, and multiple file objects can coexist.
+
+```lua
+src = file.open("init.lua", "r")
+if src then
+  dest = file.open("copy.lua", "w")
+  if dest then
+    local line
+    repeat
+      line = src:read()
+      if line then
+        dest:write(line)
+      end
+    until line == nil
+    dest:close(); dest = nil
+  end
+  src:close(); dest = nil
+end
+```
+
++!!! Attention
++
++    It is recommended to use only one single model within the application. Concurrent use of both models within can yield unpredictable behavior: Closing the default file from basic model will also close the correspoding file object. Closing a file from object model will also close the default file if they are the same file.
+
+## file.close()
+## file.obj:close()
+
+Closes the open file, if any.
+
+#### Syntax
+`file.close()`
+
+`fd:close()`
+
+#### Parameters
+none
+
+#### Returns
+`nil`
+
+#### See also
+[`file.open()`](#fileopen)
+
+## file.flush()
+## file.obj:flush()
+
+Flushes any pending writes to the file system, ensuring no data is lost on a restart. Closing the open file using [`file.close()` / `fd:close()`](#fileclose) performs an implicit flush as well.
+
+#### Syntax
+`file.flush()`
+
+`fd:flush()`
+
+#### Parameters
+none
+
+#### Returns
+`nil`
+
+#### Example (basic model)
+```lua
+-- open 'init.lua' in 'a+' mode
+if file.open("init.lua", "a+") then
+  -- write 'foo bar' to the end of the file
+  file.write('foo bar')
+  file.flush()
+  -- write 'baz' too
+  file.write('baz')
+  file.close()
+end
+```
+
+#### See also
+[`file.close()` / `file.obj:close()`](#fileclose)
+
+## file.read()
+## file.obj:read()
+
+Read content from the open file.
+
+!!! note
+
+    The function temporarily allocates 2 * (number of requested bytes) on the heap for buffering and processing the read data. Default chunk size (`FILE_READ_CHUNK`) is 1024 bytes and is regarded to be safe. Pushing this by 4x or more can cause heap overflows depending on the application. Consider this when selecting a value for parameter `n_or_char`.
+
+#### Syntax
+`file.read([n_or_char])`
+
+`fd:read([n_or_char])`
+
+#### Parameters
+- `n_or_char`:
+	- if nothing passed in, then read up to `FILE_READ_CHUNK` bytes or the entire file (whichever is smaller).
+	- if passed a number `n`, then read up to `n` bytes or the entire file (whichever is smaller).
+	- if passed a string containing the single character `char`, then read until `char` appears next in the file, `FILE_READ_CHUNK` bytes have been read, or EOF is reached.
+
+#### Returns
+File content as a string, or nil when EOF
+
+#### Example (basic model)
+```lua
+-- print the first line of 'init.lua'
+if file.open("init.lua", "r") then
+  print(file.read('\n'))
+  file.close()
+end
+```
+
+#### Example (object model)
+```lua
+-- print the first 5 bytes of 'init.lua'
+fd = file.open("init.lua", "r")
+if fd then
+  print(fd:read(5))
+  fd:close(); fd = nil
+end
+```
+
+#### See also
+- [`file.open()`](#fileopen)
+- [`file.readline()` / `file.obj:readline()`](#filereadline)
+
+## file.readline()
+## file.obj:readline()
+
+Read the next line from the open file. Lines are defined as zero or more bytes ending with a EOL ('\n') byte. If the next line is longer than 1024, this function only returns the first 1024 bytes.
+
+#### Syntax
+`file.readline()`
+
+`fd:readline()`
+
+#### Parameters
+none
+
+#### Returns
+File content in string, line by line, including EOL('\n'). Return `nil` when EOF.
+
+#### Example (basic model)
+```lua
+-- print the first line of 'init.lua'
+if file.open("init.lua", "r") then
+  print(file.readline())
+  file.close()
+end
+```
+
+#### See also
+- [`file.open()`](#fileopen)
+- [`file.close()` / `file.obj:close()`](#fileclose)
+- [`file.read()` / `file.obj:read()`](#fileread)
+
+
 ## file.seek()
+## file.obj:seek()
+
 Sets and gets the file position, measured from the beginning of the file, to the position given by offset plus a base specified by the string whence.
 
 #### Syntax
 `file.seek([whence [, offset]])`
+
+`fd:seek([whence [, offset]])`
 
 #### Parameters
 - `whence`
@@ -420,7 +485,7 @@ If no parameters are given, the function simply returns the current file offset.
 #### Returns
 the resulting file position, or `nil` on error
 
-#### Example
+#### Example (basic model)
 ```lua
 if file.open("init.lua", "r") then
   -- skip the first 5 bytes of the file
@@ -433,11 +498,14 @@ end
 [`file.open()`](#fileopen)
 
 ## file.write()
+## file.obj:write()
 
 Write a string to the open file.
 
 #### Syntax
 `file.write(string)`
+
+`fd:write(string)`
 
 #### Parameters
 `string` content to be write to file
@@ -445,7 +513,7 @@ Write a string to the open file.
 #### Returns
 `true` if the write is ok, `nil` on error
 
-#### Example
+#### Example (basic model)
 ```lua
 -- open 'init.lua' in 'a+' mode
 if file.open("init.lua", "a+") then
@@ -455,16 +523,30 @@ if file.open("init.lua", "a+") then
 end
 ```
 
+#### Example (object model)
+```lua
+-- open 'init.lua' in 'a+' mode
+fd = file.open("init.lua", "a+")
+if fd then
+  -- write 'foo bar' to the end of the file
+  fd:write('foo bar')
+  fd:close()
+end
+```
+
 #### See also
 - [`file.open()`](#fileopen)
-- [`file.writeline()`](#filewriteline)
+- [`file.writeline()` / `file.obj:writeline()`](#filewriteline)
 
 ## file.writeline()
+## file.obj:writeline()
 
 Write a string to the open file and append '\n' at the end.
 
 #### Syntax
 `file.writeline(string)`
+
+`fd:writeline(string)`
 
 #### Parameters
 `string` content to be write to file
@@ -472,7 +554,7 @@ Write a string to the open file and append '\n' at the end.
 #### Returns
 `true` if write ok, `nil` on error
 
-#### Example
+#### Example (basic model)
 ```lua
 -- open 'init.lua' in 'a+' mode
 if file.open("init.lua", "a+") then
@@ -484,4 +566,4 @@ end
 
 #### See also
 - [`file.open()`](#fileopen)
-- [`file.readline()`](#filereadline)
+- [`file.readline()` / `file.obj:readline()`](#filereadline)


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Current file access functions operate on a default file and restrict the user to only one opened file at a time. This PR adds an object model to the `file` module which removes this constraint. The basic model is kept for compatibility.

Compared to the current implementation, this extension comes at costs regarding
- memory - opening a file now allocates a Lua userdata (containing a single `int`)
- run time - functions like `file_read()` etc. call `lua_type()` to determine the used model
- dev complexity - both models have to be maintained in parallel
- user complexity - users have to understand the differences to select and consistently use one of the models

This topic was briefly mentioned in the course of the FAT concept discussion, but I'd like to re-check whether there's a common agreement that `file` should evolve in this direction.
