### PR TITLE
Improve ROTable lookups -- DO NOT MERGE -- WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ sdk/
 cache/
 user_config.h
 server-ca.crt
+.output
+*.swp
+*.o
 
 #ignore Eclipse project files
 .cproject

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifdef DEBUG
   CCFLAGS += -ggdb -O0
   LDFLAGS += -ggdb
 else
-  CCFLAGS += -Os
+  CCFLAGS += -O2 
 endif
 
 #############################################################
@@ -185,7 +185,10 @@ DEP_LIBS_$(1) = $$(foreach lib,$$(filter %.a,$$(COMPONENTS_$(1))),$$(dir $$(lib)
 DEP_OBJS_$(1) = $$(foreach obj,$$(filter %.o,$$(COMPONENTS_$(1))),$$(dir $$(obj))$$(OBJODIR)/$$(notdir $$(obj)))
 $$(IMAGEODIR)/$(1).out: $$(OBJS) $$(DEP_OBJS_$(1)) $$(DEP_LIBS_$(1)) $$(DEPENDS_$(1))
 	@mkdir -p $$(IMAGEODIR)
-	$$(CC) $$(LDFLAGS) $$(if $$(LINKFLAGS_$(1)),$$(LINKFLAGS_$(1)),$$(LINKFLAGS_DEFAULT) $$(OBJS) $$(DEP_OBJS_$(1)) $$(DEP_LIBS_$(1))) -o $$@ 
+	$$(CC) $$(LDFLAGS) $$(if $$(LINKFLAGS_$(1)),$$(LINKFLAGS_$(1)),$$(LINKFLAGS_DEFAULT) $$(OBJS) $$(DEP_OBJS_$(1)) $$(DEP_LIBS_$(1))) -o $$@.tmp 
+	python $(TOP_DIR)/tools/addhashtables.py $$@.tmp > /tmp/hashtables.c
+	cd /tmp; $$(CC) -c hashtables.c
+	$$(CC) $$(LDFLAGS) $$(if $$(LINKFLAGS_$(1)),$$(LINKFLAGS_$(1)),$$(LINKFLAGS_DEFAULT) $$(OBJS) $$(DEP_OBJS_$(1)) $$(DEP_LIBS_$(1))) /tmp/hashtables.o -o $$@
 endef
 
 $(BINODIR)/%.bin: $(IMAGEODIR)/%.out

--- a/app/include/module.h
+++ b/app/include/module.h
@@ -53,9 +53,10 @@
 #define NODEMCU_MODULE(cfgname, luaname, map, initfunc) \
   const LOCK_IN_SECTION(".lua_libs") \
     luaL_Reg MODULE_PASTE_(lua_lib_,cfgname) = { luaname, initfunc }; \
+  const uint32_t __attribute__((weak)) MODULE_PASTE_(cfgname,_hashtable)[1] = {0}; \
   const LOCK_IN_SECTION(".lua_rotable") \
     luaR_table MODULE_EXPAND_PASTE_(cfgname,MODULE_EXPAND_PASTE_(_module_selected,MODULE_PASTE_(LUA_USE_MODULES_,cfgname))) \
-    = { luaname, map }
+    = { luaname, map, MODULE_PASTE_(cfgname,_hashtable), sizeof(luaname) }
 
 
 /* System module registration support, not using LUA_USE_MODULES_XYZ. */
@@ -64,8 +65,9 @@
     luaL_Reg MODULE_PASTE_(lua_lib_,name) = { luaname, initfunc }
 
 #define BUILTIN_LIB(name, luaname, map) \
+  const uint32_t __attribute__((weak)) MODULE_PASTE_(name,_hashtable)[1] = {0}; \
   const LOCK_IN_SECTION(".lua_rotable") \
-    luaR_table MODULE_PASTE_(lua_rotable_,name) = { luaname, map }
+    luaR_table MODULE_PASTE_(lua_rotable_,name) = { luaname, map, MODULE_PASTE_(name,_hashtable) }
 
 #if !defined(LUA_CROSS_COMPILER) && !(MIN_OPT_LEVEL==2 && LUA_OPTIMIZE_MEMORY==2)
 # error "NodeMCU modules must be built with LTR enabled (MIN_OPT_LEVEL=2 and LUA_OPTIMIZE_MEMORY=2)"

--- a/app/include/module.h
+++ b/app/include/module.h
@@ -67,7 +67,7 @@
 #define BUILTIN_LIB(name, luaname, map) \
   const uint32_t __attribute__((weak)) MODULE_PASTE_(name,_hashtable)[1] = {0}; \
   const LOCK_IN_SECTION(".lua_rotable") \
-    luaR_table MODULE_PASTE_(lua_rotable_,name) = { luaname, map, MODULE_PASTE_(name,_hashtable) }
+    luaR_table MODULE_PASTE_(lua_rotable_,name) = { luaname, map, MODULE_PASTE_(name,_hashtable), sizeof(luaname) }
 
 #if !defined(LUA_CROSS_COMPILER) && !(MIN_OPT_LEVEL==2 && LUA_OPTIMIZE_MEMORY==2)
 # error "NodeMCU modules must be built with LTR enabled (MIN_OPT_LEVEL=2 and LUA_OPTIMIZE_MEMORY=2)"

--- a/app/lua/lapi.c
+++ b/app/lua/lapi.c
@@ -412,6 +412,7 @@ LUA_API const void *lua_topointer (lua_State *L, int idx) {
     case LUA_TLIGHTUSERDATA:
       return lua_touserdata(L, idx);
     case LUA_TROTABLE: 
+      return rvalue(o);
     case LUA_TLIGHTFUNCTION:
       return pvalue(o);
     default: return NULL;
@@ -642,7 +643,7 @@ LUA_API int lua_getmetatable (lua_State *L, int objindex) {
     res = 0;
   else {
     if(luaR_isrotable(mt))
-      setrvalue(L->top, mt)
+      setrvalue(L->top, (struct _luaR_table *) mt)
     else
       sethvalue(L, L->top, mt)
     api_incr_top(L);

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -410,10 +410,11 @@ LUALIB_API const char *luaL_findtable (lua_State *L, int idx,
     e = c_strchr(fname, '.');
     if (e == NULL) e = fname + c_strlen(fname);
     lua_pushlstring(L, fname, e - fname);
+    int fnamehash = tsvalue(L->top - 1)->hash;
     lua_rawget(L, -2);
     if (lua_isnil(L, -1)) {
       /* If looking for a global variable, check the rotables too */
-      void *ptable = luaR_findglobal(fname, e - fname);
+      void *ptable = luaR_findglobalhash(fname, fnamehash);
       if (ptable) {
         lua_pop(L, 1);
         lua_pushrotable(L, ptable);

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -131,12 +131,12 @@ LUALIB_API int luaL_newmetatable (lua_State *L, const char *tname) {
   return 1;
 }
 
-LUALIB_API int luaL_rometatable (lua_State *L, const char* tname, void *p) {
+LUALIB_API int luaL_rometatable (lua_State *L, const char* tname, const struct _luaR_table *p) {
   lua_getfield(L, LUA_REGISTRYINDEX, tname);  /* get registry.name */
   if (!lua_isnil(L, -1))  /* name already in use? */
     return 0;  /* leave previous value on top, but return 0 */
   lua_pop(L, 1);
-  lua_pushrotable(L, p);
+  lua_pushrotable(L, (struct _luaR_table *) p);
   lua_pushvalue(L, -1);
   lua_setfield(L, LUA_REGISTRYINDEX, tname);  /* registry.name = metatable */
   return 1;

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -412,9 +412,12 @@ LUALIB_API const char *luaL_findtable (lua_State *L, int idx,
     lua_pushlstring(L, fname, e - fname);
     int fnamehash = tsvalue(L->top - 1)->hash;
     lua_rawget(L, -2);
-    if (lua_isnil(L, -1)) {
+    if (lua_isnil(L, -1) && e - fname <= LUA_MAX_ROTABLE_NAME) {
+      char fnamenull[LUA_MAX_ROTABLE_NAME + 1];
+      c_memcpy(fnamenull, fname, e - fname);
+      fnamenull[e - fname] = 0;
       /* If looking for a global variable, check the rotables too */
-      void *ptable = luaR_findglobalhash(fname, fnamehash);
+      void *ptable = luaR_findglobalhash(fnamenull, fnamehash);
       if (ptable) {
         lua_pop(L, 1);
         lua_pushrotable(L, ptable);

--- a/app/lua/lauxlib.h
+++ b/app/lua/lauxlib.h
@@ -40,7 +40,7 @@ typedef struct luaL_Reg {
   lua_CFunction func;
 } luaL_Reg;
 
-
+struct _luaR_table;
 
 LUALIB_API void (luaI_openlib) (lua_State *L, const char *libname,
                                 const luaL_Reg *l, int nup, int ftype);
@@ -70,7 +70,7 @@ LUALIB_API void (luaL_checkanyfunction) (lua_State *L, int narg);
 LUALIB_API void (luaL_checkanytable) (lua_State *L, int narg);
 
 LUALIB_API int   (luaL_newmetatable) (lua_State *L, const char *tname);
-LUALIB_API int   (luaL_rometatable) (lua_State *L, const char* tname, void *p);
+LUALIB_API int   (luaL_rometatable) (lua_State *L, const char* tname, const struct _luaR_table *p);
 LUALIB_API void *(luaL_checkudata) (lua_State *L, int ud, const char *tname);
 
 LUALIB_API void (luaL_where) (lua_State *L, int lvl);

--- a/app/lua/liolib.c
+++ b/app/lua/liolib.c
@@ -552,9 +552,11 @@ const LUA_REG_TYPE iolib[] = {
 };
 
 #if LUA_OPTIMIZE_MEMORY == 2
+const uint32_t __attribute((weak)) lua_iolib_func_table_hashtable[1] = {0};
+const luaR_table lua_iolib_func_table = { 0, iolib_funcs, lua_iolib_func_table_hashtable };
 static int luaL_index(lua_State *L)
 {
-  return luaR_findfunction(L, iolib_funcs);
+  return luaR_findfunction(L, &lua_iolib_func_table);
 }
   
 const luaL_Reg iolib[] = {
@@ -566,6 +568,7 @@ const luaL_Reg iolib[] = {
 #undef MIN_OPT_LEVEL
 #define MIN_OPT_LEVEL 1
 #include "lrodefs.h"
+LUA_TABLE_REG_1(flib);
 const LUA_REG_TYPE flib[] = {
   {LSTRKEY("close"), LFUNCVAL(io_close)},
   {LSTRKEY("flush"), LFUNCVAL(f_flush)},
@@ -581,6 +584,7 @@ const LUA_REG_TYPE flib[] = {
 #endif
   {LNILKEY, LNILVAL}
 };
+LUA_TABLE_REG_2(flib);
 
 static void createmeta (lua_State *L) {
 #if LUA_OPTIMIZE_MEMORY == 0
@@ -589,7 +593,7 @@ static void createmeta (lua_State *L) {
   lua_setfield(L, -2, "__index");  /* metatable.__index = metatable */
   luaL_register(L, NULL, flib);  /* file methods */
 #else
-  luaL_rometatable(L, LUA_FILEHANDLE, (void*)flib);  /* create metatable for file handles */
+  luaL_rometatable(L, LUA_FILEHANDLE, &flib_table);  /* create metatable for file handles */
 #endif
 }
 

--- a/app/lua/loadlib.c
+++ b/app/lua/loadlib.c
@@ -649,10 +649,12 @@ static const lua_CFunction loaders[] =
 #undef MIN_OPT_LEVEL
 #define MIN_OPT_LEVEL 1
 #include "lrodefs.h"
+LUA_TABLE_REG_1(lmt);
 const LUA_REG_TYPE lmt[] = {
   {LRO_STRKEY("__gc"), LRO_FUNCVAL(gctm)},
   {LRO_NILKEY, LRO_NILVAL}
 };
+LUA_TABLE_REG_2(lmt);
 #endif
 
 LUALIB_API int luaopen_package (lua_State *L) {
@@ -663,7 +665,7 @@ LUALIB_API int luaopen_package (lua_State *L) {
   lua_pushlightfunction(L, gctm);
   lua_setfield(L, -2, "__gc");
 #else
-  luaL_rometatable(L, "_LOADLIB", (void*)lmt);
+  luaL_rometatable(L, "_LOADLIB", &lmt_table);
 #endif
   /* create `package' table */
   luaL_register_light(L, LUA_LOADLIBNAME, pk_funcs);

--- a/app/lua/loadlib.c
+++ b/app/lua/loadlib.c
@@ -25,6 +25,7 @@
 #include "lauxlib.h"
 #include "lualib.h"
 #include "lrotable.h"
+#include "lstate.h"
 
 /* prefix for open functions in C libraries */
 #define LUA_POF		"luaopen_"
@@ -474,7 +475,7 @@ static int ll_require (lua_State *L) {
     return 1;  /* package is already loaded */
   }
   /* Is this a readonly table? */
-  void *res = luaR_findglobal(name, c_strlen(name));
+  void *res = luaR_findglobalhash(name, tsvalue(L->base + 1 - 1)->hash);
   if (res) {
     lua_pushrotable(L, res);
     return 1;
@@ -563,7 +564,7 @@ static void modinit (lua_State *L, const char *modname) {
 
 static int ll_module (lua_State *L) {
   const char *modname = luaL_checkstring(L, 1);
-  if (luaR_findglobal(modname, c_strlen(modname)))
+  if (luaR_findglobalhash(modname, tsvalue(L->base + 1 - 1)->hash))
     return 0;
   int loaded = lua_gettop(L) + 1;  /* index of _LOADED table */
   lua_getfield(L, LUA_REGISTRYINDEX, "_LOADED");

--- a/app/lua/lobject.h
+++ b/app/lua/lobject.h
@@ -57,7 +57,7 @@ typedef struct GCheader {
 
 
 
-
+struct _luaR_table;
 /*
 ** Union of all Lua values
 */
@@ -169,7 +169,7 @@ typedef TValuefields TValue;
 #endif // #ifndef LUA_PACK_VALUE
 #define gcvalue(o)	check_exp(iscollectable(o), (o)->value.gc)
 #define pvalue(o)	check_exp(ttislightuserdata(o), (o)->value.p)
-#define rvalue(o)	check_exp(ttisrotable(o), (o)->value.p)
+#define rvalue(o)	check_exp(ttisrotable(o), (struct _luaR_table *) (o)->value.p)
 #define fvalue(o) check_exp(ttislightfunction(o), (o)->value.p)
 #define nvalue(o)	check_exp(ttisnumber(o), (o)->value.n)
 #define rawtsvalue(o)	check_exp(ttisstring(o), &(o)->value.gc->ts)
@@ -213,7 +213,7 @@ typedef TValuefields TValue;
   { void *i_x = (x); TValue *i_o=(obj); i_o->value.p=i_x; i_o->tt=LUA_TLIGHTUSERDATA; }
 
 #define setrvalue(obj,x) \
-  { void *i_x = (x); TValue *i_o=(obj); i_o->value.p=i_x; i_o->tt=LUA_TROTABLE; }
+  { struct _luaR_table *i_x = (x); TValue *i_o=(obj); i_o->value.p=i_x; i_o->tt=LUA_TROTABLE; }
 
 #define setfvalue(obj,x) \
   { void *i_x = (x); TValue *i_o=(obj); i_o->value.p=i_x; i_o->tt=LUA_TLIGHTFUNCTION; }

--- a/app/lua/lrodefs.h
+++ b/app/lua/lrodefs.h
@@ -23,7 +23,7 @@
 #define LFUNCVAL                    LRO_FUNCVAL
 #define LUDATA                      LRO_LUDATA
 #define LNUMVAL                     LRO_NUMVAL
-#define LROVAL                      LRO_ROVAL
+#define LROVAL(x)                   LRO_ROVAL(&x##_table)
 #define LNILVAL                     LRO_NILVAL
 #define LREGISTER(L, name, table)\
   return 0

--- a/app/lua/lrotable.c
+++ b/app/lua/lrotable.c
@@ -8,6 +8,7 @@
 #include "lstring.h"
 #include "lobject.h"
 #include "lapi.h"
+#include "memeq.h"
 
 /* Local defines */
 #define LUAR_FINDFUNCTION     0
@@ -15,29 +16,72 @@
 
 /* Externally defined read-only table array */
 extern const luaR_table lua_rotable[];
+const uint32_t __attribute__((weak)) lua_rotable_table_hashtable[1];
+
+static uint32_t strhash(const char *str) {
+  uint32_t l = c_strlen(str);
+  unsigned int h = cast(unsigned int, l);  /* seed */
+  size_t step = (l>>5)+1;  /* if string is too long, don't hash all its chars */
+  size_t l1;
+  for (l1=l; l1>=step; l1-=step)  /* compute hash */
+    h = h ^ ((h<<5)+(h>>2)+cast(unsigned char, str[l1-1]));
+
+  return h;
+}
 
 /* Find a global "read only table" in the constant lua_rotable array */
-void* luaR_findglobal(const char *name, unsigned len) {
+luaR_table* luaR_findglobal(const char *name, unsigned len) {
   unsigned i;
 
   if (c_strlen(name) > LUA_MAX_ROTABLE_NAME)
     return NULL;
-  for (i=0; lua_rotable[i].name; i ++)
-    if (*lua_rotable[i].name != '\0' && c_strlen(lua_rotable[i].name) == len && !c_strncmp(lua_rotable[i].name, name, len)) {
-      return (void*)(lua_rotable[i].pentries);
+  for (i=0; lua_rotable[i].name; i ++) {
+    if (lua_rotable[len].name == '\0' && !c_strncmp(lua_rotable[i].name, name, len)) {
+      return (luaR_table *) &(lua_rotable[i]);
     }
+  }
+  return NULL;
+}
+
+/* Find a global "read only table" in the constant lua_rotable array */
+luaR_table* luaR_findglobalhash(const char *name, uint32_t hash) {
+  unsigned i;
+
+  const uint32_t *bits = lua_rotable_table_hashtable;
+  uint32_t mask = *bits++;
+  if (mask) {
+    int probeval;
+    for (int probe = hash & mask; probeval = (bits[probe >> 2] >> ((probe & 3) << 3)) & 0xff; probe = (probe + 1) & mask) {
+      const luaR_table *pthis = lua_rotable + (probeval & 0x7f) - 1;
+      if (!memeq(pthis->name, name, pthis->namesize)) {
+        return (luaR_table *) pthis;
+      }
+      if (probeval & 0x80) {
+        break;
+      }
+    }
+
+    return NULL;
+  }
+
+  for (i=0; lua_rotable[i].name; i ++) {
+    if (!c_strcmp(lua_rotable[i].name, name)) {
+      return (luaR_table *) &(lua_rotable[i]);
+    }
+  }
   return NULL;
 }
 
 /* Find an entry in a rotable and return it */
-static const TValue* luaR_auxfind(const luaR_entry *pentry, const char *strkey, luaR_numkey numkey, unsigned *ppos) {
+static const TValue* luaR_auxfind(const luaR_table *ptable, const char *strkey, luaR_numkey numkey, unsigned *ppos) {
+  const luaR_entry *pentry = ptable->pentries;
   const TValue *res = NULL;
   unsigned i = 0;
   
   if (pentry == NULL)
     return NULL;  
   while(pentry->key.type != LUA_TNIL) {
-    if ((strkey && (pentry->key.type == LUA_TSTRING) && (!c_strcmp(pentry->key.id.strkey, strkey))) || 
+    if ((strkey && ((pentry->key.type & 0xff) == LUA_TSTRING) && (!c_strcmp(pentry->key.id.strkey, strkey))) || 
         (!strkey && (pentry->key.type == LUA_TNUMBER) && ((luaR_numkey)pentry->key.id.numkey == numkey))) {
       res = &pentry->value;
       break;
@@ -49,11 +93,51 @@ static const TValue* luaR_auxfind(const luaR_entry *pentry, const char *strkey, 
   return res;
 }
 
-int luaR_findfunction(lua_State *L, const luaR_entry *ptable) {
+static const TValue* luaR_auxfindstr(const luaR_table *ptable, const char *strkey, uint32_t hash) {
+  const luaR_entry *pentry = ptable->pentries;
+
+  if (pentry == NULL)
+    return NULL;  
+  
+  const uint32_t *bits = ptable->hashtable;
+  if (bits) {
+    if (hash == 0) {
+      hash = strhash(strkey);
+      dbg_printf("Hashing %s to 0x%x\n", strkey, hash);
+    }
+  
+    uint32_t mask = *bits++;
+    if (mask) {
+      int probeval;
+      for (int probe = hash & mask; probeval = (bits[probe >> 2] >> ((probe & 3) << 3)) & 0xff; probe = (probe + 1) & mask) {
+        const luaR_entry *pthis = pentry + (probeval & 0x7f) - 1;
+        if (!memeq(pthis->key.id.strkey, strkey, pthis->key.type >> 8)) {
+          return &pthis->value;
+        }
+        if (probeval & 0x80) {
+          break;
+        }
+      }
+
+      return NULL;
+    }
+  }
+
+  while (pentry->key.type != LUA_TNIL) {
+    if (((pentry->key.type & 0xff) == LUA_TSTRING) && (!c_strcmp(pentry->key.id.strkey, strkey))) {
+      return &pentry->value;
+    }
+    pentry ++;
+  }
+  return NULL;
+}
+
+int luaR_findfunction(lua_State *L, const luaR_table *ptable) {
   const TValue *res = NULL;
   const char *key = luaL_checkstring(L, 2);
+  uint32_t hash = tsvalue(L->base + 2 - 1)->hash;
     
-  res = luaR_auxfind(ptable, key, 0, NULL);  
+  res = luaR_auxfindstr(ptable, key, hash);  
   if (res && ttislightfunction(res)) {
     luaA_pushobject(L, res);
     return 1;
@@ -65,14 +149,18 @@ int luaR_findfunction(lua_State *L, const luaR_entry *ptable) {
 /* Find an entry in a rotable and return its type 
    If "strkey" is not NULL, the function will look for a string key,
    otherwise it will look for a number key */
-const TValue* luaR_findentry(void *data, const char *strkey, luaR_numkey numkey, unsigned *ppos) {
-  return luaR_auxfind((const luaR_entry*)data, strkey, numkey, ppos);
+const TValue* luaR_findentry(const luaR_table *ptable, const char *strkey, luaR_numkey numkey, unsigned *ppos) {
+  return luaR_auxfind(ptable, strkey, numkey, ppos);
+}
+
+const TValue* luaR_findentrytstr(const luaR_table *ptable, const TString *key) {
+  return luaR_auxfindstr(ptable, getstr(key), key->tsv.hash);
 }
 
 /* Find the metatable of a given table */
-void* luaR_getmeta(void *data) {
+void* luaR_getmeta(const luaR_table *ptable) {
 #ifdef LUA_META_ROTABLES
-  const TValue *res = luaR_auxfind((const luaR_entry*)data, "__metatable", 0, NULL);
+  const TValue *res = luaR_auxfindstr(ptable, "__metatable", 0xbdd03a15);
   return res && ttisrotable(res) ? rvalue(res) : NULL;
 #else
   return NULL;
@@ -84,7 +172,7 @@ static void luaR_next_helper(lua_State *L, const luaR_entry *pentries, int pos, 
   setnilvalue(val);
   if (pentries[pos].key.type != LUA_TNIL) {
     /* Found an entry */
-    if (pentries[pos].key.type == LUA_TSTRING)
+    if ((pentries[pos].key.type  & 0xff) == LUA_TSTRING)
       setsvalue(L, key, luaS_newro(L, pentries[pos].key.id.strkey))
     else
       setnvalue(key, (lua_Number)pentries[pos].key.id.numkey)
@@ -92,8 +180,8 @@ static void luaR_next_helper(lua_State *L, const luaR_entry *pentries, int pos, 
   }
 }
 /* next (used for iteration) */
-void luaR_next(lua_State *L, void *data, TValue *key, TValue *val) {
-  const luaR_entry* pentries = (const luaR_entry*)data;
+void luaR_next(lua_State *L, const luaR_table *ptable, TValue *key, TValue *val) {
+  const luaR_entry* pentries = ptable->pentries;
   char strkey[LUA_MAX_ROTABLE_NAME + 1], *pstrkey = NULL;
   luaR_numkey numkey = 0;
   unsigned keypos;
@@ -108,7 +196,7 @@ void luaR_next(lua_State *L, void *data, TValue *key, TValue *val) {
       pstrkey = strkey;
     } else   
       numkey = (luaR_numkey)nvalue(key);
-    luaR_findentry(data, pstrkey, numkey, &keypos);
+    luaR_findentry(ptable, pstrkey, numkey, &keypos);
     /* Advance to next key */
     keypos ++;    
     luaR_next_helper(L, pentries, keypos, key, val);

--- a/app/lua/lrotable.c
+++ b/app/lua/lrotable.c
@@ -21,6 +21,9 @@
 extern const luaR_table lua_rotable[];
 const uint32_t __attribute__((weak)) lua_rotable_table_hashtable[1];
 
+const uint8_t __attribute__((section(".keep.rodata"))) luaR_table_size = sizeof(luaR_table);
+const uint8_t __attribute__((section(".keep.rodata"))) luaR_entry_size = sizeof(luaR_entry);
+
 static uint32_t strhash(const char *str) {
   uint32_t l = c_strlen(str);
   unsigned int h = cast(unsigned int, l);  /* seed */

--- a/app/lua/lrotable.h
+++ b/app/lua/lrotable.h
@@ -30,7 +30,7 @@
 #endif // #ifdef ELUA_ENDIAN_LITTLE
 #endif // #ifndef LUA_PACK_VALUE
 
-#define LRO_STRKEY(k)   {LUA_TSTRING, {.strkey = k}}
+#define LRO_STRKEY(k)   {(sizeof(k) << 8) + LUA_TSTRING, {.strkey = k}}
 #define LRO_NUMKEY(k)   {LUA_TNUMBER, {.numkey = k}}
 #define LRO_NILKEY      {LUA_TNIL, {.strkey=NULL}}
 
@@ -43,7 +43,7 @@ typedef int luaR_numkey;
 /* The next structure defines the type of a key */
 typedef struct
 {
-  int type;
+  int type;   // is actually size << 8 + type -- size is sizeof(string)
   union
   {
     const char*   strkey;
@@ -59,22 +59,36 @@ typedef struct
 } luaR_entry;
 
 /* A rotable */
-typedef struct
+typedef struct _luaR_table
 {
   const char *name;
   const luaR_entry *pentries;
+  const uint32_t *hashtable;
+  const uint32_t namesize;
 } luaR_table;
 
-void* luaR_findglobal(const char *key, unsigned len);
-int luaR_findfunction(lua_State *L, const luaR_entry *ptable);
-const TValue* luaR_findentry(void *data, const char *strkey, luaR_numkey numkey, unsigned *ppos);
+luaR_table* luaR_findglobal(const char *key, unsigned len);
+luaR_table* luaR_findglobalhash(const char *key, uint32_t hash);
+int luaR_findfunction(lua_State *L, const luaR_table *ptable);
+const TValue* luaR_findentry(const luaR_table *ptable, const char *strkey, luaR_numkey numkey, unsigned *ppos);
+const TValue* luaR_findentrytstr(const luaR_table *ptable, const TString *key);
 void luaR_getcstr(char *dest, const TString *src, size_t maxsize);
-void luaR_next(lua_State *L, void *data, TValue *key, TValue *val);
-void* luaR_getmeta(void *data);
+void luaR_next(lua_State *L, const luaR_table *ptable, TValue *key, TValue *val);
+void* luaR_getmeta(const luaR_table *ptable);
 #ifdef LUA_META_ROTABLES
 int luaR_isrotable(void *p);
 #else
 #define luaR_isrotable(p)     (0)
 #endif
 
+#define LUA_TABLE_PASTE(x,y) x##y
+#define LUA_TABLE_STRINGIFY(x) LUA_TABLE_XSTRINGIFY(x)
+#define LUA_TABLE_XSTRINGIFY(x) #x
+
+#define LUA_TABLE_REG_1(x) \
+  const luaR_table LUA_TABLE_PASTE(x,_table);
+
+#define LUA_TABLE_REG_2(x) \
+  const uint32_t __attribute__((weak)) LUA_TABLE_PASTE(x,_hashtable)[1] = {0}; \
+  const luaR_table LUA_TABLE_PASTE(x,_table) = { LUA_TABLE_STRINGIFY(x), x, LUA_TABLE_PASTE(x,_hashtable) };
 #endif

--- a/app/lua/lrotable.h
+++ b/app/lua/lrotable.h
@@ -89,5 +89,5 @@ int luaR_isrotable(void *p);
 
 #define LUA_TABLE_REG_2(x) \
   const uint32_t __attribute__((weak)) LUA_TABLE_PASTE(x,_hashtable)[1] = {0}; \
-  const luaR_table LUA_TABLE_PASTE(x,_table) = { LUA_TABLE_STRINGIFY(x), x, LUA_TABLE_PASTE(x,_hashtable) };
+  const luaR_table LUA_TABLE_PASTE(x,_table) = { LUA_TABLE_STRINGIFY(x), x, LUA_TABLE_PASTE(x,_hashtable), 0 };
 #endif

--- a/app/lua/lrotable.h
+++ b/app/lua/lrotable.h
@@ -67,7 +67,6 @@ typedef struct _luaR_table
   const uint32_t namesize;
 } luaR_table;
 
-luaR_table* luaR_findglobal(const char *key, unsigned len);
 luaR_table* luaR_findglobalhash(const char *key, uint32_t hash);
 int luaR_findfunction(lua_State *L, const luaR_table *ptable);
 const TValue* luaR_findentry(const luaR_table *ptable, const char *strkey, luaR_numkey numkey, unsigned *ppos);

--- a/app/lua/lstring.c
+++ b/app/lua/lstring.c
@@ -86,7 +86,7 @@ static TString *luaS_newlstr_helper (lua_State *L, const char *str, size_t l, in
   unsigned int h = cast(unsigned int, l);  /* seed */
   size_t step = (l>>5)+1;  /* if string is too long, don't hash all its chars */
   size_t l1;
-  if ((((uint32_t) str) & 3) || step > 1) {
+  if ((((uint32_t) str) & 3) || step > 1 || !readonly) {
     for (l1=l; l1>=step; l1-=step)  /* compute hash */
       h = h ^ ((h<<5)+(h>>2)+cast(unsigned char, str[l1-1]));
   } else {

--- a/app/lua/lstrlib.c
+++ b/app/lua/lstrlib.c
@@ -828,6 +828,7 @@ static int str_format (lua_State *L) {
 #undef MIN_OPT_LEVEL
 #define MIN_OPT_LEVEL 1
 #include "lrodefs.h"
+LUA_TABLE_REG_1(strlib);
 const LUA_REG_TYPE strlib[] = {
   {LSTRKEY("byte"), LFUNCVAL(str_byte)},
   {LSTRKEY("char"), LFUNCVAL(str_char)},
@@ -853,6 +854,7 @@ const LUA_REG_TYPE strlib[] = {
 #endif
   {LNILKEY, LNILVAL}
 };
+LUA_TABLE_REG_2(strlib);
 
 
 #if LUA_OPTIMIZE_MEMORY != 2
@@ -882,7 +884,7 @@ LUALIB_API int luaopen_string (lua_State *L) {
   return 1;
 #else
   lua_pushliteral(L,"");
-  lua_pushrotable(L, (void*)strlib);
+  lua_pushrotable(L, (void *) &strlib_table);
   lua_setmetatable(L, -2);
   lua_pop(L,1);
   return 0;  

--- a/app/lua/ltable.c
+++ b/app/lua/ltable.c
@@ -105,8 +105,9 @@ static Node *mainposition (const Table *t, const TValue *key) {
       return hashstr(t, rawtsvalue(key));
     case LUA_TBOOLEAN:
       return hashboolean(t, bvalue(key));
-    case LUA_TLIGHTUSERDATA:
     case LUA_TROTABLE:
+      return hashpointer(t, rvalue(key));
+    case LUA_TLIGHTUSERDATA:
     case LUA_TLIGHTFUNCTION:
       return hashpointer(t, pvalue(key));
     default:
@@ -598,12 +599,10 @@ const TValue *luaH_getstr (Table *t, TString *key) {
 
 /* same thing for rotables */
 const TValue *luaH_getstr_ro (void *t, TString *key) {
-  char keyname[LUA_MAX_ROTABLE_NAME + 1];
   const TValue *res;  
   if (!t)
     return luaO_nilobject;
-  luaR_getcstr(keyname, key, LUA_MAX_ROTABLE_NAME);   
-  res = luaR_findentry(t, keyname, 0, NULL);
+  res = luaR_findentrytstr(t, key);
   return res ? res : luaO_nilobject;
 }
 

--- a/app/lua/lvm.c
+++ b/app/lua/lvm.c
@@ -131,7 +131,7 @@ void luaV_gettable (lua_State *L, const TValue *t, TValue *key, StkId val) {
   for (loop = 0; loop < MAXTAGLOOP; loop++) {
     const TValue *tm;
     if (ttistable(t) || ttisrotable(t)) {  /* `t' is a table? */
-      void *h = ttistable(t) ? hvalue(t) : rvalue(t);
+      void *h = ttistable(t) ? hvalue(t) : (void *) rvalue(t);
       const TValue *res = ttistable(t) ? luaH_get((Table*)h, key) : luaH_get_ro(h, key); /* do a primitive get */
       if (!ttisnil(res) ||  /* result is no nil? */
           (tm = fasttm(L, ttistable(t) ? ((Table*)h)->metatable : (Table*)luaR_getmeta(h), TM_INDEX)) == NULL) { /* or no TM? */
@@ -163,7 +163,7 @@ void luaV_settable (lua_State *L, const TValue *t, TValue *key, StkId val) {
   for (loop = 0; loop < MAXTAGLOOP; loop++) {
     const TValue *tm;
     if (ttistable(t) || ttisrotable(t)) {  /* `t' is a table? */
-      void *h = ttistable(t) ? hvalue(t) : rvalue(t);
+      void *h = ttistable(t) ? hvalue(t) : (void *) rvalue(t);
       TValue *oldval = ttistable(t) ? luaH_set(L, (Table*)h, key) : NULL; /* do a primitive set */
       if ((oldval && !ttisnil(oldval)) ||  /* result is no nil? */
           (tm = fasttm(L, ttistable(t) ? ((Table*)h)->metatable : (Table*)luaR_getmeta(h), TM_NEWINDEX)) == NULL) { /* or no TM? */
@@ -292,8 +292,9 @@ int luaV_equalval (lua_State *L, const TValue *t1, const TValue *t2) {
     case LUA_TNIL: return 1;
     case LUA_TNUMBER: return luai_numeq(nvalue(t1), nvalue(t2));
     case LUA_TBOOLEAN: return bvalue(t1) == bvalue(t2);  /* true must be 1 !! */
-    case LUA_TLIGHTUSERDATA: 
     case LUA_TROTABLE:
+      return rvalue(t1) == rvalue(t2);
+    case LUA_TLIGHTUSERDATA: 
     case LUA_TLIGHTFUNCTION:
       return pvalue(t1) == pvalue(t2);
     case LUA_TUSERDATA: {

--- a/app/modules/coap.c
+++ b/app/modules/coap.c
@@ -556,6 +556,7 @@ static int coap_client_delete( lua_State* L )
 }
 
 // Module function map
+LUA_TABLE_REG_1(coap_server_map);
 static const LUA_REG_TYPE coap_server_map[] = {
   { LSTRKEY( "listen" ),  LFUNCVAL( coap_server_listen ) },
   { LSTRKEY( "close" ),   LFUNCVAL( coap_server_close ) },
@@ -565,7 +566,9 @@ static const LUA_REG_TYPE coap_server_map[] = {
   { LSTRKEY( "__index" ), LROVAL( coap_server_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(coap_server_map);
 
+LUA_TABLE_REG_1(coap_client_map);
 static const LUA_REG_TYPE coap_client_map[] = {
   { LSTRKEY( "get" ),     LFUNCVAL( coap_client_get ) },
   { LSTRKEY( "post" ),    LFUNCVAL( coap_client_post ) },
@@ -575,7 +578,9 @@ static const LUA_REG_TYPE coap_client_map[] = {
   { LSTRKEY( "__index" ), LROVAL( coap_client_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(coap_client_map);
 
+LUA_TABLE_REG_1(coap_map);
 static const LUA_REG_TYPE coap_map[] = 
 {
   { LSTRKEY( "Server" ),      LFUNCVAL( coap_createServer ) },
@@ -591,12 +596,13 @@ static const LUA_REG_TYPE coap_map[] =
   { LSTRKEY( "__metatable" ), LROVAL( coap_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(coap_map);
 
 int luaopen_coap( lua_State *L )
 {
   endpoint_setup();
-  luaL_rometatable(L, "coap_server", (void *)coap_server_map);  // create metatable for coap_server 
-  luaL_rometatable(L, "coap_client", (void *)coap_client_map);  // create metatable for coap_client  
+  luaL_rometatable(L, "coap_server", &coap_server_map_table);  // create metatable for coap_server 
+  luaL_rometatable(L, "coap_client", &coap_client_map_table);  // create metatable for coap_client  
   return 0;
 }
 

--- a/app/modules/crypto.c
+++ b/app/modules/crypto.c
@@ -397,6 +397,7 @@ static int lcrypto_decrypt (lua_State *L)
 }
 
 // Hash function map
+LUA_TABLE_REG_1(crypto_hash_map);
 static const LUA_REG_TYPE crypto_hash_map[] = {
   { LSTRKEY( "update" ),  LFUNCVAL( crypto_hash_update ) },
   { LSTRKEY( "finalize" ),   LFUNCVAL( crypto_hash_finalize ) },
@@ -404,6 +405,7 @@ static const LUA_REG_TYPE crypto_hash_map[] = {
   { LSTRKEY( "__index" ), LROVAL( crypto_hash_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(crypto_hash_map);
 
 
 // Module function map
@@ -424,7 +426,7 @@ static const LUA_REG_TYPE crypto_map[] = {
 
 int luaopen_crypto ( lua_State *L )
 {
-  luaL_rometatable(L, "crypto.hash", (void *)crypto_hash_map);  // create metatable for crypto.hash
+  luaL_rometatable(L, "crypto.hash", &crypto_hash_map_table);  // create metatable for crypto.hash
   return 0;
 }
 

--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -513,6 +513,7 @@ static int file_vol_umount( lua_State *L )
 }
 
 
+LUA_TABLE_REG_1(file_obj_map);
 static const LUA_REG_TYPE file_obj_map[] =
 {
   { LSTRKEY( "close" ),     LFUNCVAL( file_close ) },
@@ -526,7 +527,9 @@ static const LUA_REG_TYPE file_obj_map[] =
   { LSTRKEY( "__index" ),   LROVAL( file_obj_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(file_obj_map);
 
+LUA_TABLE_REG_1(file_vol_map);
 static const LUA_REG_TYPE file_vol_map[] =
 {
   { LSTRKEY( "umount" ),   LFUNCVAL( file_vol_umount )},
@@ -536,6 +539,7 @@ static const LUA_REG_TYPE file_vol_map[] =
   { LSTRKEY( "__index" ),  LROVAL( file_vol_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(file_vol_map);
 
 // Module function map
 static const LUA_REG_TYPE file_map[] = {
@@ -565,8 +569,8 @@ static const LUA_REG_TYPE file_map[] = {
 };
 
 int luaopen_file( lua_State *L ) {
-  luaL_rometatable( L, "file.vol",  (void *)file_vol_map );
-  luaL_rometatable( L, "file.obj",  (void *)file_obj_map );
+  luaL_rometatable( L, "file.vol",  &file_vol_map_table );
+  luaL_rometatable( L, "file.obj",  &file_obj_map_table );
   return 0;
 }
 

--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -1582,6 +1582,7 @@ static int mqtt_socket_lwt( lua_State* L )
 }
 
 // Module function map
+LUA_TABLE_REG_1(mqtt_socket_map);
 static const LUA_REG_TYPE mqtt_socket_map[] = {
   { LSTRKEY( "connect" ),   LFUNCVAL( mqtt_socket_connect ) },
   { LSTRKEY( "close" ),     LFUNCVAL( mqtt_socket_close ) },
@@ -1594,8 +1595,10 @@ static const LUA_REG_TYPE mqtt_socket_map[] = {
   { LSTRKEY( "__index" ),   LROVAL( mqtt_socket_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(mqtt_socket_map);
 
 
+LUA_TABLE_REG_1(mqtt_map);
 static const LUA_REG_TYPE mqtt_map[] = {
   { LSTRKEY( "Client" ),                                LFUNCVAL( mqtt_socket_client ) },
 
@@ -1614,10 +1617,11 @@ static const LUA_REG_TYPE mqtt_map[] = {
   { LSTRKEY( "__metatable" ),                           LROVAL( mqtt_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(mqtt_map);
 
 int luaopen_mqtt( lua_State *L )
 {
-  luaL_rometatable(L, "mqtt.socket", (void *)mqtt_socket_map);  // create metatable for mqtt.socket
+  luaL_rometatable(L, "mqtt.socket", &mqtt_socket_map_table);  // create metatable for mqtt.socket
   return 0;
 }
 

--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -1682,6 +1682,7 @@ static int expose_array(lua_State* L, char *array, unsigned short len) {
 #endif
 
 // Module function map
+LUA_TABLE_REG_1(net_server_map);
 static const LUA_REG_TYPE net_server_map[] = {
   { LSTRKEY( "listen" ),  LFUNCVAL( net_server_listen ) },
   { LSTRKEY( "close" ),   LFUNCVAL( net_server_close ) },
@@ -1692,7 +1693,9 @@ static const LUA_REG_TYPE net_server_map[] = {
   { LSTRKEY( "__index" ), LROVAL( net_server_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(net_server_map);
 
+LUA_TABLE_REG_1(net_socket_map);
 static const LUA_REG_TYPE net_socket_map[] = {
   { LSTRKEY( "connect" ), LFUNCVAL( net_socket_connect ) },
   { LSTRKEY( "close" ),   LFUNCVAL( net_socket_close ) },
@@ -1707,6 +1710,7 @@ static const LUA_REG_TYPE net_socket_map[] = {
   { LSTRKEY( "__index" ), LROVAL( net_socket_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(net_socket_map);
 #if 0
 static const LUA_REG_TYPE net_array_map[] = {
   { LSTRKEY( "__index" ),    LFUNCVAL( net_array_index ) },
@@ -1715,6 +1719,7 @@ static const LUA_REG_TYPE net_array_map[] = {
 };
 #endif
 
+LUA_TABLE_REG_1(net_cert_map);
 static const LUA_REG_TYPE net_cert_map[] = {
   { LSTRKEY( "verify" ), 	LFUNCVAL( net_cert_verify ) },  
 #ifdef CLIENT_SSL_CERT_AUTH_ENABLE
@@ -1722,14 +1727,18 @@ static const LUA_REG_TYPE net_cert_map[] = {
 #endif
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(net_cert_map);
 
+LUA_TABLE_REG_1(net_dns_map);
 static const LUA_REG_TYPE net_dns_map[] = {
   { LSTRKEY( "setdnsserver" ), LFUNCVAL( net_setdnsserver ) },  
   { LSTRKEY( "getdnsserver" ), LFUNCVAL( net_getdnsserver ) }, 
   { LSTRKEY( "resolve" ),      LFUNCVAL( net_dns_static ) },  
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(net_dns_map);
 
+LUA_TABLE_REG_1(net_map);
 static const LUA_REG_TYPE net_map[] = {
   { LSTRKEY( "createServer" ),     LFUNCVAL( net_createServer ) },
   { LSTRKEY( "createConnection" ), LFUNCVAL( net_createConnection ) },
@@ -1744,6 +1753,7 @@ static const LUA_REG_TYPE net_map[] = {
   { LSTRKEY( "__metatable" ),      LROVAL( net_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(net_map);
 
 int luaopen_net( lua_State *L ) {
   int i;
@@ -1752,10 +1762,10 @@ int luaopen_net( lua_State *L ) {
     socket[i] = LUA_NOREF;
   }
 
-  luaL_rometatable(L, "net.server", (void *)net_server_map);  // create metatable for net.server
-  luaL_rometatable(L, "net.socket", (void *)net_socket_map);  // create metatable for net.socket
+  luaL_rometatable(L, "net.server", &net_server_map_table);  // create metatable for net.server
+  luaL_rometatable(L, "net.socket", &net_socket_map_table);  // create metatable for net.socket
   #if 0
-  luaL_rometatable(L, "net.array", (void *)net_array_map);    // create metatable for net.array
+  luaL_rometatable(L, "net.array", &net_array_map_table);    // create metatable for net.array
   #endif
 
   return 0;

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -439,9 +439,9 @@ static int node_stripdebug (lua_State *L) {
 }
 #endif
 
-#ifdef DEVELOPMENT_TOOLS
+#ifdef NODE_BYTE_LOAD_STATS
 // Return some statistics about the interpreter
-static int node_stats(lua_State *L) {
+static int node_byte_stats(lua_State *L) {
   extern uint32_t wide_handler_count;
   extern uint32_t wide_handler_last_epc[];
   extern uint8_t wide_handler_last_epc_index;
@@ -553,8 +553,8 @@ static const LUA_REG_TYPE node_map[] =
   { LSTRKEY( "setcpufreq" ), LFUNCVAL( node_setcpufreq) },
   { LSTRKEY( "bootreason" ), LFUNCVAL( node_bootreason) },
   { LSTRKEY( "restore" ), LFUNCVAL( node_restore) },
-#ifdef DEVELOPMENT_TOOLS
-  { LSTRKEY( "stats" ), LFUNCVAL( node_stats) },
+#ifdef NODE_BYTE_LOAD_STATS
+  { LSTRKEY( "bytestats" ), LFUNCVAL( node_byte_stats) },
 #endif
 #ifdef LUA_OPTIMIZE_DEBUG
   { LSTRKEY( "stripdebug" ), LFUNCVAL( node_stripdebug ) },

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -469,6 +469,7 @@ static int node_osprint( lua_State* L )
 
 // Module function map
 
+LUA_TABLE_REG_1(node_egc_map);
 static const LUA_REG_TYPE node_egc_map[] = {
   { LSTRKEY( "setmode" ),           LFUNCVAL( node_egc_setmode ) },
   { LSTRKEY( "NOT_ACTIVE" ),        LNUMVAL( EGC_NOT_ACTIVE ) },
@@ -477,6 +478,8 @@ static const LUA_REG_TYPE node_egc_map[] = {
   { LSTRKEY( "ALWAYS" ),            LNUMVAL( EGC_ALWAYS ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(node_egc_map);
+LUA_TABLE_REG_1(node_task_map);
 static const LUA_REG_TYPE node_task_map[] = {
   { LSTRKEY( "post" ),            LFUNCVAL( node_task_post ) },
   { LSTRKEY( "LOW_PRIORITY" ),    LNUMVAL( TASK_PRIORITY_LOW ) },
@@ -484,6 +487,7 @@ static const LUA_REG_TYPE node_task_map[] = {
   { LSTRKEY( "HIGH_PRIORITY" ),   LNUMVAL( TASK_PRIORITY_HIGH ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(node_task_map);
 
 static const LUA_REG_TYPE node_map[] =
 {

--- a/app/modules/pcm.c
+++ b/app/modules/pcm.c
@@ -229,6 +229,7 @@ static int pcm_new( lua_State *L )
 }
 
 
+LUA_TABLE_REG_1(pcm_driver_map);
 static const LUA_REG_TYPE pcm_driver_map[] = {
   { LSTRKEY( "play" ),    LFUNCVAL( pcm_drv_play ) },
   { LSTRKEY( "pause" ),   LFUNCVAL( pcm_drv_pause ) },
@@ -239,6 +240,7 @@ static const LUA_REG_TYPE pcm_driver_map[] = {
   { LSTRKEY( "__index" ), LROVAL( pcm_driver_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(pcm_driver_map);
 
 // Module function map
 static const LUA_REG_TYPE pcm_map[] = {
@@ -256,7 +258,7 @@ static const LUA_REG_TYPE pcm_map[] = {
 };
 
 int luaopen_pcm( lua_State *L ) {
-  luaL_rometatable( L, "pcm.driver", (void *)pcm_driver_map );  // create metatable
+  luaL_rometatable( L, "pcm.driver", &pcm_driver_map_table );  // create metatable
   return 0;
 }
 

--- a/app/modules/tmr.c
+++ b/app/modules/tmr.c
@@ -354,6 +354,7 @@ static int tmr_create( lua_State *L ) {
 
 // Module function map
 
+LUA_TABLE_REG_1(tmr_dyn_map);
 static const LUA_REG_TYPE tmr_dyn_map[] = {
 	{ LSTRKEY( "register" ),    LFUNCVAL( tmr_register ) },
 	{ LSTRKEY( "alarm" ),       LFUNCVAL( tmr_alarm ) },
@@ -366,6 +367,7 @@ static const LUA_REG_TYPE tmr_dyn_map[] = {
 	{ LSTRKEY( "__index" ),     LROVAL( tmr_dyn_map ) },
 	{ LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(tmr_dyn_map);
 
 static const LUA_REG_TYPE tmr_map[] = {
 	{ LSTRKEY( "delay" ),        LFUNCVAL( tmr_delay ) },
@@ -390,7 +392,7 @@ static const LUA_REG_TYPE tmr_map[] = {
 int luaopen_tmr( lua_State *L ){
 	int i;	
 
-	luaL_rometatable(L, "tmr.timer", (void *)tmr_dyn_map);
+	luaL_rometatable(L, "tmr.timer", &tmr_dyn_map_table);
 
 	for(i=0; i<NUM_TMR; i++){
 		alarm_timers[i].lua_ref = LUA_NOREF;

--- a/app/modules/u8g.c
+++ b/app/modules/u8g.c
@@ -1068,6 +1068,7 @@ U8G_DISPLAY_TABLE_SPI
 
 
 // Module function map
+LUA_TABLE_REG_1(lu8g_display_map);
 static const LUA_REG_TYPE lu8g_display_map[] = {
   { LSTRKEY( "begin" ),                        LFUNCVAL( lu8g_begin ) },
   { LSTRKEY( "drawBitmap" ),                   LFUNCVAL( lu8g_drawBitmap ) },
@@ -1124,10 +1125,12 @@ static const LUA_REG_TYPE lu8g_display_map[] = {
   { LSTRKEY( "__index" ),                      LROVAL( lu8g_display_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(lu8g_display_map);
 
 #undef U8G_DISPLAY_TABLE_ENTRY
 #undef U8G_FONT_TABLE_ENTRY
 
+LUA_TABLE_REG_1(lu8g_map);
 static const LUA_REG_TYPE lu8g_map[] = {
 #define U8G_DISPLAY_TABLE_ENTRY(device) \
   { LSTRKEY( #device ),            LFUNCVAL ( lu8g_ ##device ) },
@@ -1149,9 +1152,10 @@ static const LUA_REG_TYPE lu8g_map[] = {
   { LSTRKEY( "__metatable" ), LROVAL( lu8g_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(lu8g_map);
 
 int luaopen_u8g( lua_State *L ) {
-  luaL_rometatable(L, "u8g.display", (void *)lu8g_display_map);  // create metatable
+  luaL_rometatable(L, "u8g.display", &lu8g_display_map_table);  // create metatable
   return 0;
 }
 

--- a/app/modules/ucg.c
+++ b/app/modules/ucg.c
@@ -879,6 +879,7 @@ UCG_DISPLAY_TABLE
 
 
 // Module function map
+LUA_TABLE_REG_1(lucg_display_map);
 static const LUA_REG_TYPE lucg_display_map[] =
 {
     { LSTRKEY( "begin" ),              LFUNCVAL( lucg_begin ) },
@@ -929,7 +930,9 @@ static const LUA_REG_TYPE lucg_display_map[] =
     { LSTRKEY( "__index" ), LROVAL ( lucg_display_map ) },
     { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(lucg_display_map);
 
+LUA_TABLE_REG_1(lucg_map);
 static const LUA_REG_TYPE lucg_map[] = 
 {
 #undef UCG_DISPLAY_TABLE_ENTRY
@@ -955,10 +958,11 @@ static const LUA_REG_TYPE lucg_map[] =
     { LSTRKEY( "__metatable" ), LROVAL( lucg_map ) },
     { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(lucg_map);
 
 int luaopen_ucg( lua_State *L )
 {
-    luaL_rometatable(L, "ucg.display", (void *)lucg_display_map);  // create metatable
+    luaL_rometatable(L, "ucg.display", &lucg_display_map_table);  // create metatable
     return 0;
 }
 

--- a/app/modules/websocket.c
+++ b/app/modules/websocket.c
@@ -262,6 +262,7 @@ static const LUA_REG_TYPE websocket_map[] =
   { LNILKEY, LNILVAL }
 };
 
+LUA_TABLE_REG_1(websocketclient_map);
 static const LUA_REG_TYPE websocketclient_map[] =
 {
   { LSTRKEY("on"), LFUNCVAL(websocketclient_on) },
@@ -272,9 +273,10 @@ static const LUA_REG_TYPE websocketclient_map[] =
   { LSTRKEY("__index"), LROVAL(websocketclient_map) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(websocketclient_map);
 
 int loadWebsocketModule(lua_State *L) {
-  luaL_rometatable(L, METATABLE_WSCLIENT, (void *) websocketclient_map);
+  luaL_rometatable(L, METATABLE_WSCLIENT, &websocketclient_map_table);
 
   return 0;
 }

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1430,6 +1430,7 @@ static int wifi_ap_dhcp_stop( lua_State* L )
 
 
 // Module function map
+LUA_TABLE_REG_1(wifi_station_map);
 static const LUA_REG_TYPE wifi_station_map[] = {
   { LSTRKEY( "autoconnect" ),      LFUNCVAL( wifi_station_setauto ) },
   { LSTRKEY( "changeap" ),         LFUNCVAL( wifi_station_change_ap ) },
@@ -1459,14 +1460,18 @@ static const LUA_REG_TYPE wifi_station_map[] = {
   { LSTRKEY( "status" ),           LFUNCVAL( wifi_station_status ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(wifi_station_map);
 
+LUA_TABLE_REG_1(wifi_ap_dhcp_map);
 static const LUA_REG_TYPE wifi_ap_dhcp_map[] = {
   { LSTRKEY( "config" ),  LFUNCVAL( wifi_ap_dhcp_config ) },
   { LSTRKEY( "start" ),   LFUNCVAL( wifi_ap_dhcp_start ) },
   { LSTRKEY( "stop" ),    LFUNCVAL( wifi_ap_dhcp_stop ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(wifi_ap_dhcp_map);
 
+LUA_TABLE_REG_1(wifi_ap_map);
 static const LUA_REG_TYPE wifi_ap_map[] = {
   { LSTRKEY( "config" ),              LFUNCVAL( wifi_ap_config ) },
   { LSTRKEY( "deauth" ),              LFUNCVAL( wifi_ap_deauth ) },
@@ -1482,7 +1487,11 @@ static const LUA_REG_TYPE wifi_ap_map[] = {
 //{ LSTRKEY( "__metatable" ),         LROVAL( wifi_ap_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(wifi_ap_map);
 
+LUA_TABLE_REG_2(wifi_event_monitor_map);
+
+LUA_TABLE_REG_1(wifi_map);
 static const LUA_REG_TYPE wifi_map[] =  {
   { LSTRKEY( "setmode" ),        LFUNCVAL( wifi_setmode ) },
   { LSTRKEY( "getmode" ),        LFUNCVAL( wifi_getmode ) },
@@ -1532,6 +1541,7 @@ static const LUA_REG_TYPE wifi_map[] =  {
   { LSTRKEY( "__metatable" ),    LROVAL( wifi_map ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(wifi_map);
 
 // Used by user_rf_pre_init(user_main.c)
 void wifi_change_default_host_name(void)

--- a/app/modules/wifi_eventmon.c
+++ b/app/modules/wifi_eventmon.c
@@ -338,6 +338,8 @@ static const LUA_REG_TYPE wifi_event_monitor_reason_map[] =
 LUA_TABLE_REG_2(wifi_event_monitor_reason_map);
 #endif
 
+// This doesn't need the LUA_TABLE_REG wrapper her as the wrapper is actually in wifi.c
+// This table is not actually referenced here, but is only referenced from wifi.c
 const LUA_REG_TYPE wifi_event_monitor_map[] =
 {
   { LSTRKEY( "register" ),            LFUNCVAL( wifi_event_monitor_register ) },

--- a/app/modules/wifi_eventmon.c
+++ b/app/modules/wifi_eventmon.c
@@ -302,6 +302,7 @@ static void wifi_event_monitor_process_event_queue(task_param_t param, uint8 pri
 }
 
 #ifdef WIFI_EVENT_MONITOR_DISCONNECT_REASON_LIST_ENABLE
+LUA_TABLE_REG_1(wifi_event_monitor_reason_map);
 static const LUA_REG_TYPE wifi_event_monitor_reason_map[] =
 {
   { LSTRKEY( "UNSPECIFIED" ),              LNUMVAL( REASON_UNSPECIFIED ) },
@@ -334,6 +335,7 @@ static const LUA_REG_TYPE wifi_event_monitor_reason_map[] =
   { LSTRKEY( "HANDSHAKE_TIMEOUT" ),        LNUMVAL( REASON_HANDSHAKE_TIMEOUT ) },
   { LNILKEY, LNILVAL }
 };
+LUA_TABLE_REG_2(wifi_event_monitor_reason_map);
 #endif
 
 const LUA_REG_TYPE wifi_event_monitor_map[] =

--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -565,6 +565,7 @@ static int ws2812_buffer_tostring(lua_State* L) {
   return 1;
 }
 
+LUA_TABLE_REG_1(ws2812_buffer_map);
 static const LUA_REG_TYPE ws2812_buffer_map[] =
 {
   { LSTRKEY( "dump" ),    LFUNCVAL( ws2812_buffer_dump )},
@@ -583,7 +584,9 @@ static const LUA_REG_TYPE ws2812_buffer_map[] =
   { LSTRKEY( "__tostring" ), LFUNCVAL( ws2812_buffer_tostring )},
   { LNILKEY, LNILVAL}
 };
+LUA_TABLE_REG_2(ws2812_buffer_map);
 
+LUA_TABLE_REG_1(ws2812_map);
 static const LUA_REG_TYPE ws2812_map[] =
 {
   { LSTRKEY( "init" ),           LFUNCVAL( ws2812_init )},
@@ -597,10 +600,11 @@ static const LUA_REG_TYPE ws2812_map[] =
   { LSTRKEY( "SHIFT_CIRCULAR" ), LNUMVAL( SHIFT_CIRCULAR ) },
   { LNILKEY, LNILVAL}
 };
+LUA_TABLE_REG_2(ws2812_map);
 
 int luaopen_ws2812(lua_State *L) {
   // TODO: Make sure that the GPIO system is initialized
-  luaL_rometatable(L, "ws2812.buffer", (void *)ws2812_buffer_map);  // create metatable for ws2812.buffer
+  luaL_rometatable(L, "ws2812.buffer", &ws2812_buffer_map_table);  // create metatable for ws2812.buffer
   return 0;
 }
 

--- a/app/platform/memeq.c
+++ b/app/platform/memeq.c
@@ -1,0 +1,55 @@
+
+#include "c_string.h"
+#include "memeq.h"
+
+int memeq(const char *a, const char *b, size_t l) {
+  if (((uint32_t) a | (uint32_t) b) & 3) {
+    return memcmp(a, b, l);
+  }
+
+  const uint32_t *a32 = (const uint32_t *) a;
+  const uint32_t *b32 = (const uint32_t *) b;
+
+  while (l >= 16) {
+    int res = (*a32++ ^ *b32++);
+    res = res | (*a32++ ^ *b32++);
+    res = res | (*a32++ ^ *b32++);
+    res = res | (*a32++ ^ *b32++);
+    if (res) {
+      return 1;
+    }
+    l -= 16;
+  }
+
+  if (l >= 8) {
+    int res = (*a32++ ^ *b32++);
+    res = res | (*a32++ ^ *b32++);
+    if (res) {
+      return 1;
+    }
+    l -= 8;
+  }
+
+  if (l >= 4) {
+    int res = (*a32++ ^ *b32++);
+    if (res) {
+      return 1;
+    }
+    l -= 4;
+  }
+
+  if (!l) {
+    return 0;
+  }
+
+  // l is 1,2,3
+  int res = *a32 ^ *b32;
+  // Processor is little endian
+  res = res << ((4 - l) << 3);
+
+  if (res) {
+    return 1;
+  }
+
+  return 0;
+}

--- a/app/platform/memeq.c
+++ b/app/platform/memeq.c
@@ -4,7 +4,7 @@
 
 int memeq(const char *a, const char *b, size_t l) {
   if (((uint32_t) a | (uint32_t) b) & 3) {
-    return memcmp(a, b, l);
+    return c_memcmp(a, b, l);
   }
 
   const uint32_t *a32 = (const uint32_t *) a;
@@ -16,7 +16,7 @@ int memeq(const char *a, const char *b, size_t l) {
     res = res | (*a32++ ^ *b32++);
     res = res | (*a32++ ^ *b32++);
     if (res) {
-      return 1;
+      return res;
     }
     l -= 16;
   }
@@ -25,7 +25,7 @@ int memeq(const char *a, const char *b, size_t l) {
     int res = (*a32++ ^ *b32++);
     res = res | (*a32++ ^ *b32++);
     if (res) {
-      return 1;
+      return res;
     }
     l -= 8;
   }
@@ -33,7 +33,7 @@ int memeq(const char *a, const char *b, size_t l) {
   if (l >= 4) {
     int res = (*a32++ ^ *b32++);
     if (res) {
-      return 1;
+      return res;
     }
     l -= 4;
   }
@@ -47,9 +47,5 @@ int memeq(const char *a, const char *b, size_t l) {
   // Processor is little endian
   res = res << ((4 - l) << 3);
 
-  if (res) {
-    return 1;
-  }
-
-  return 0;
+  return res;
 }

--- a/app/platform/memeq.h
+++ b/app/platform/memeq.h
@@ -1,0 +1,6 @@
+#ifndef MEMEQ_H
+#define MEMEQ_H
+
+extern int memeq(const char *a, const char *b, size_t l);
+
+#endif

--- a/app/user/user_exceptions.c
+++ b/app/user/user_exceptions.c
@@ -40,7 +40,7 @@
 
 static exception_handler_fn load_store_handler;
 
-#ifdef DEVELOPMENT_TOOLS
+#ifdef NODE_BYTE_LOAD_STATS
 uint32_t wide_handler_count;
 uint32_t wide_handler_last_epc[4];
 uint8_t wide_handler_last_epc_index;  // Points to most recent to be used
@@ -89,7 +89,7 @@ die:
     while (1) {}
   }
 
-#ifdef DEVELOPMENT_TOOLS
+#ifdef NODE_BYTE_LOAD_STATS
   wide_handler_count++;
   if (wide_handler_last_epc[wide_handler_last_epc_index & 3] != epc1) {
     wide_handler_last_epc_index++;

--- a/app/user/user_exceptions.c
+++ b/app/user/user_exceptions.c
@@ -40,6 +40,12 @@
 
 static exception_handler_fn load_store_handler;
 
+#ifdef DEVELOPMENT_TOOLS
+uint32_t wide_handler_count;
+uint32_t wide_handler_last_epc[4];
+uint8_t wide_handler_last_epc_index;  // Points to most recent to be used
+#endif
+
 
 void load_non_32_wide_handler (struct exception_frame *ef, uint32_t cause)
 {
@@ -82,6 +88,14 @@ die:
     asm ("break 1, 1");
     while (1) {}
   }
+
+#ifdef DEVELOPMENT_TOOLS
+  wide_handler_count++;
+  if (wide_handler_last_epc[wide_handler_last_epc_index & 3] != epc1) {
+    wide_handler_last_epc_index++;
+    wide_handler_last_epc[wide_handler_last_epc_index & 3] = epc1;
+  }
+#endif
 
   /* Load, shift and mask down to correct size */
   uint32_t val = (*(uint32_t *)(excvaddr & ~0x3));

--- a/ld/nodemcu.ld
+++ b/ld/nodemcu.ld
@@ -81,6 +81,8 @@ SECTIONS
     *(.rodata*)
     *(.sdk.version)
 
+    KEEP(*(.keep.rodata))
+
     /* Link-time arrays containing the defs for the included modules */
     . = ALIGN(4);
     lua_libs = ABSOLUTE(.);

--- a/ld/nodemcu.ld
+++ b/ld/nodemcu.ld
@@ -5,7 +5,7 @@ MEMORY
   dport0_0_seg :                        org = 0x3FF00000, len = 0x10
   dram0_0_seg :                         org = 0x3FFE8000, len = 0x14000
   iram1_0_seg :                         org = 0x40100000, len = 0x8000
-  irom0_0_seg :                         org = 0x40210000, len = 0x80000
+  irom0_0_seg :                         org = 0x40210000, len = 0x90000
 }
 
 PHDRS

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,4 @@
 TLS.*
 private_key.h
 cert.h
+*.pyc

--- a/tools/addhashtables.py
+++ b/tools/addhashtables.py
@@ -306,13 +306,8 @@ def hashimage(args):
         data = e.load_section(section)
         image.add_segment(e.get_symbol_addr(start), data)
 
-    sizes = image.read32(e.get_symbol_addr("lua_rotable_table_hashtable"))
-
-    #table_size = (sizes >> 16) & 0xff
-    #entry_size = (sizes >> 8) & 0xff
-
-    table_size = 16
-    entry_size = 16
+    table_size = image.read8(e.get_symbol_addr("luaR_table_size"))
+    entry_size = image.read8(e.get_symbol_addr("luaR_entry_size"))
 
     if table_size != 16:
       raise FatalError("luaR_table size is not recognized (%d)" % (table_size))

--- a/tools/addhashtables.py
+++ b/tools/addhashtables.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python
+#
+# This tool adds the (constant) hash tables to the firmware image that enable
+# fast lookups.
+#
+# This code uses some pieces of esptool.py which has the following license.
+#
+# Copyright (C) 2014-2016 Fredrik Ahlberg, Angus Gratton, other contributors as noted.
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 2 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import argparse
+import hashlib
+import inspect
+import json
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+
+
+__version__ = "0.1-dev"
+
+def binutils_safe_path(p):
+    """Returns a 'safe' version of path 'p' to pass to binutils
+
+    Only does anything under Cygwin Python, where cygwin paths need to
+    be translated to Windows paths if the binutils wasn't compiled
+    using Cygwin (should also work with binutils compiled using
+    Cygwin, see #73.)
+    """
+    if sys.platform == "cygwin":
+        try:
+            return subprocess.check_output(["cygpath", "-w", p]).rstrip('\n')
+        except subprocess.CalledProcessError:
+            print "WARNING: Failed to call cygpath to sanitise Cygwin path."
+    return p
+
+
+
+class ELFFile(object):
+    def __init__(self, name):
+        self.name = binutils_safe_path(name)
+        self.symbols = None
+
+    def _fetch_symbols(self):
+        if self.symbols is not None:
+            return
+        self.symbols = {}
+        try:
+            tool_nm = "xtensa-lx106-elf-nm"
+            if os.getenv('XTENSA_CORE') == 'lx106':
+                tool_nm = "xt-nm"
+            proc = subprocess.Popen([tool_nm, self.name], stdout=subprocess.PIPE)
+        except OSError:
+            print "Error calling %s, do you have Xtensa toolchain in PATH?" % tool_nm
+            sys.exit(1)
+        for l in proc.stdout:
+            fields = l.strip().split()
+            try:
+                if fields[0] == "U":
+                    print "Warning: ELF binary has undefined symbol %s" % fields[1]
+                    continue
+                if fields[0] == "w":
+                    continue  # can skip weak symbols
+                self.symbols[fields[2]] = int(fields[0], 16)
+            except ValueError:
+                raise FatalError("Failed to strip symbol output from nm: %s" % fields)
+
+    def get_symbol_addr(self, sym):
+        self._fetch_symbols()
+        return self.symbols[sym]
+
+    def foreach_symbol(self, fn):
+        for symbol in self.symbols.iterkeys():
+          fn(symbol)
+
+    def get_entry_point(self):
+        tool_readelf = "xtensa-lx106-elf-readelf"
+        if os.getenv('XTENSA_CORE') == 'lx106':
+            tool_readelf = "xt-readelf"
+        try:
+            proc = subprocess.Popen([tool_readelf, "-h", self.name], stdout=subprocess.PIPE)
+        except OSError:
+            print "Error calling %s, do you have Xtensa toolchain in PATH?" % tool_readelf
+            sys.exit(1)
+        for l in proc.stdout:
+            fields = l.strip().split()
+            if fields[0] == "Entry":
+                return int(fields[3], 0)
+
+    def load_section(self, section):
+        tool_objcopy = "xtensa-lx106-elf-objcopy"
+        if os.getenv('XTENSA_CORE') == 'lx106':
+            tool_objcopy = "xt-objcopy"
+        tmpsection = binutils_safe_path(tempfile.mktemp(suffix=".section"))
+        try:
+            subprocess.check_call([tool_objcopy, "--only-section", section, "-Obinary", self.name, tmpsection])
+            with open(tmpsection, "rb") as f:
+                data = f.read()
+        except OSError, e:
+            print "Error calling %s, do you have Xtensa toolchain in PATH?" % tool_nm
+            sys.exit(1)
+        finally:
+            os.remove(tmpsection)
+        return data
+
+def luahash(str):
+  # unsigned int h = cast(unsigned int, l);  /* seed */
+  # size_t step = (l>>5)+1;  /* if string is too long, don't hash all its chars */
+  # size_t l1;
+  # for (l1=l; l1>=step; l1-=step)  /* compute hash */
+  #   h = h ^ ((h<<5)+(h>>2)+cast(unsigned char, str[l1-1]));
+
+  h = len(str)
+  step = (len(str) >> 5) + 1
+  for li in range(len(str) - 1, -1, -step):
+    h = h ^ ((h << 5) + (h >> 2) + ord(str[li]))
+
+  return h
+
+class Image(object):
+  imagedata = []
+
+  def add_segment(self, addr, data):
+    self.imagedata.append([addr, data])
+    self.sortit()
+
+  def sortit(self):
+    self.imagedata = sorted(self.imagedata, key=lambda section: section[0])
+
+  def find_section(self, addr):
+    best = (None,None)
+    for entry in self.imagedata:
+      if addr >= entry[0]:
+        best = entry
+      else:
+        return best
+
+    return best
+    
+  def readstring(self, addr):
+    base, data = self.find_section(addr)
+    if base:
+      data = data[addr - base : addr - base + 128]
+      return data[:data.index("\0")]
+    return None
+
+  def read32(self, addr):
+    base, data = self.find_section(addr)
+    if not base:
+      return None
+    data = data[addr - base : addr - base + 4]
+    if not data:
+      return None
+    return struct.unpack("i", data)[0]
+
+
+def setoffset(hash, h, i):
+    mask = len(hash) - 1
+
+    while hash[h & mask]:
+      hash[h & mask] = hash[h & mask] & 0x7f
+      h = h + 1
+
+    hash[h & mask] = 128 + i + 1
+
+def dump_rotable(image, rotable, name, forcesize=None):
+    # Count entries in tbl
+    # name, value
+    i = 0
+    while image.read32(rotable + i * 16):
+      i += 1
+
+    print "// %s: %d entries" % (name, i)
+
+    nents = 4
+    while nents < i * 3:
+      nents = nents << 1
+
+    if nents > 256:
+      nents = 256
+
+    if forcesize > nents:
+      nents = forcesize
+
+    hash = [0] * nents
+    i = 0
+    while image.read32(rotable + i * 16):
+      str = image.readstring(image.read32(rotable + i * 16))
+      h = luahash(str) % nents
+      setoffset(hash, h, i)
+
+      i += 1
+
+    dump_with_name(hash, name, nents)
+
+dumped = {}
+
+def dump_table(image, rotable=None, name=None, forcesize=None):
+    if dumped.get(rotable):
+      return
+    dumped[rotable] = 1
+    if not name:
+        name = image.readstring(image.read32(rotable)).upper()
+    tbl = image.read32(rotable + 4)
+
+    # Count entries in tbl
+    # name, value
+    i = 0
+    while image.read32(tbl + i * 16):
+      i += 1
+
+    print "// %s: %d entries" % (name, i)
+
+    nents = 4
+    while nents < i * 3:
+      nents = nents << 1
+
+    if nents > 256:
+      nents = 256
+
+    if forcesize > nents:
+      nents = forcesize
+
+    hash = [0] * nents
+    i = 0
+    while image.read32(tbl + i * 16):
+      if (image.read32(tbl + i * 16) & 0xff) == 6:
+        str = image.readstring(image.read32(tbl + i * 16 + 4))
+        h = luahash(str) % nents
+        setoffset(hash, h, i)
+
+        if image.read32(tbl + i * 16 + 12) == 2:
+          nexttbl = image.read32(tbl + i * 16 + 8)
+          dump_table(image, rotable=nexttbl, name=image.readstring(image.read32(nexttbl)))
+
+      i += 1
+
+    dump_with_name(hash, name, nents)
+
+def dump_with_name(hash, name, nents):
+    print "const unsigned int %s_hashtable[] = { %d " % (name, nents - 1)
+    print "// ", "".join(["," + hex(x) for x in hash])
+    val = 0
+    for i in range(0, nents):
+      val = val + (hash[i] << (8 * (i & 3)))
+      if (i & 3) == 3:
+        print ",",hex(val),
+        val = 0
+    print "\n};"
+
+def maybe_dump_table(image, symbol, addr):
+    if symbol.endswith("_table"):
+      name_addr = image.read32(addr)
+      if name_addr:
+        name = image.readstring(name_addr)
+        if name and symbol.startswith(name):
+          dump_table(image, addr, name)
+
+
+def hashimage(args):
+    e = ELFFile(args.input)
+
+    # Start at "lua_rotable" and step through. 
+    # Generate the C file with symbols MODULE_hashtable to replace the weak references
+
+    image = Image()
+
+    for section, start in ((".irom0.text", "_irom0_text_start"), (".text", "_text_start"), (".data", "_data_start"), (".rodata", "_rodata_start")):
+        data = e.load_section(section)
+        image.add_segment(e.get_symbol_addr(start), data)
+
+    #luaR_table is name, table, stuff
+
+    rotable = e.get_symbol_addr("lua_rotable")
+
+    while image.read32(rotable):
+      dump_table(image, rotable)
+      rotable += 16
+
+    dump_table(image, e.get_symbol_addr("lua_base_funcs_table"), "lua_base_funcs_table", forcesize=256)
+    dump_table(image, e.get_symbol_addr("strlib_table"), "strlib_table")
+    dump_rotable(image, e.get_symbol_addr("lua_rotable"), "lua_rotable_table", forcesize=256)
+
+    e.foreach_symbol(lambda symbol: maybe_dump_table(image, symbol, e.get_symbol_addr(symbol)))
+
+
+class FatalError(RuntimeError):
+    """
+    Wrapper class for runtime errors that aren't caused by internal bugs, but by
+    ESP8266 responses or input content.
+    """
+    def __init__(self, message):
+        RuntimeError.__init__(self, message)
+
+    @staticmethod
+    def WithResult(message, result):
+        """
+        Return a fatal error object that includes the hex values of
+        'result' as a string formatted argument.
+        """
+        return FatalError(message % ", ".join(hex(ord(x)) for x in result))
+
+
+def version(args):
+    print __version__
+
+#
+# End of operations functions
+#
+
+
+def main():
+    parser = argparse.ArgumentParser(description='addhashtables.py v%s - NodeMCU firmware patches' % __version__, prog='addhashtables')
+    parser.add_argument('input', help='Input ELF file')
+
+    args = parser.parse_args()
+
+    # print 'esptool.py v%s' % __version__
+
+    # operation function can take 1 arg (args), 2 args (esp, arg)
+    # or be a member function of the ESPROM class.
+
+    hashimage(args)
+
+
+if __name__ == '__main__':
+    try:
+        main()
+    except FatalError as e:
+        print '\nA fatal error occurred: %s' % e
+        sys.exit(2)


### PR DESCRIPTION
Fixes #1590 

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

This is the current state of the branch that speeds up rotable lookups. For example the line

a = tmr.now

gets about a factor 10 faster. 

There are a lot of things going into this, see the discussion in #1590 for more information.

Yes -- this PR isn't done -- there are probably debug printfs in there still enabled etc.

This now builds (and runs) in both integer and float environments.  