### PR TITLE
Fix missing dbg_printf when build luac.cross

### DIFF
--- a/tools/cross-lua.lua
+++ b/tools/cross-lua.lua
@@ -16,7 +16,7 @@ end
 builder:init( args )
 builder:set_build_mode( builder.BUILD_DIR_LINEARIZED )
 local output = 'luac.cross'
-local cdefs = '-DLUA_CROSS_COMPILER'
+local cdefs = '-DLUA_CROSS_COMPILER -Ddbg_printf=printf'
 
 -- Lua source files and include path
 local lua_files = [[


### PR DESCRIPTION
Fixes #1637.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This eliminates the stray reference to `dbg_printf` with a call to `printf`