### PR TITLE
support for custom websocket headers

### DIFF
--- a/app/modules/websocket.c
+++ b/app/modules/websocket.c
@@ -120,7 +120,6 @@ static int websocketclient_on(lua_State *L) {
   NODE_DBG("websocketclient_on\n");
 
   ws_info *ws = (ws_info *) luaL_checkudata(L, 1, METATABLE_WSCLIENT);  
-  luaL_argcheck(L, ws, 1, "Client websocket expected");
 
   ws_data *data = (ws_data *) ws->reservedData;
 
@@ -172,7 +171,6 @@ static int websocketclient_connect(lua_State *L) {
   NODE_DBG("websocketclient_connect is called.\n");
 
   ws_info *ws = (ws_info *) luaL_checkudata(L, 1, METATABLE_WSCLIENT);  
-  luaL_argcheck(L, ws, 1, "Client websocket expected");
 
   ws_data *data = (ws_data *) ws->reservedData;
 
@@ -207,7 +205,6 @@ static int websocketclient_config(lua_State *L) {
   NODE_DBG("websocketclient_config is called.\n");
 
   ws_info *ws = (ws_info *) luaL_checkudata(L, 1, METATABLE_WSCLIENT);
-  luaL_argcheck(L, ws, 1, "Client websocket expected");
 
   ws_data *data = (ws_data *) ws->reservedData;
 
@@ -246,7 +243,6 @@ static int websocketclient_send(lua_State *L) {
   NODE_DBG("websocketclient_send is called.\n");
 
   ws_info *ws = (ws_info *) luaL_checkudata(L, 1, METATABLE_WSCLIENT);  
-  luaL_argcheck(L, ws, 1, "Client websocket expected");
 
   ws_data *data = (ws_data *) ws->reservedData;
 
@@ -279,7 +275,6 @@ static int websocketclient_gc(lua_State *L) {
   NODE_DBG("websocketclient_gc\n");
 
   ws_info *ws = (ws_info *) luaL_checkudata(L, 1, METATABLE_WSCLIENT);  
-  luaL_argcheck(L, ws, 1, "Client websocket expected");
 
   ws->extraHeaders = realloc_headers(ws->extraHeaders, 0);
 

--- a/app/modules/websocket.c
+++ b/app/modules/websocket.c
@@ -45,7 +45,7 @@ static void websocketclient_onConnectionCallback(ws_info *ws) {
   }
 }
 
-static void websocketclient_onReceiveCallback(ws_info *ws, char *message, int opCode) {
+static void websocketclient_onReceiveCallback(ws_info *ws, int len, char *message, int opCode) {
   NODE_DBG("websocketclient_onReceiveCallback\n");
 
   lua_State *L = lua_getstate();
@@ -59,7 +59,7 @@ static void websocketclient_onReceiveCallback(ws_info *ws, char *message, int op
   if (data->onReceive != LUA_NOREF) {
     lua_rawgeti(L, LUA_REGISTRYINDEX, data->onReceive); // load the callback function
     lua_rawgeti(L, LUA_REGISTRYINDEX, data->self_ref);  // pass itself, #1 callback argument
-    lua_pushstring(L, message); // #2 callback argument
+    lua_pushlstring(L, message, len); // #2 callback argument
     lua_pushnumber(L, opCode); // #3 callback argument
     lua_call(L, 3, 0);
   }
@@ -183,7 +183,8 @@ static int websocketclient_connect(lua_State *L) {
   data->self_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
   const char *url = luaL_checkstring(L, 2);
-  ws_connect(ws, url);
+  const char *extraHeaders = luaL_optstring(L, 3, NULL);
+  ws_connect(ws, url, extraHeaders);
 
   return 0;
 }

--- a/app/websocket/websocketclient.c
+++ b/app/websocket/websocketclient.c
@@ -583,7 +583,7 @@ static void connect_callback(void *arg) {
   header_t headers[] = {
 	  {"Upgrade", "websocket"},
 	  {"Connection", "Upgrade"},
-	  {"Sec-Websocket-Key", key},
+	  {"Sec-WebSocket-Key", key},
 	  {"Sec-WebSocket-Version", "13"},
 	  {0}
   };

--- a/app/websocket/websocketclient.h
+++ b/app/websocket/websocketclient.h
@@ -43,6 +43,11 @@ typedef void (*ws_onConnectionCallback)(struct ws_info *wsInfo);
 typedef void (*ws_onReceiveCallback)(struct ws_info *wsInfo, int len, char *message, int opCode);
 typedef void (*ws_onFailureCallback)(struct ws_info *wsInfo, int errorCode);
 
+typedef struct {
+	char *key;
+	char *value;
+} header_t;
+
 typedef struct ws_info {
   int connectionState;
 
@@ -51,7 +56,7 @@ typedef struct ws_info {
   int port;
   char *path;
   char *expectedSecKey;
-  char *extraHeaders;
+  header_t *extraHeaders;
 
   struct espconn *conn;
   void *reservedData;
@@ -75,7 +80,7 @@ typedef struct ws_info {
 /*
  * Attempts to estabilish a websocket connection to the given url.
  */
-void ws_connect(ws_info *wsInfo, const char *url, const char *extraHeaders);
+void ws_connect(ws_info *wsInfo, const char *url);
 
 /*
  * Sends a message with a given opcode.

--- a/app/websocket/websocketclient.h
+++ b/app/websocket/websocketclient.h
@@ -40,7 +40,7 @@
 struct ws_info;
 
 typedef void (*ws_onConnectionCallback)(struct ws_info *wsInfo);
-typedef void (*ws_onReceiveCallback)(struct ws_info *wsInfo, char *message, int opCode);
+typedef void (*ws_onReceiveCallback)(struct ws_info *wsInfo, int len, char *message, int opCode);
 typedef void (*ws_onFailureCallback)(struct ws_info *wsInfo, int errorCode);
 
 typedef struct ws_info {
@@ -51,6 +51,7 @@ typedef struct ws_info {
   int port;
   char *path;
   char *expectedSecKey;
+  char *extraHeaders;
 
   struct espconn *conn;
   void *reservedData;
@@ -74,7 +75,7 @@ typedef struct ws_info {
 /*
  * Attempts to estabilish a websocket connection to the given url.
  */
-void ws_connect(ws_info *wsInfo, const char *url);
+void ws_connect(ws_info *wsInfo, const char *url, const char *extraHeaders);
 
 /*
  * Sends a message with a given opcode.

--- a/docs/en/modules/websocket.md
+++ b/docs/en/modules/websocket.md
@@ -66,16 +66,36 @@ ws = nil -- fully dispose the client as lua will now gc it
 ```
 
 
+## websocket.client:config(params)
+
+Configures websocket client instance.
+
+#### Syntax
+`websocket:config(params)`
+
+#### Parameters
+- `params` table with configuration parameters. Following keys are recognized:
+  - `headers` table of extra request headers
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+ws = websocket.createClient()
+ws:config({headers={['User-Agent']='NodeMCU'}})
+```
+
+
 ## websocket.client:connect()
 
 Attempts to estabilish a websocket connection to the given URL.
 
 #### Syntax
-`websocket:connect(url, headers)`
+`websocket:connect(url)`
 
 #### Parameters
 - `url` the URL for the websocket.
-- `headers` optional additional headers to append, *including \r\n*; may be `nil`
 
 #### Returns
 `nil`

--- a/docs/en/modules/websocket.md
+++ b/docs/en/modules/websocket.md
@@ -75,7 +75,7 @@ Configures websocket client instance.
 
 #### Parameters
 - `params` table with configuration parameters. Following keys are recognized:
-  - `headers` table of extra request headers
+  - `headers` table of extra request headers affecting every request
 
 #### Returns
 `nil`

--- a/docs/en/modules/websocket.md
+++ b/docs/en/modules/websocket.md
@@ -7,10 +7,6 @@ A websocket *client* module that implements [RFC6455](https://tools.ietf.org/htm
 
 The implementation supports fragmented messages, automatically respondes to ping requests and periodically pings if the server isn't communicating.
 
-!!! note
-
-    Currently, it is **not** possible to change the request headers, most notably the user agent.
-
 **SSL/TLS support**
 
 Take note of constraints documented in the [net module](net.md). 
@@ -75,10 +71,11 @@ ws = nil -- fully dispose the client as lua will now gc it
 Attempts to estabilish a websocket connection to the given URL.
 
 #### Syntax
-`websocket:connect(url)`
+`websocket:connect(url, headers)`
 
 #### Parameters
 - `url` the URL for the websocket.
+- `headers` optional additional headers to append, *including \r\n*; may be `nil`
 
 #### Returns
 `nil`


### PR DESCRIPTION
This PR adds support for optional parameter 'headers' in websocket.client:connect. It is implemented similarly to http module, for example headers string must include '\r\n' line terminators.

Also:
- fix to allow for '\0's in received messages
- support lowercase headers in server response (currently connection fails if server responds with perfectly valid lowercase 'sec-websocket-accept' header)

Above fixes together are necessary to connect to Amazon's MQTT via websocket gateway.  
