### PR TITLE
Adds uart.check(0) to get the current uart parameters

### DIFF
--- a/app/driver/uart.c
+++ b/app/driver/uart.c
@@ -356,3 +356,7 @@ uart_setup(uint8 uart_no)
 void ICACHE_FLASH_ATTR uart_set_alt_output_uart0(void (*fn)(char)) {
   alt_uart0_tx = fn;
 }
+
+int ICACHE_FLASH_ATTR uart_get_baudrate(uint8 uart_no) {
+  return UART_CLK_FREQ / (*(uint32_t *) (0x60000014 + 0xf00 * uart_no));
+}

--- a/app/driver/uart.c
+++ b/app/driver/uart.c
@@ -357,6 +357,17 @@ void ICACHE_FLASH_ATTR uart_set_alt_output_uart0(void (*fn)(char)) {
   alt_uart0_tx = fn;
 }
 
-int ICACHE_FLASH_ATTR uart_get_baudrate(uint8 uart_no) {
-  return UART_CLK_FREQ / (*(uint32_t *) (0x60000014 + 0xf00 * uart_no));
+UartConfig ICACHE_FLASH_ATTR uart_get_config(uint8 uart_no) {
+  UartConfig config;
+
+  config.baut_rate = UART_CLK_FREQ / READ_PERI_REG(UART_CLKDIV(uart_no));
+
+  uint32_t conf = READ_PERI_REG(UART_CONF0(uart_no));
+
+  config.exist_parity = (conf >> UART_PARITY_EN_S)    & UART_PARITY_EN_M;
+  config.parity       = (conf >> UART_PARITY_S)       & UART_PARITY_M;
+  config.stop_bits    = (conf >> UART_STOP_BIT_NUM_S) & UART_STOP_BIT_NUM;
+  config.data_bits    = (conf >> UART_BIT_NUM_S)      & UART_BIT_NUM;
+
+  return config;
 }

--- a/app/include/driver/uart.h
+++ b/app/include/driver/uart.h
@@ -102,6 +102,7 @@ typedef struct {
 } UartDevice;
 
 void uart_init(UartBautRate uart0_br, UartBautRate uart1_br, os_signal_t sig_input, uint8 *flag_input);
+int uart_get_baudrate(uint8 uart_no);
 void uart0_alt(uint8 on);
 void uart0_sendStr(const char *str);
 void uart0_putc(const char c);

--- a/app/include/driver/uart.h
+++ b/app/include/driver/uart.h
@@ -101,8 +101,16 @@ typedef struct {
     int                      buff_uart_no;  //indicate which uart use tx/rx buffer
 } UartDevice;
 
+typedef struct {
+    UartBautRate      baut_rate;
+    UartBitsNum4Char  data_bits;
+    UartExistParity   exist_parity;
+    UartParityMode    parity;   
+    UartStopBitsNum   stop_bits;
+} UartConfig;
+
 void uart_init(UartBautRate uart0_br, UartBautRate uart1_br, os_signal_t sig_input, uint8 *flag_input);
-int uart_get_baudrate(uint8 uart_no);
+UartConfig uart_get_config(uint8 uart_no);
 void uart0_alt(uint8 on);
 void uart0_sendStr(const char *str);
 void uart0_putc(const char c);

--- a/app/modules/uart.c
+++ b/app/modules/uart.c
@@ -96,6 +96,11 @@ static int uart_setup( lua_State* L )
   
   id = luaL_checkinteger( L, 1 );
   MOD_CHECK_ID( uart, id );
+
+  if (lua_gettop(L) == 1) {
+    lua_pushinteger(L, uart_get_baudrate(id));
+    return 1;
+  }
   baud = luaL_checkinteger( L, 2 );
   databits = luaL_checkinteger( L, 3 );
   parity = luaL_checkinteger( L, 4 );

--- a/app/modules/uart.c
+++ b/app/modules/uart.c
@@ -114,8 +114,8 @@ static int l_uart_setup( lua_State* L )
   return 1;
 }
 
