### PR TITLE
i2c - allow slave stretching SCL (just loop and check)

### DIFF
--- a/app/driver/i2c_master.c
+++ b/app/driver/i2c_master.c
@@ -33,6 +33,8 @@ LOCAL uint8 pinSCL = 15;
 LOCAL void ICACHE_FLASH_ATTR
 i2c_master_setDC(uint8 SDA, uint8 SCL)
 {
+    uint8 sclLevel;
+
     SDA	&= 0x01;
     SCL	&= 0x01;
     m_nLastSDA = SDA;
@@ -46,6 +48,11 @@ i2c_master_setDC(uint8 SDA, uint8 SCL)
         I2C_MASTER_SDA_HIGH_SCL_LOW();
     } else {
         I2C_MASTER_SDA_HIGH_SCL_HIGH();
+    }
+    if(1 == SCL) {
+        do {
+            sclLevel = GPIO_INPUT_GET(GPIO_ID_PIN(I2C_MASTER_SCL_GPIO));
+        } while(sclLevel == 0);
     }
 }
 


### PR DESCRIPTION
Fixes #1586 .

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Some i2c devices will hold SCL if the clock is too fast and they are not ready. Added a while loop to wait SCL to be high in i2c_master_setDC()
