### PR TITLE
Add note on dev board usage of SPI bus 0

### DIFF
--- a/docs/en/modules/spi.md
+++ b/docs/en/modules/spi.md
@@ -6,6 +6,16 @@
 All transactions for sending and receiving are most-significant-bit first and least-significant last.
 For technical details of the underlying hardware refer to [metalphreak's ESP8266 HSPI articles](http://d.av.id.au/blog/tag/hspi/).
 
+## A note on the SPI busses
+
+The ESP hardware provides two SPI busses, with IDs 0, and 1, which map to pins
+generally labelled SPI and HSPI.
+
+If you are using any kind of development board which provides flash, then bus
+ID 0 (SPI) is almost certainly used for communicating with the flash chip.
+You probably want to choose bus ID 1 (HSPI) for your communication, as you
+will have uncontended use of it.
+
 ## High Level Functions
 The high level functions provide a send & receive API for half- and
 full-duplex mode. Sent and received data items are restricted to 1 - 32 bit


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] (NA) I have thoroughly tested my contribution.
- [x] (NA) The code changes are reflected in the documentation at `docs/en/*`.

Documentation only.

I spent time and effort researching the mapping from bus number to the SPI/HSPI pin groups and also ran in to confusion with bus 0 being already in use by my dev board. This note is what I wish I'd found when first opening this module.