-// uart.check(id)
-static int l_uart_check( lua_State* L )
+// uart.getconfig(id)
+static int l_uart_getconfig( lua_State* L )
 {
   uint32_t id, databits, parity, stopbits;
   uint32_t baud;
@@ -176,7 +176,7 @@ static int l_uart_write( lua_State* L )
 // Module function map
 static const LUA_REG_TYPE uart_map[] =  {
   { LSTRKEY( "setup" ), LFUNCVAL( l_uart_setup ) },
-  { LSTRKEY( "check" ), LFUNCVAL( l_uart_check ) },
+  { LSTRKEY( "getconfig" ), LFUNCVAL( l_uart_getconfig ) },
   { LSTRKEY( "write" ), LFUNCVAL( l_uart_write ) },
   { LSTRKEY( "on" ),    LFUNCVAL( l_uart_on ) },
   { LSTRKEY( "alt" ),   LFUNCVAL( l_uart_alt ) },

--- a/app/modules/uart.c
+++ b/app/modules/uart.c
@@ -27,7 +27,7 @@ bool uart_on_data_cb(const char *buf, size_t len){
 uint16_t need_len = 0;
 int16_t end_char = -1;
 // Lua: uart.on("method", [number/char], function, [run_input])
-static int uart_on( lua_State* L )
+static int l_uart_on( lua_State* L )
 {
   size_t sl, el;
   int32_t run = 1;
@@ -89,18 +89,14 @@ static int uart_on( lua_State* L )
 
 bool uart0_echo = true;
 // Lua: actualbaud = setup( id, baud, databits, parity, stopbits, echo )
-static int uart_setup( lua_State* L )
+static int l_uart_setup( lua_State* L )
 {
-  unsigned id, databits, parity, stopbits, echo = 1;
-  u32 baud, res;
+  uint32_t id, databits, parity, stopbits, echo = 1;
+  uint32_t baud, res;
   
   id = luaL_checkinteger( L, 1 );
   MOD_CHECK_ID( uart, id );
 
-  if (lua_gettop(L) == 1) {
-    lua_pushinteger(L, platform_uart_get_baudrate(id));
-    return 1;
-  }
   baud = luaL_checkinteger( L, 2 );
   databits = luaL_checkinteger( L, 3 );
   parity = luaL_checkinteger( L, 4 );
@@ -118,8 +114,26 @@ static int uart_setup( lua_State* L )
   return 1;
 }
 
+// uart.check(id)
+static int l_uart_check( lua_State* L )
+{
+  uint32_t id, databits, parity, stopbits;
+  uint32_t baud;
+  
+  id = luaL_checkinteger( L, 1 );
+  MOD_CHECK_ID( uart, id );
+
+  platform_uart_get_config(id, &baud, &databits, &parity, &stopbits);
+
+  lua_pushinteger(L, baud);
+  lua_pushinteger(L, databits);
+  lua_pushinteger(L, parity);
+  lua_pushinteger(L, stopbits);
+  return 4;
+}
+
 // Lua: alt( set )
-static int uart_alt( lua_State* L )
+static int l_uart_alt( lua_State* L )
 {
   unsigned set;
   
@@ -130,7 +144,7 @@ static int uart_alt( lua_State* L )
 }
 
 // Lua: write( id, string1, [string2], ..., [stringn] )
-static int uart_write( lua_State* L )
+static int l_uart_write( lua_State* L )
 {
   int id;
   const char* buf;
@@ -161,10 +175,11 @@ static int uart_write( lua_State* L )
 
 // Module function map
 static const LUA_REG_TYPE uart_map[] =  {
-  { LSTRKEY( "setup" ), LFUNCVAL( uart_setup ) },
-  { LSTRKEY( "write" ), LFUNCVAL( uart_write ) },
-  { LSTRKEY( "on" ),    LFUNCVAL( uart_on ) },
-  { LSTRKEY( "alt" ),   LFUNCVAL( uart_alt ) },
+  { LSTRKEY( "setup" ), LFUNCVAL( l_uart_setup ) },
+  { LSTRKEY( "check" ), LFUNCVAL( l_uart_check ) },
+  { LSTRKEY( "write" ), LFUNCVAL( l_uart_write ) },
+  { LSTRKEY( "on" ),    LFUNCVAL( l_uart_on ) },
+  { LSTRKEY( "alt" ),   LFUNCVAL( l_uart_alt ) },
   { LSTRKEY( "STOPBITS_1" ),   LNUMVAL( PLATFORM_UART_STOPBITS_1 ) },
   { LSTRKEY( "STOPBITS_1_5" ), LNUMVAL( PLATFORM_UART_STOPBITS_1_5 ) },
   { LSTRKEY( "STOPBITS_2" ),   LNUMVAL( PLATFORM_UART_STOPBITS_2 ) },

--- a/app/modules/uart.c
+++ b/app/modules/uart.c
@@ -98,7 +98,7 @@ static int uart_setup( lua_State* L )
   MOD_CHECK_ID( uart, id );
 
   if (lua_gettop(L) == 1) {
-    lua_pushinteger(L, uart_get_baudrate(id));
+    lua_pushinteger(L, platform_uart_get_baudrate(id));
     return 1;
   }
   baud = luaL_checkinteger( L, 2 );

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -410,6 +410,10 @@ uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int pari
   return baud;
 }
 
+int platform_uart_get_baudrate(unsigned id) {
+  return uart_get_baudrate(id);
+}
+
 // if set=1, then alternate serial output pins are used. (15=rx, 13=tx)
 void platform_uart_alt( int set )
 {

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -32,6 +32,26 @@ static struct gpio_hook platform_gpio_hook;
 #endif
 #endif
 
+static const int uart_bitrates[] = {
+    BIT_RATE_300,
+    BIT_RATE_600,
+    BIT_RATE_1200,
+    BIT_RATE_2400,
+    BIT_RATE_4800,
+    BIT_RATE_9600,
+    BIT_RATE_19200,
+    BIT_RATE_38400,
+    BIT_RATE_57600,
+    BIT_RATE_74880,
+    BIT_RATE_115200,
+    BIT_RATE_230400,
+    BIT_RATE_256000,
+    BIT_RATE_460800,
+    BIT_RATE_921600,
+    BIT_RATE_1843200,
+    BIT_RATE_3686400
+};
+
 int platform_init()
 {
   // Setup the various forward and reverse mappings for the pins
@@ -410,8 +430,62 @@ uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int pari
   return baud;
 }
 
-int platform_uart_get_baudrate(unsigned id) {
-  return uart_get_baudrate(id);
+void platform_uart_get_config(unsigned id, uint32_t *baudp, uint32_t *databitsp, uint32_t *parityp, uint32_t *stopbitsp) {
+  UartConfig config =  uart_get_config(id);
+  int i;
+
+  int offset = config.baut_rate;
+
+  for (i = 0; i < sizeof(uart_bitrates) / sizeof(uart_bitrates[0]); i++) {
+    int diff = config.baut_rate - uart_bitrates[i];
+
+    if (diff < 0) {
+      diff = -diff;
+    }
+
+    if (diff < offset) {
+       offset = diff;
+       *baudp = uart_bitrates[i];
+    }
+  }
+
+  switch( config.data_bits )
+  {
+    case FIVE_BITS:
+      *databitsp = 5;
+      break;
+    case SIX_BITS:
+      *databitsp = 6;
+      break;
+    case SEVEN_BITS:
+      *databitsp = 7;
+      break;
+    case EIGHT_BITS:
+    default:
+      *databitsp = 8;
+      break;
+  }
+
+  switch (config.stop_bits)
+  {
+    case ONE_HALF_STOP_BIT:
+      *stopbitsp = PLATFORM_UART_STOPBITS_1_5;
+      break;
+    case TWO_STOP_BIT:
+      *stopbitsp = PLATFORM_UART_STOPBITS_2;
+      break;
+    default:
+      *stopbitsp = PLATFORM_UART_STOPBITS_1;
+      break;
+  }
+
+  if (config.exist_parity == STICK_PARITY_DIS) {
+    *parityp = PLATFORM_UART_PARITY_NONE;
+  } else if (config.parity == EVEN_BITS) {
+    *parityp = PLATFORM_UART_PARITY_EVEN;
+  } else {
+    *parityp = PLATFORM_UART_PARITY_ODD;
+  }
 }
 
 // if set=1, then alternate serial output pins are used. (15=rx, 13=tx)

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -161,6 +161,7 @@ int platform_s_uart_recv( unsigned id, timer_data_type timeout );
 int platform_uart_set_flow_control( unsigned id, int type );
 int platform_s_uart_set_flow_control( unsigned id, int type );
 void platform_uart_alt( int set );
+int platform_uart_get_baudrate(unsigned id);
 
 // *****************************************************************************
 // PWM subsection

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -7,6 +7,7 @@
 
 #include "c_types.h"
 #include "driver/pwm.h"
+#include "driver/uart.h"
 #include "task/task.h"
 
 // Error / status codes
@@ -161,7 +162,7 @@ int platform_s_uart_recv( unsigned id, timer_data_type timeout );
 int platform_uart_set_flow_control( unsigned id, int type );
 int platform_s_uart_set_flow_control( unsigned id, int type );
 void platform_uart_alt( int set );
-int platform_uart_get_baudrate(unsigned id);
+void platform_uart_get_config(unsigned id, uint32_t *baudp, uint32_t *databitsp, uint32_t *parityp, uint32_t *stopbitsp);
 
 // *****************************************************************************
 // PWM subsection

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -67,10 +67,11 @@ end, 0)
 
 ## uart.setup()
 
-(Re-)configures the communication parameters of the UART.
+(Re-)configures the communication parameters of the UART. If only the id parameter is passed, then the currently configured baud rate is returned.
 
 #### Syntax
 `uart.setup(id, baud, databits, parity, stopbits, echo)`
+`uart.setup(id)`
 
 #### Parameters
 - `id` always zero, only one uart supported

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -110,7 +110,10 @@ Four values as follows:
 #### Example
 ```lua
 print (uart.check(0))
+-- prints 9600 8 0 1   for 9600, 8N1
 ```
+
+
 
 ## uart.write()
 

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -89,12 +89,12 @@ configured baud rate (number)
 uart.setup(0, 9600, 8, uart.PARITY_NONE, uart.STOPBITS_1, 1)
 ```
 
-## uart.check()
+## uart.getconfig()
 
 Returns the current configuration parameters of the UART. 
 
 #### Syntax
-`uart.check(id)`
+`uart.getconfig(id)`
 
 #### Parameters
 - `id` always zero, only one uart supported
@@ -109,7 +109,7 @@ Four values as follows:
 
 #### Example
 ```lua
-print (uart.check(0))
+print (uart.getconfig(0))
 -- prints 9600 8 0 1   for 9600, 8N1
 ```
 

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -67,11 +67,10 @@ end, 0)
 
 ## uart.setup()
 
-(Re-)configures the communication parameters of the UART. If only the id parameter is passed, then the currently configured baud rate is returned.
+(Re-)configures the communication parameters of the UART. 
 
 #### Syntax
 `uart.setup(id, baud, databits, parity, stopbits, echo)`
-`uart.setup(id)`
 
 #### Parameters
 - `id` always zero, only one uart supported
@@ -88,6 +87,29 @@ configured baud rate (number)
 ```lua
 -- configure for 9600, 8N1, with echo
 uart.setup(0, 9600, 8, uart.PARITY_NONE, uart.STOPBITS_1, 1)
+```
+
+## uart.check()
+
+Returns the current configuration parameters of the UART. 
+
+#### Syntax
+`uart.check(id)`
+
+#### Parameters
+- `id` always zero, only one uart supported
+
+#### Returns
+Four values as follows:
+
+- `baud` one of 300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 256000, 460800, 921600, 1843200, 3686400
+- `databits` one of 5, 6, 7, 8
+- `parity` `uart.PARITY_NONE`, `uart.PARITY_ODD`, or `uart.PARITY_EVEN`
+- `stopbits` `uart.STOPBITS_1`, `uart.STOPBITS_1_5`, or `uart.STOPBITS_2`
+
+#### Example
+```lua
+print (uart.check(0))
 ```
 
 ## uart.write()


### PR DESCRIPTION
Fixes #1655.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This adds the `uart.check(0)` to return the current settings of the UART0. It actually reads from the registers (in the driver) to do this, so it will always return the right data. The only caveat is that the setting interface only allows setting one of the specified baud rates. Any other value is set to 9600. In order to make the developer experience better, the `uart.check` code adjusts the actual baud rate to the closest permitted value. This is needed as the autobaud code can pick some pretty funny rates that are really close to the nominal rate. 

