### PR TITLE
Fix vfs_lseek() result checking in enduser_setup

### DIFF
--- a/app/modules/enduser_setup.c
+++ b/app/modules/enduser_setup.c
@@ -498,7 +498,7 @@ static int enduser_setup_http_load_payload(void)
   const char cl_hdr[] = "Content-length:%5d\r\n\r\n";
   const size_t cl_len = LITLEN(cl_hdr) + 3; /* room to expand %4d */
 
-  if (!f || err != VFS_RES_OK || err2 != VFS_RES_OK)
+  if (!f || err == VFS_RES_ERR || err2 == VFS_RES_ERR)
   {
     ENDUSER_SETUP_DEBUG("enduser_setup_http_load_payload unable to load file enduser_setup.html, loading backup HTML.");
 

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -457,7 +457,8 @@ static sint32_t myspiffs_vfs_lseek( const struct vfs_file *fd, sint32_t off, int
     break;
   }
 
-  return SPIFFS_lseek( &fs, fh, off, spiffs_whence );
+  sint32_t res = SPIFFS_lseek( &fs, fh, off, spiffs_whence );
+  return res >= 0 ? res : VFS_RES_ERR;
 }
 
 static sint32_t myspiffs_vfs_eof( const struct vfs_file *fd ) {


### PR DESCRIPTION
Fixes #1397.
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.

As reported in https://github.com/nodemcu/nodemcu-firmware/issues/1508#issuecomment-257040880, checking the result from `vfs_lseek()` was broken. PR fixes this particular case and also ensures correct return code from `SPIFFS_lseek()`. API header doc for `SPIFFS_lseek` is a bit fuzzy in this respect.

This change should be double checked by somebody with a valid enduser_setup configuration.
