### PR TITLE
Move init_data from .text to .rodata.dram section

### DIFF
--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -37,7 +37,7 @@ extern const uint32_t init_data[];
 extern const uint32_t init_data_end[];
 __asm__(
   /* Place in .text for same reason as user_start_trampoline */
-  ".section \".text\"\n"
+  ".section \".rodata.dram\"\n"
   ".align 4\n"
   "init_data:\n"
   ".incbin \"" ESP_INIT_DATA_DEFAULT "\"\n"


### PR DESCRIPTION
Fixes #1640.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

As per https://github.com/nodemcu/nodemcu-firmware/issues/1640#issuecomment-264708167: Pre-loaded init_data shall be put into `.rodata.dram` section.
