### PR TITLE
Fix typo at rtctime.md

### DIFF
--- a/docs/en/modules/rtctime.md
+++ b/docs/en/modules/rtctime.md
@@ -55,7 +55,7 @@ rtctime.dsleep(5000000, 4)
 For applications where it is necessary to take samples with high regularity, this function is useful. It provides an easy way to implement a "wake up on the next 5-minute boundary" scheme, without having to explicitly take into account how long the module has been active for etc before going back to sleep.
 
 #### Syntax
-`rtctime.dsleep(aligned_us, minsleep_us [, option])`
+`rtctime.dsleep_aligned(aligned_us, minsleep_us [, option])`
 
 #### Parameters
 - `aligned_us` boundary interval in microseconds


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

rtctime.dsleep -> rtctime.dsleep_aligned