### PR TITLE
BME280: fixing humidity trimming parameter readout bug

### DIFF
--- a/app/modules/bme280.c
+++ b/app/modules/bme280.c
@@ -286,7 +286,7 @@ static int bme280_lua_init(lua_State* L) {
 		reg = BME280_REGISTER_DIG_H2;
 		bme280_data.dig_H2 = r16sLE(reg); reg+=2;
 		bme280_data.dig_H3 = r8u(reg); reg++;
-		bme280_data.dig_H4 = ((int16_t)r8u(reg) << 4 | (r8u(reg+1) & 0xF)); reg+=2;
+		bme280_data.dig_H4 = ((int16_t)r8u(reg) << 4 | (r8u(reg+1) & 0xF)); reg++;
 		bme280_data.dig_H5 = ((int16_t)r8u(reg+1) << 4 | (r8u(reg) >> 4)); reg+=2;
 		bme280_data.dig_H6 = (int8_t)r8u(reg);
 		// NODE_DBG("dig_H: %d\t%d\t%d\t%d\t%d\t%d\n", bme280_data.dig_H1, bme280_data.dig_H2, bme280_data.dig_H3, bme280_data.dig_H4, bme280_data.dig_H5, bme280_data.dig_H6);


### PR DESCRIPTION
Fixes https://github.com/nodemcu/nodemcu-firmware/issues/1636.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Fixes a bug in reading of trimming parameter `dig_H5` and `dig_H6` (Datasheet: 6.2.2 Trimming parameter readout). These parameters are used in compensation formulas for calculating humidity - i.e. humidity readout before this bug fix was not correct.