### PR TITLE
Add support to mix ws2812.buffer objects. 

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -300,7 +300,7 @@ static int ws2812_buffer_shift(lua_State* L) {
     // Store the values which are moved out of the array (last n pixels)
     c_memcpy(tmp_pixels, &buffer->values[offset + (size-shift)*buffer->colorsPerLed], shift_len);
     // Move pixels to end
-    os_memmove(&buffer->values[offset + shift*buffer->colorsPerLed], &buffer->values[0], remaining_len);
+    os_memmove(&buffer->values[offset + shift*buffer->colorsPerLed], &buffer->values[offset], remaining_len);
     // Fill beginning with temp data
     if (shift_type == SHIFT_LOGICAL)
     {
@@ -316,7 +316,7 @@ static int ws2812_buffer_shift(lua_State* L) {
     // Store the values which are moved out of the array (last n pixels)
     c_memcpy(tmp_pixels, &buffer->values[offset], shift_len);
     // Move pixels to end
-    os_memmove(&buffer->values[0], &buffer->values[offset + shift*buffer->colorsPerLed], remaining_len);
+    os_memmove(&buffer->values[offset], &buffer->values[offset + shift*buffer->colorsPerLed], remaining_len);
     // Fill beginning with temp data
     if (shift_type == SHIFT_LOGICAL)
     {

--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -224,7 +224,7 @@ static int ws2812_buffer_fill(lua_State* L) {
 }
 
 static int ws2812_buffer_fade(lua_State* L) {
-  ws2812_buffer * buffer = (ws2812_buffer*)luaL_checkudata(L, 1, "ws2812.udata");
+  ws2812_buffer * buffer = (ws2812_buffer*)luaL_checkudata(L, 1, "ws2812.buffer");
   const int fade = luaL_checkinteger(L, 2);
   unsigned direction = luaL_optinteger( L, 3, FADE_OUT );
 
@@ -253,7 +253,7 @@ static int ws2812_buffer_fade(lua_State* L) {
 
 
 static int ws2812_buffer_shift(lua_State* L) {
-  ws2812_buffer * buffer = (ws2812_buffer*)luaL_checkudata(L, 1, "ws2812.udata");
+  ws2812_buffer * buffer = (ws2812_buffer*)luaL_checkudata(L, 1, "ws2812.buffer");
   const int shiftValue = luaL_checkinteger(L, 2);
   const unsigned shift_type = luaL_optinteger( L, 3, SHIFT_LOGICAL );
 

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -181,6 +181,86 @@ The number of given bytes must match the number of bytesPerLed of the buffer
 buffer:fill(0, 0, 0) -- fill the buffer with black for a RGB strip
 ```
 
+## ws2812.buffer:dump()
+Returns the contents of the buffer (the pixel values) as a string. This can then be saved to a file or sent over a network.
+
+#### Syntax
+`buffer:dump()`
+
+#### Returns
+A string containing the pixel values. 
+
+#### Example
+```lua
+local s = buffer:dump() 
+```
+
+## ws2812.buffer:load()
+Converts a string into a buffer (see also the `dump` method). The buffer must have the correct shape or an error will be thrown.
+
+#### Syntax
+`buffer:load(string)`
+
+#### Parameters
+ - `string` the pixel values to be set into the buffer
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+`buffer:load(anotherbuffer:dump()) -- copy a buffer
+```
+
+## ws2812.buffer:mix()
+This is a general method that loads data into a buffer that is a linear combination of data from other buffers. It can be used to copy a buffer or,
+more usefully, do a cross fade.
+
+#### Syntax
+`buffer:mix(factor1, buffer1, ...)`
+
+#### Parameters
+ - `factor1` This is the factor that the contents of `buffer1` are multiplied by. This factor is scaled by a factor of 256. Thus `factor1` value of 256 is a factor of 1.0.
+ - `buffer1` This is the source buffer. It must be of the same shape as the destination buffer.
+
+There can be any number of factor/buffer pairs.
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+-- loads buffer with a crossfade between buffer1 and buffer2
+buffer:mix(256 - crossmix, buffer1, crossmix, buffer2)
+
+-- multiplies all values in buffer by 0.75
+-- This can be used in place of buffer:fade
+buffer:mix(192, buffer)
+```
+
+## ws2812.buffer:power()
+Computes the total energy requirement for the buffer. This is merely the total sum of all the pixel values (which assumes that each color in each
+pixel consumes the same amount of power).
+
+#### Syntax
+`buffer:power()`
+
+#### Returns
+An integer which is the sum of all the pixel values.
+
+#### Example
+```lua
+-- Dim the buffer to no more than the PSU can provide
+local psu_current_ma = 1000
+local led_current_ma = 20
+local led_sum = psu_current_ma * 255 / led_current_ma
+
+local p = buffer:power()
+if p > led_sum then
+  buffer:mix(256 * led_sum / p, buffer) -- power is now limited
+end
+```
+
 ## ws2812.buffer:fade()
 Fade in or out. Defaults to out. Multiply or divide each byte of each led with/by the given value. Useful for a fading effect. 
 

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -195,14 +195,16 @@ A string containing the pixel values.
 local s = buffer:dump() 
 ```
 
-## ws2812.buffer:load()
-Converts a string into a buffer (see also the `dump` method). The buffer must have the correct shape or an error will be thrown.
+## ws2812.buffer:replace()
+Inserts a string (or a buffer) into another buffer with an offset.
+The buffer must have the same number of colors per led or an error will be thrown.
 
 #### Syntax
-`buffer:load(string)`
+`buffer:replace(source[, offset])`
 
 #### Parameters
- - `string` the pixel values to be set into the buffer
+ - `source` the pixel values to be set into the buffer. This is either a string or a buffer.
+ - `offset` the offset where the source is to be placed in the buffer. Default is 1. Negative values can be used.
 
 #### Returns
 `nil`
@@ -241,7 +243,8 @@ buffer:mix(192, buffer)
 
 ## ws2812.buffer:power()
 Computes the total energy requirement for the buffer. This is merely the total sum of all the pixel values (which assumes that each color in each
-pixel consumes the same amount of power).
+pixel consumes the same amount of power). A real WS2812 (or WS2811) has three constant current drivers of 20mA -- one for each of R, G and B. The
+pulse width modulation will cause the *average* current to scale linearly with pixel value. 
 
 #### Syntax
 `buffer:power()`
@@ -297,3 +300,42 @@ Shift the content of the buffer in positive or negative direction. This allows s
 ```lua
 buffer:shift(3)
 ```
+
+## ws2812.buffer:sub()
+This implements the extraction function like `string.sub`. The indexes are in leds and all the same rules apply.
+
+#### Syntax
+`buffer1:sub(i[, j])`
+
+#### Parameters
+ - `i` This is the start of the extracted data. Negative values can be used.
+ - `j` this is the end of the extracted data. Negative values can be used. The default is -1.
+
+#### Returns
+A buffer containing the extracted piece.
+
+#### Example
+```
+b = buffer:sub(1,10)
+```
+
+## ws2812.buffer:__concat()
+This implements the `..` operator to concatenate two buffers. They must have the same number of colors per led.
+
+#### Syntax
+`buffer1 .. buffer2`
+
+#### Parameters
+ - `buffer1` this is the start of the resulting buffer
+ - `buffer2` this is the end of the resulting buffer
+
+#### Returns
+The concatenated buffer.
+
+#### Example
+```
+ws2812.write(buffer1 .. buffer2)
+```
+
+
+

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -71,7 +71,7 @@ ws2812.write(nil, string.char(0, 255, 0, 0, 255, 0)) -- turn the two first RGB l
 For more advanced animations, it is useful to keep a "framebuffer" of the strip,
 interact with it and flush it to the strip.
 
-For this purpose, the ws2812 library offers a read/write buffer.
+For this purpose, the ws2812 library offers a read/write buffer. This buffer has a `__tostring` method so that it can be printed. This is useful for debugging.
 
 #### Example
 Led chaser with a RGBW strip
@@ -214,7 +214,8 @@ Converts a string into a buffer (see also the `dump` method). The buffer must ha
 
 ## ws2812.buffer:mix()
 This is a general method that loads data into a buffer that is a linear combination of data from other buffers. It can be used to copy a buffer or,
-more usefully, do a cross fade.
+more usefully, do a cross fade. The pixel values are computed as integers and then range limited to [0, 255]. This means that negative
+factors work as expected, and that the order of combining buffers does not matter.
 
 #### Syntax
 `buffer:mix(factor1, buffer1, ...)`

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -211,7 +211,9 @@ The buffer must have the same number of colors per led or an error will be throw
 
 #### Example
 ```lua
-`buffer:load(anotherbuffer:dump()) -- copy a buffer
+buffer:replace(anotherbuffer:dump()) -- copy one buffer into another via a string
+buffer:replace(anotherbuffer) -- copy one buffer into another
+newbuffer = buffer.sub(1)     -- make a copy of a buffer into a new buffer
 ```
 
 ## ws2812.buffer:mix()

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -284,14 +284,17 @@ buffer:fade(2)
 buffer:fade(2, ws2812.FADE_IN)
 ```
 ## ws2812.buffer:shift()
-Shift the content of the buffer in positive or negative direction. This allows simple animation effects.
+Shift the content of (a piece of) the buffer in positive or negative direction. This allows simple animation effects. A slice of the buffer can be specified by using the 
+standard start and end offset Lua notation. Negative values count backwards from the end of the buffer.
 
 #### Syntax
-`buffer:shift(value [, mode])`
+`buffer:shift(value [, mode[, i[, j]]])`
 
 #### Parameters
  - `value` number of pixels by which to rotate the buffer. Positive values rotate forwards, negative values backwards. 
  - `mode` is the shift mode to use. Can be one of `ws2812.SHIFT_LOGICAL` or `ws2812.SHIFT_CIRCULAR`. In case of SHIFT\_LOGICAL, the freed pixels are set to 0 (off). In case of SHIFT\_CIRCULAR, the buffer is treated like a ring buffer, inserting the pixels falling out on one end again on the other end. Defaults to SHIFT\_LOGICAL. 
+ - `i` is the first offset in the buffer to be affected. Negative values are permitted and count backwards from the end. Default is 1.
+ - `j` is the last offset in the buffer to be affected. Negative values are permitted and count backwards from the end. Default is -1.
 
 #### Returns
 `nil`


### PR DESCRIPTION
Fixes #1574 
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This adds a number of new methods on the ws2812.buffer object. 

mix -- mix together a number of buffers in adjustable rations
power -- get the total power consumption of a buffer (useful if your power supply is limited)
load/dump -- convert a buffer to and from a string (in the raw string format)
__tostring -- format the buffer in a way that is useful for debug printing

Updated the documentation to match. Also improved the verification of the user data object.
