### PR TITLE
Handle error condition in file.read()

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -357,7 +357,7 @@ static int file_g_read( lua_State* L, int n, int16_t end_char, int fd )
       break;
     }
 
-  if (i == 0) {
+  if (i == 0 || n == VFS_RES_ERR) {
     if (heap_mem) {
       luaM_free(L, heap_mem);
       heap_mem = NULL;

--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -350,12 +350,16 @@ static int file_g_read( lua_State* L, int n, int16_t end_char, int fd )
 
   n = vfs_read(fd, p, n);
   // bypass search if no end character provided
-  for (i = end_char != EOF ? 0 : n; i < n; ++i)
-    if (p[i] == end_char)
-    {
-      ++i;
-      break;
-    }
+  if (n > 0 && end_char != EOF) {
+    for (i = 0; i < n; ++i)
+      if (p[i] == end_char)
+      {
+        ++i;
+        break;
+      }
+  } else {
+    i = n;
+  }
 
   if (i == 0 || n == VFS_RES_ERR) {
     if (heap_mem) {

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -433,13 +433,17 @@ static sint32_t myspiffs_vfs_close( const struct vfs_file *fd ) {
 static sint32_t myspiffs_vfs_read( const struct vfs_file *fd, void *ptr, size_t len ) {
   GET_FILE_FH(fd);
 
-  return SPIFFS_read( &fs, fh, ptr, len );
+  sint32_t n = SPIFFS_read( &fs, fh, ptr, len );
+
+  return n >= 0 ? n : VFS_RES_ERR;
 }
 
 static sint32_t myspiffs_vfs_write( const struct vfs_file *fd, const void *ptr, size_t len ) {
   GET_FILE_FH(fd);
 
-  return SPIFFS_write( &fs, fh, (void *)ptr, len );
+  sint32_t n = SPIFFS_write( &fs, fh, (void *)ptr, len );
+
+  return n >= 0 ? n : VFS_RES_ERR;
 }
 
 static sint32_t myspiffs_vfs_lseek( const struct vfs_file *fd, sint32_t off, int whence ) {


### PR DESCRIPTION
Fixes #1592.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

SPIFFS reports an error code when reading from an empty file (why not result in 0 len read instead?). This was not caught up to now in `file.read()` and led the firmware to crash.
Any error conditions are now handled and transformed into an empty read aka `nil` return.

This PR also unifies the return values from `SPIFFS_read()` and `SPIFFS_write()`. The header doc says they return -1 in case of errors, while they apparently report the specific error code.