### PR TITLE
Rework support for >4MB modules: place SPIFFS after SDK data

### DIFF
--- a/app/platform/flash_api.c
+++ b/app/platform/flash_api.c
@@ -35,6 +35,12 @@ uint32_t flash_safe_get_size_byte(void)
     if (flash_size == 0)
     {
         flash_size = flash_detect_size_byte();
+#if !defined(FLASH_SAFE_API)
+	// clip maximum flash size to 4MByte if "SAFE API" is not used
+	if (flash_size > FLASH_SIZE_4MBYTE) {
+	    flash_size = FLASH_SIZE_4MBYTE;
+	}
+#endif
     }
     return flash_size;
 }

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -53,8 +53,14 @@ static bool myspiffs_set_location(spiffs_config *cfg, int align, int offset, int
 #ifdef SPIFFS_FIXED_LOCATION
   cfg->phys_addr = (SPIFFS_FIXED_LOCATION + block_size - 1) & ~(block_size-1);
 #else
-  cfg->phys_addr = ( u32_t )platform_flash_get_first_free_block_address( NULL ) + offset; 
-  cfg->phys_addr = (cfg->phys_addr + align - 1) & ~(align - 1);
+  if (flash_safe_get_size_byte() <= FLASH_SIZE_4MBYTE) {
+    // 256kByte - 4MByte modules: SPIFFS partition starts right after firmware image
+    cfg->phys_addr = ( u32_t )platform_flash_get_first_free_block_address( NULL ) + offset; 
+    cfg->phys_addr = (cfg->phys_addr + align - 1) & ~(align - 1);
+  } else {
+    // > 4MByte modules: SPIFFS partition starts after SDK data
+    cfg->phys_addr = flash_rom_get_size_byte();
+  }
 #endif
 #ifdef SPIFFS_SIZE_1M_BOUNDARY
   cfg->phys_size = ((0x100000 - (SYS_PARAM_SEC_NUM * INTERNAL_FLASH_SECTOR_SIZE) - ( ( u32_t )cfg->phys_addr )) & ~(block_size - 1)) & 0xfffff;

--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -55,7 +55,7 @@ static bool myspiffs_set_location(spiffs_config *cfg, int align, int offset, int
 #else
   if (flash_safe_get_size_byte() <= FLASH_SIZE_4MBYTE) {
     // 256kByte - 4MByte modules: SPIFFS partition starts right after firmware image
-    cfg->phys_addr = ( u32_t )platform_flash_get_first_free_block_address( NULL ) + offset; 
+    cfg->phys_addr = ( u32_t )platform_flash_get_first_free_block_address( NULL ) + offset;
     cfg->phys_addr = (cfg->phys_addr + align - 1) & ~(align - 1);
   } else {
     // > 4MByte modules: SPIFFS partition starts after SDK data

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -122,17 +122,26 @@ void nodemcu_init(void)
         return;
     }
 
-#if defined(FLASH_SAFE_API)
-    if( flash_safe_get_size_byte() != flash_rom_get_size_byte()) {
-        NODE_ERR("Self adjust flash size.\n");
-        // Fit hardware real flash size.
-        flash_rom_set_size_byte(flash_safe_get_size_byte());
+    if( flash_safe_get_size_byte() <= FLASH_SIZE_4MBYTE ) {
+        if( flash_safe_get_size_byte() != flash_rom_get_size_byte() ) {
+            NODE_ERR("Self adjust flash size.\n");
+            // Fit hardware real flash size.
+            flash_rom_set_size_byte(flash_safe_get_size_byte());
+
+            system_restart ();
+            // Don't post the start_lua task, we're about to reboot...
+            return;
+        }
+    } else if( (flash_rom_get_size_byte() < FLASH_SIZE_1MBYTE) ||
+               (flash_rom_get_size_byte() > FLASH_SIZE_4MBYTE) ) {
+        NODE_ERR("Locking flash size for SDK to 1MByte.\n");
+        // SDK/ROM can't handle flash size > 4MByte, ensure a minimum of 1MByte for firmware image
+        flash_rom_set_size_byte(FLASH_SIZE_1MBYTE);
 
         system_restart ();
         // Don't post the start_lua task, we're about to reboot...
         return;
     }
-#endif // defined(FLASH_SAFE_API)
 
 #if defined ( CLIENT_SSL_ENABLE ) && defined ( SSL_BUFFER_SIZE )
     espconn_secure_set_size(ESPCONN_CLIENT, SSL_BUFFER_SIZE);

--- a/docs/en/flash.md
+++ b/docs/en/flash.md
@@ -115,3 +115,5 @@ Device: 4016
 The chip ID can then be looked up in [https://code.coreboot.org/p/flashrom/source/tree/HEAD/trunk/flashchips.h](https://code.coreboot.org/p/flashrom/source/tree/HEAD/trunk/flashchips.h). This leads to a manufacturer name and a chip model name/number e.g. `AMIC_A25LQ032`. That information can then be fed into your favorite search engine to find chip descriptions and data sheets.
 
 By convention the last two or three digits in the module name denote the capacity in megabits. So, `A25LQ032` in the example above is a 32Mb(=4MB) module.
+
+Modules with flash chips larger than 4MB (e.g. WeMos D1 mini pro) are configured automatically to 1MB/15MB: Firmware image and SDK init data occupy the first 1MB, while the remaining 15MB of the flash are used for SPIFFS.

--- a/docs/en/flash.md
+++ b/docs/en/flash.md
@@ -32,6 +32,8 @@ Run the following command to flash an *aggregated* binary as is produced for exa
 - esptool.py is under heavy development. It's advised you run the latest version (check with `esptool.py version`). Since this documentation may not have been able to keep up refer to the [esptool flash modes documentation](https://github.com/themadinventor/esptool#flash-modes) for current options and parameters.
 - In some uncommon cases, the [SDK init data](#sdk-init-data) may be invalid and NodeMCU may fail to boot. The easiest solution is to fully erase the chip before flashing:
 `esptool.py --port <serial-port-of-ESP8266> erase_flash`
+- Modules with flash chips larger than 4&nbsp;MByte (e.g. WeMos D1 mini pro) need to be manually configured to at least 1&nbsp;MByte: Firmware image and SDK init data occupy the first MByte, while the remaining 7/15&nbsp;MByte of the flash are used for SPIFFS:
+`esptool.py --port <serial-port-of-ESP8266> write_flash -fm <mode> -fs 8m 0x00000 <nodemcu-firmware>.bin`
 
 ### NodeMCU Flasher
 > A firmware Flash tool for NodeMCU...We are working on next version and will use QT framework. It will be cross platform and open-source.
@@ -115,5 +117,3 @@ Device: 4016
 The chip ID can then be looked up in [https://code.coreboot.org/p/flashrom/source/tree/HEAD/trunk/flashchips.h](https://code.coreboot.org/p/flashrom/source/tree/HEAD/trunk/flashchips.h). This leads to a manufacturer name and a chip model name/number e.g. `AMIC_A25LQ032`. That information can then be fed into your favorite search engine to find chip descriptions and data sheets.
 
 By convention the last two or three digits in the module name denote the capacity in megabits. So, `A25LQ032` in the example above is a 32Mb(=4MB) module.
-
-Modules with flash chips larger than 4MB (e.g. WeMos D1 mini pro) are configured automatically to 1MB/15MB: Firmware image and SDK init data occupy the first 1MB, while the remaining 15MB of the flash are used for SPIFFS.


### PR DESCRIPTION
Fixes #1634.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

The default flash memory map strategy of the firmware doesn't scale beyond 4&nbsp;Mbyte / 32&nbsp;Mbit modules since SDK and ROM cannot access flash in the upper region (>4&nbsp;MByte). This breaks e.g. non-volatile Wifi settings which are supposed to be stored at the very end of a 16&nbsp;MByte Wemos D1 mini pro. Also see [ESP8266 16MB Flash Handling](http://www.packom.org/esp8266/16mb/flash/eeprom/2016/10/14/esp8266-16mbyte-flash_handling.html) for details.

PR establishes a new strategy for flash sizes >4&nbsp;MByte (inspired by the Arduino configuration for Wemos D1 mini pro and @moononournation's [instructions on WeMos D1 mini Pro flash NodeMCU firmware](http://www.instructables.com/id/WeMos-D1-Mini-Pro-Flash-NodeMCU-Firmware/)):
- Treat the module like a 1&nbsp;MByte variant, with the firmware image and SDK init data stored in this region.
- Place SPIFFS *after* the SDK init data, occupying the remaining flash by default.

Two locations in the firmware needed adaption. If the >4&nbsp;MByte case is detected, then
1. the code for self adjust of the flash size during startup doesn't extend the "SDK size" to the full flash size, but just ensures at least 1&nbsp;MByte, and
2. `myspiffs_set_location()` places SPIFFS after the SDK init data, not after the firmware image.
