### PR TITLE
rtctime.dsleep() current draw improvements

### DIFF
--- a/app/include/rtc/rtcaccess.h
+++ b/app/include/rtc/rtcaccess.h
@@ -54,4 +54,17 @@ static inline uint32_t rtc_reg_read(uint32_t addr)
   rtc_memw();
   return *((volatile uint32_t*)addr);
 }
+
+static inline void rtc_reg_write_and_loop(uint32_t addr, uint32_t val)
+{
+  addr+=RTC_MMIO_BASE;
+  rtc_memw();
+  asm("j 1f\n"
+      ".align 32\n"
+      "1:\n"
+      "s32i.n %1,%0,0\n"
+      "2:\n"
+      "j 2b\n"::"r"(addr),"r"(val):);
+}
+
 #endif

--- a/app/include/rtc/rtctime_internal.h
+++ b/app/include/rtc/rtctime_internal.h
@@ -396,10 +396,10 @@ static inline void rtc_time_add_sleep_tracking(uint32_t us, uint32_t cycles)
   }
 }
 
+extern void rtc_time_enter_deep_sleep_final(void);
+
 static void rtc_time_enter_deep_sleep_us(uint32_t us)
 {
-  ets_intr_lock();
-
   if (rtc_time_check_wake_magic())
     rtc_time_set_sleep_magic();
 
@@ -439,8 +439,7 @@ static void rtc_time_enter_deep_sleep_us(uint32_t us)
   rtc_reg_write(0x44,32);
   rtc_reg_write(0x10,0);
 
-  rtc_reg_write(0x18,8);
-  rtc_reg_write_and_loop(0x08,0x00100000); //  go to sleep
+  rtc_time_enter_deep_sleep_final();
 }
 
 static inline void rtc_time_deep_sleep_us(uint32_t us)

--- a/app/include/rtc/rtctime_internal.h
+++ b/app/include/rtc/rtctime_internal.h
@@ -432,14 +432,15 @@ static void rtc_time_enter_deep_sleep_us(uint32_t us)
   rtc_reg_write(0x9c,17);
   rtc_reg_write(0xa0,3);
 
-  // Clear bit 0 of DPORT 0x04. Doesn't seem to be necessary
-  // wm(0x3fff0004,bitrm(0x3fff0004),0xfffffffe));
+  volatile uint32_t* dport4=(volatile uint32_t*)0x3ff00004;
+  *dport4&=0xfffffffe;
+
   rtc_reg_write(0x40,-1);
   rtc_reg_write(0x44,32);
   rtc_reg_write(0x10,0);
 
   rtc_reg_write(0x18,8);
-  rtc_reg_write(0x08,0x00100000); //  go to sleep
+  rtc_reg_write_and_loop(0x08,0x00100000); //  go to sleep
 }
 
 static inline void rtc_time_deep_sleep_us(uint32_t us)

--- a/app/include/rtc/rtctime_internal.h
+++ b/app/include/rtc/rtctime_internal.h
@@ -398,6 +398,8 @@ static inline void rtc_time_add_sleep_tracking(uint32_t us, uint32_t cycles)
 
 static void rtc_time_enter_deep_sleep_us(uint32_t us)
 {
+  ets_intr_lock();
+
   if (rtc_time_check_wake_magic())
     rtc_time_set_sleep_magic();
 

--- a/app/modules/rtctime.c
+++ b/app/modules/rtctime.c
@@ -35,6 +35,14 @@ static int __isleap (int year) {
 }
 
 // ******* C API functions *************
+void __attribute__((noreturn)) TEXT_SECTION_ATTR rtc_time_enter_deep_sleep_final (void)
+{
+  ets_intr_lock();
+  Cache_Read_Disable();
+  rtc_reg_write(0x18,8);
+  rtc_reg_write_and_loop(0x08,0x00100000); //  go to sleep
+  __builtin_unreachable();
+}
 
 void rtctime_early_startup (void)
 {


### PR DESCRIPTION
Fixes some aspects of #1625.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution. **I haven't, but others have; see referenced issue for discussion**
- [ ] The code changes are reflected in the documentation at `docs/en/*`. **n/a**
