### PR TITLE
Fix for httpclient resetting the system (maybe)

### DIFF
--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -411,13 +411,6 @@ static void ICACHE_FLASH_ATTR http_disconnect_callback( void * arg )
 }
 
 
-static void ICACHE_FLASH_ATTR http_error_callback( void *arg, sint8 errType )
-{
-	HTTPCLIENT_DEBUG( "Disconnected with error\n" );
-	http_disconnect_callback( arg );
-}
-
-
 static void ICACHE_FLASH_ATTR http_timeout_callback( void *arg )
 {
 	HTTPCLIENT_DEBUG( "Connection timeout\n" );
@@ -436,6 +429,13 @@ static void ICACHE_FLASH_ATTR http_timeout_callback( void *arg )
 		espconn_secure_disconnect( conn );
 	else
 		espconn_disconnect( conn );
+}
+
+
+static void ICACHE_FLASH_ATTR http_error_callback( void *arg, sint8 errType )
+{
+	HTTPCLIENT_DEBUG( "Disconnected with error: %d\n", errType );
+	http_timeout_callback( arg );
 }
 
 


### PR DESCRIPTION
Partially Fixes #1546.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.

The issue was that the reconcb called the disconnect cb. This was bad as it freed up all the control blocks and didn't disconnect the connection. I switched it over to called the timeout callback which does try and disconnect the connection and which then does the cleanup. 

I'm not entirely convinced that this is the right fix -- but I'm putting it out there in case anybody wants to build on it.