### PR TITLE
Add u8g display ssd1306_128x32

### DIFF
--- a/app/include/u8g_config.h
+++ b/app/include/u8g_config.h
@@ -24,6 +24,7 @@
 //
 // I2C based displays go into here:
 //    U8G_DISPLAY_TABLE_ENTRY(sh1106_128x64_i2c)          \
+//    U8G_DISPLAY_TABLE_ENTRY(ssd1306_128x32_i2c)         \
 //    U8G_DISPLAY_TABLE_ENTRY(ssd1306_128x64_i2c)         \
 //    U8G_DISPLAY_TABLE_ENTRY(ssd1306_64x48_i2c)          \
 //    U8G_DISPLAY_TABLE_ENTRY(ssd1309_128x64_i2c)         \
@@ -40,6 +41,7 @@
 //    U8G_DISPLAY_TABLE_ENTRY(pcd8544_84x48_hw_spi)               \
 //    U8G_DISPLAY_TABLE_ENTRY(pcf8812_96x65_hw_spi)               \
 //    U8G_DISPLAY_TABLE_ENTRY(sh1106_128x64_hw_spi)               \
+//    U8G_DISPLAY_TABLE_ENTRY(ssd1306_128x32_hw_spi)              \
 //    U8G_DISPLAY_TABLE_ENTRY(ssd1306_128x64_hw_spi)              \
 //    U8G_DISPLAY_TABLE_ENTRY(ssd1306_64x48_hw_spi)               \
 //    U8G_DISPLAY_TABLE_ENTRY(ssd1309_128x64_hw_spi)              \

--- a/docs/en/modules/u8g.md
+++ b/docs/en/modules/u8g.md
@@ -8,7 +8,7 @@ U8glib is a graphics library developed at [olikraus/u8glib](https://github.com/o
 I²C and SPI mode:
 
 - sh1106_128x64
-- ssd1306 - 128x64 and 64x48 variants
+- ssd1306 - 128x32, 128x64, and 64x48 variants
 - ssd1309_128x64
 - ssd1327_96x96_gr
 - uc1611 - dogm240 and dogxl240 variants
@@ -107,6 +107,7 @@ Initialize a display via I²C.
 The init sequence would insert delays to match the display specs. These can destabilize the overall system if wifi service is blocked for too long. It is therefore advisable to disable such delays unless the specific use case can exclude wifi traffic while initializing the display driver.
 
 - `u8g.sh1106_128x64_i2c()`
+- `u8g.ssd1306_128x32_i2c()`
 - `u8g.ssd1306_128x64_i2c()`
 - `u8g.ssd1306_64x48_i2c()`
 - `u8g.ssd1309_128x64_i2c()`
@@ -146,6 +147,7 @@ The init sequence would insert delays to match the display specs. These can dest
 - `u8g.pcd8544_84x48_hw_spi()`
 - `u8g.pcf8812_96x65_hw_spi()`
 - `u8g.sh1106_128x64_hw_spi()`
+- `u8g.ssd1306_128x32_hw_spi()`
 - `u8g.ssd1306_128x64_hw_spi()`
 - `u8g.ssd1306_64x48_hw_spi()`
 - `u8g.ssd1309_128x64_hw_spi()`


### PR DESCRIPTION
Fixes #1567.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have tested my contribution to compile correctly, but no hardware available.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Adds SSD1306_128x32 (I2C and SPI) to `u8g_config.h`.
