### PR TITLE
gpio: report system time

### DIFF
--- a/app/modules/gpio.c
+++ b/app/modules/gpio.c
@@ -52,7 +52,8 @@ static void gpio_intr_callback_task (task_param_t param, uint8 priority)
     // Do the actual callback
     lua_rawgeti(L, LUA_REGISTRYINDEX, gpio_cb_ref[pin]);
     lua_pushinteger(L, level);
-    lua_call(L, 1, 0);
+    lua_pushinteger(L, 0x7FFFFFFF & system_get_time());
+    lua_call(L, 2, 0);
 
     if (INTERRUPT_TYPE_IS_LEVEL(pin_int_type[pin])) {
       // Level triggered -- re-enable the callback


### PR DESCRIPTION
This small change allows for easy parsing of some common protocols.
Say, NEC IR:

```lua
------------------------------------------------------------------------------
-- IR recv module
--
-- LICENSE: http://opensource.org/licenses/MIT
-- Vladimir Dronnikov <dronnikov@gmail.com>
--
-- Example:
-- dofile("irrecv.lua").nec(3, function(code) print(("%08X"):format(code)) end)
------------------------------------------------------------------------------ 

irrecv = { }

-- http://www.sbprojects.com/knowledge/ir/nec.php

function irrecv.nec(pin, reporter)
  -- cache
  local bs, br, ba, bx, brs = bit.set, bit.clear, bit.band, bit.bxor, bit.rshift
  local i = 32
  local b = 0
  local dt = 0
  gpio.mode(pin, gpio.INT)
  gpio.trig(pin, "both", function(l, t)
    -- analyse pulse widths
    if l == 1 then
      dt = t
    else
      dt = t - dt
      -- 0
      if dt < 1000 then
        i = i - 1
        b = br(b, i)
      -- 1
      elseif dt < 2000 then
        i = i - 1
        b = bs(b, i)
      -- start of sequence
      elseif dt > 4000 then
        i = 32
        b = 0
      end
      -- sequence end?
      if i == 0 then
        -- check crc
        if bx(ba(brs(b, 8), 0xff), ba(b, 0xff)) == 0xff then
          reporter(b)
        end
      end
    end
  end)
end

return irrecv 
```

Pity, it starts to behave wrong if processor is performing tight tasks. E.g. it was missing pulses when I did tight 5ms endless cycle of reading MCP23017 pins.

So this patch is mostly for staff to stare and decide on whether it is feasible to have and how to make it work under the load.
