### PR TITLE
Add time frame for removal of deprecated tmr functions

### DIFF
--- a/docs/en/modules/tmr.md
+++ b/docs/en/modules/tmr.md
@@ -13,7 +13,7 @@ NodeMCU provides 7 static timers, numbered 0-6, and dynamic timer creation funct
 
 !!! attention
 
-    Static timers are deprecated and will be removed later.
+    Static timers are deprecated and will be removed at the end of 2016.
 
 ## tmr.alarm()
 


### PR DESCRIPTION
This came up while reviewing #1532.
