### PR TITLE
Avoid task queue overrun for serial input

### DIFF
--- a/app/include/driver/uart.h
+++ b/app/include/driver/uart.h
@@ -101,7 +101,7 @@ typedef struct {
     int                      buff_uart_no;  //indicate which uart use tx/rx buffer
 } UartDevice;
 
-void uart_init(UartBautRate uart0_br, UartBautRate uart1_br, os_signal_t sig_input);
+void uart_init(UartBautRate uart0_br, UartBautRate uart1_br, os_signal_t sig_input, uint8 *flag_input);
 void uart0_alt(uint8 on);
 void uart0_sendStr(const char *str);
 void uart0_putc(const char c);

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -30,6 +30,7 @@
 #endif
 
 static task_handle_t input_sig;
+static uint8 input_sig_flag = 0;
 
 /* Contents of esp_init_data_default.bin */
 extern const uint32_t init_data[];
@@ -100,7 +101,10 @@ static void start_lua(task_param_t param, uint8 priority) {
 
 static void handle_input(task_param_t flag, uint8 priority) {
   (void)priority;
-  lua_handle_input (flag);
+  if (flag & 0x8000) {
+    input_sig_flag = flag & 0x4000 ? 1 : 0;
+  }
+  lua_handle_input (flag & 0x01);
 }
 
 bool user_process_input(bool force) {
@@ -231,7 +235,7 @@ void user_init(void)
     UartBautRate br = BIT_RATE_DEFAULT;
 
     input_sig = task_get_id(handle_input);
-    uart_init (br, br, input_sig);
+    uart_init (br, br, input_sig, &input_sig_flag);
 
 #ifndef NODE_DEBUG
     system_set_os_print(0);


### PR DESCRIPTION
Fixes #1536.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This PR mitigates overrunning the task queue with superfluous posts for the serial input handler. Details are described in https://github.com/nodemcu/nodemcu-firmware/issues/1536#issuecomment-253062971.

#### Test case
I used the code from http://www.esp8266.com/viewtopic.php?f=24&t=12026 to trigger the issue on current `dev`:
```lua
pin = 4

occupied = false

-- callback resets the occupied flag
function seroutCallback()
  occupied = false
end

-- gets run every 50ms
function timerCallback()
  if occupied then
    print("occupied")
  else
    print(" not occupied")

    occupied = true
    -- gpio.serout() is asynchronus, if a callback is provided
    -- the times dont matter
    gpio.serout(pin, gpio.LOW,{5000,5000,5000,5000,5000,5000,5000}, 1, seroutCallback)

  end
end


tmr.register(3, 50, tmr.ALARM_AUTO, timerCallback)
tmr.start(3)
```

Sending some bytes to the ESP while the timer has started overflows the queue:
```
0123456789012345678901234567890123456789
0123456789012345678901234567890123456789
0123456789012345678901234567890123456789
0123456789012345678901234567890123456789
0123456789012345678901234567890123456789
0123456789
```

No overflow occurs with this patch applied.
