### PR TITLE
Fix dereferencing NULL pointer in vfs_errno()

### DIFF
--- a/app/platform/vfs.c
+++ b/app/platform/vfs.c
@@ -355,10 +355,11 @@ sint32_t vfs_chdir( const char *path )
 sint32_t vfs_errno( const char *name )
 {
   vfs_fs_fns *fs_fns;
-  const char *normname = normalize_path( name );
   char *outname;
 
   if (!name) name = "";  // current drive
+
+  const char *normname = normalize_path( name );
 
 #ifdef BUILD_SPIFFS
   if (fs_fns = myspiffs_realm( normname, &outname, FALSE )) {


### PR DESCRIPTION
Fixes #1397.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

Fixes dereferencing NULL pointer in `vfs_errno()`.
