### PR TITLE
BME280: improved reliability and efficiency

### DIFF
--- a/app/modules/bme280.c
+++ b/app/modules/bme280.c
@@ -23,14 +23,14 @@
 #define BME280_REGISTER_VERSION               (0xD1)
 #define BME280_REGISTER_SOFTRESET             (0xE0)
 #define BME280_REGISTER_CAL26                 (0xE1)
-#define BME280_REGISTER_TEMP                  (0xFA)
-#define BME280_REGISTER_PRESS                 (0xF7)
-#define BME280_REGISTER_HUM                   (0xFD)
+#define BME280_REGISTER_PRESS                 (0xF7)	// 0xF7-0xF9
+#define BME280_REGISTER_TEMP                  (0xFA)	// 0xFA-0xFC
+#define BME280_REGISTER_HUM                   (0xFD)	// 0xFD-0xFE
 
-#define BME280_REGISTER_DIG_T                 (0x88)
-#define BME280_REGISTER_DIG_P                 (0x8E)
-#define BME280_REGISTER_DIG_H1                (0xA1)
-#define BME280_REGISTER_DIG_H2                (0xE1)
+#define BME280_REGISTER_DIG_T                 (0x88)	// 0x88-0x8D ( 6)
+#define BME280_REGISTER_DIG_P                 (0x8E)	// 0x8E-0x9F (18)
+#define BME280_REGISTER_DIG_H1                (0xA1)	// 0xA1      ( 1)
+#define BME280_REGISTER_DIG_H2                (0xE1)	// 0xE1-0xE7 ( 7)
 /****************************************************/
 /**\name	I2C ADDRESS DEFINITIONS  */
 /***************************************************/
@@ -53,7 +53,7 @@
 #define BME280_OVERSAMP_8X                    (0x04)
 #define BME280_OVERSAMP_16X                   (0x05)
 /****************************************************/
-/**\name	STANDBY DEFINITIONS  */
+/**\name	STANDBY TIME DEFINITIONS  */
 /***************************************************/
 #define BME280_STANDBY_TIME_1_MS              (0x00)
 #define BME280_STANDBY_TIME_63_MS             (0x01)
@@ -80,12 +80,12 @@
 
 #define BME280_SAMPLING_DELAY  113 //maximum measurement time in ms for maximum oversampling for all measures = 1.25 + 2.3*16 + 2.3*16 + 0.575 + 2.3*16 + 0.575 ms
 
-#define r16s(reg)  ((int16_t)r16u(reg))
-#define r16sLE(reg)  ((int16_t)r16uLE(reg))
+// #define r16s(reg)  ((int16_t)r16u(reg))
+// #define r16sLE(reg)  ((int16_t)r16uLE(reg))
 
-#define bme280_adc_T(void) r24u(BME280_REGISTER_TEMP)
-#define bme280_adc_P(void) r24u(BME280_REGISTER_PRESS)
-#define bme280_adc_H(void) r16u(BME280_REGISTER_HUM)
+// #define bme280_adc_P(void) r24u(BME280_REGISTER_PRESS)
+// #define bme280_adc_T(void) r24u(BME280_REGISTER_TEMP)
+// #define bme280_adc_H(void) r16u(BME280_REGISTER_HUM)
 
 static const uint32_t bme280_i2c_id = 0;
 
@@ -119,21 +119,25 @@ static struct {
 
 static BME280_S32_t bme280_t_fine;
 static uint32_t bme280_h = 0;
-static double bme280_hc = 0.0;
+static double bme280_hc = 1.0;
 
-static uint8_t r8u(uint8_t reg) {
-	uint8_t ret;
+// return 0 if good
+static int r8u_n(uint8_t reg, int n, uint8_t *buf) {
+	int i;
 
 	platform_i2c_send_start(bme280_i2c_id);
 	platform_i2c_send_address(bme280_i2c_id, bme280_i2c_addr, PLATFORM_I2C_DIRECTION_TRANSMITTER);
 	platform_i2c_send_byte(bme280_i2c_id, reg);
-	platform_i2c_send_stop(bme280_i2c_id);
+//	platform_i2c_send_stop(bme280_i2c_id);	// doco says not needed
+
 	platform_i2c_send_start(bme280_i2c_id);
 	platform_i2c_send_address(bme280_i2c_id, bme280_i2c_addr, PLATFORM_I2C_DIRECTION_RECEIVER);
-	ret = platform_i2c_recv_byte(bme280_i2c_id, 0);
+
+	while (n-- > 0)
+		*buf++ = platform_i2c_recv_byte(bme280_i2c_id, n > 0);
 	platform_i2c_send_stop(bme280_i2c_id);
-	//NODE_DBG("reg:%x, value:%x \n", reg, ret);
-	return ret;
+
+	return 0;
 }
 
 static uint8_t w8u(uint8_t reg, uint8_t val) {
@@ -144,23 +148,10 @@ static uint8_t w8u(uint8_t reg, uint8_t val) {
 	platform_i2c_send_stop(bme280_i2c_id);
 }
 
-static uint16_t r16u(uint8_t reg) {
-	uint8_t high = r8u(reg);
-	uint8_t low  = r8u(++reg);
-	return (high << 8) | low;
-}
-
-static uint16_t r16uLE(uint8_t reg) {
-	uint8_t low = r8u(reg);
-	uint8_t high  = r8u(++reg);
-	return (high << 8) | low;
-}
-
-static uint32_t r24u(uint8_t reg) {
-	uint8_t high = r8u(reg);
-	uint8_t mid  = r8u(++reg);
-	uint8_t low  = r8u(++reg);
-	return (uint32_t)(((high << 16) | (mid << 8) | low) >> 4);
+static uint8_t r8u(uint8_t reg) {
+	uint8_t ret[1];
+	r8u_n(reg, 1, ret);
+	return ret[0];
 }
 
 // Returns temperature in DegC, resolution is 0.01 DegC. Output value of “5123” equals 51.23 DegC.  
@@ -214,11 +205,34 @@ static BME280_U32_t bme280_compensate_H(BME280_S32_t adc_H) {
 	return (BME280_U32_t)((v_x1_u32r * 1000)>>10); 
 } 
 
+static double ln(double x) {
+	double y = (x-1)/(x+1);
+	double y2 = y*y;
+	double r = 0;
+	for (int8_t i=33; i>0; i-=2) { //we've got the power
+		r = 1.0/(double)i + y2 * r;
+	}
+	return 2*y*r;
+}
+
+static double bme280_qfe2qnh(int32_t qfe, int32_t h) {
+	double hc;
+	if (bme280_h == h) {
+		hc = bme280_hc;
+	} else {
+		hc = pow((double)(1.0 - 2.25577e-5 * h), (double)(-5.25588));
+		bme280_hc = hc; bme280_h = h;
+	}
+	double qnh = (double)qfe * hc;
+	return qnh;
+}
+
 static int bme280_lua_init(lua_State* L) {
 	uint8_t sda;
 	uint8_t scl;
 	uint8_t config;
 	uint8_t ack;
+	uint8_t full_init;
 	
 	uint8_t const bit3 = 0b111;
 	uint8_t const bit2 = 0b11;
@@ -237,6 +251,7 @@ static int bme280_lua_init(lua_State* L) {
 	
 	config = ((!lua_isnumber(L, 7)?BME280_STANDBY_TIME_20_MS:(luaL_checkinteger(L, 7)&bit3))<< 4) // 7-th parameter: inactive duration in normal mode
 		| ((!lua_isnumber(L, 8)?BME280_FILTER_COEFF_16:(luaL_checkinteger(L, 8)&bit3)) << 1); // 8-th parameter: IIR filter
+	full_init = !lua_isnumber(L, 9)?1:lua_tointeger(L, 9); // 9-th parameter: init the chip too
 	NODE_DBG("mode: %x\nhumidity oss: %x\nconfig: %x\n", bme280_mode, bme280_ossh, config);
 	
 	platform_i2c_setup(bme280_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
@@ -261,42 +276,50 @@ static int bme280_lua_init(lua_State* L) {
 	NODE_DBG("chip_id: %x\n", chipid);
 	bme280_isbme = (chipid == 0x60);
 	
-	uint8_t reg = BME280_REGISTER_DIG_T;
-	bme280_data.dig_T1 = r16uLE(reg); reg+=2;
-	bme280_data.dig_T2 = r16sLE(reg); reg+=2;
-	bme280_data.dig_T3 = r16sLE(reg);
+#define r16uLE_buf(reg)	(uint16_t)((reg[1] << 8) | reg[0])
+#define r16sLE_buf(reg)	 (int16_t)(r16uLE_buf(reg))
+	uint8_t	buf[18], *reg;
+
+	r8u_n(BME280_REGISTER_DIG_T, 6, buf);
+	reg = buf;
+	bme280_data.dig_T1 = r16uLE_buf(reg); reg+=2;
+	bme280_data.dig_T2 = r16sLE_buf(reg); reg+=2;
+	bme280_data.dig_T3 = r16sLE_buf(reg);
 	//NODE_DBG("dig_T: %d\t%d\t%d\n", bme280_data.dig_T1, bme280_data.dig_T2, bme280_data.dig_T3);
 
-	reg = BME280_REGISTER_DIG_P;
-	bme280_data.dig_P1 = r16uLE(reg); reg+=2;
-	bme280_data.dig_P2 = r16sLE(reg); reg+=2;
-	bme280_data.dig_P3 = r16sLE(reg); reg+=2;
-	bme280_data.dig_P4 = r16sLE(reg); reg+=2;
-	bme280_data.dig_P5 = r16sLE(reg); reg+=2;
-	bme280_data.dig_P6 = r16sLE(reg); reg+=2;
-	bme280_data.dig_P7 = r16sLE(reg); reg+=2;
-	bme280_data.dig_P8 = r16sLE(reg); reg+=2;
-	bme280_data.dig_P9 = r16sLE(reg);
+	r8u_n(BME280_REGISTER_DIG_P, 18, buf);
+	reg = buf;
+	bme280_data.dig_P1 = r16uLE_buf(reg); reg+=2;
+	bme280_data.dig_P2 = r16sLE_buf(reg); reg+=2;
+	bme280_data.dig_P3 = r16sLE_buf(reg); reg+=2;
+	bme280_data.dig_P4 = r16sLE_buf(reg); reg+=2;
+	bme280_data.dig_P5 = r16sLE_buf(reg); reg+=2;
+	bme280_data.dig_P6 = r16sLE_buf(reg); reg+=2;
+	bme280_data.dig_P7 = r16sLE_buf(reg); reg+=2;
+	bme280_data.dig_P8 = r16sLE_buf(reg); reg+=2;
+	bme280_data.dig_P9 = r16sLE_buf(reg);
 	// NODE_DBG("dig_P: %d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n", bme280_data.dig_P1, bme280_data.dig_P2, bme280_data.dig_P3, bme280_data.dig_P4, bme280_data.dig_P5, bme280_data.dig_P6, bme280_data.dig_P7, bme280_data.dig_P8, bme280_data.dig_P9);
 	
-	w8u(BME280_REGISTER_CONFIG, config);
+	if (full_init) w8u(BME280_REGISTER_CONFIG, config);
 	if (bme280_isbme) {
-		reg = BME280_REGISTER_DIG_H1;
-		bme280_data.dig_H1 = r8u(reg);
-		reg = BME280_REGISTER_DIG_H2;
-		bme280_data.dig_H2 = r16sLE(reg); reg+=2;
-		bme280_data.dig_H3 = r8u(reg); reg++;
-		bme280_data.dig_H4 = ((int16_t)r8u(reg) << 4 | (r8u(reg+1) & 0xF)); reg++;
-		bme280_data.dig_H5 = ((int16_t)r8u(reg+1) << 4 | (r8u(reg) >> 4)); reg+=2;
-		bme280_data.dig_H6 = (int8_t)r8u(reg);
+		bme280_data.dig_H1 = r8u(BME280_REGISTER_DIG_H1);
+		r8u_n(BME280_REGISTER_DIG_H2, 7, buf);
+		reg = buf;
+		bme280_data.dig_H2 = r16sLE_buf(reg); reg+=2;
+		bme280_data.dig_H3 = reg[0]; reg++;
+		bme280_data.dig_H4 = (int16_t)reg[0] << 4 | (reg[1] & 0x0F); reg+=1;	// H4[11:4 3:0] = 0xE4[7:0] 0xE5[3:0] 12-bit signed
+		bme280_data.dig_H5 = (int16_t)reg[1] << 4 | (reg[0]   >> 4); reg+=2;	// H5[11:4 3:0] = 0xE6[7:0] 0xE5[7:4] 12-bit signed
+		bme280_data.dig_H6 = (int8_t)reg[0];
 		// NODE_DBG("dig_H: %d\t%d\t%d\t%d\t%d\t%d\n", bme280_data.dig_H1, bme280_data.dig_H2, bme280_data.dig_H3, bme280_data.dig_H4, bme280_data.dig_H5, bme280_data.dig_H6);
 
-		w8u(BME280_REGISTER_CONTROL_HUM, bme280_ossh);
+		if (full_init) w8u(BME280_REGISTER_CONTROL_HUM, bme280_ossh);
 		lua_pushinteger(L, 2);
 	} else {
 		lua_pushinteger(L, 1);
 	}
-	w8u(BME280_REGISTER_CONTROL, bme280_mode);
+#undef r16uLE_buf
+#undef r16sLE_buf
+	if (full_init) w8u(BME280_REGISTER_CONTROL, bme280_mode);
 	
 	return 1;
 }
@@ -339,8 +362,50 @@ static int bme280_lua_startreadout(lua_State* L) {
 	return 0;
 }
 
+// Return nothing on failure
+// Return T, QFE, H if no altitude given
+// Return T, QFE, H, QNH if altitude given
+static int bme280_lua_read(lua_State* L) {
+	uint8_t buf[8];
+	uint32_t qfe;
+	uint8_t calc_qnh = lua_isnumber(L, 1);
+
+	r8u_n(BME280_REGISTER_PRESS, 8, buf);	// registers are P[3], T[3], H[2]
+
+	// Must do Temp first since bme280_t_fine is used by the other compensation functions
+	uint32_t adc_T = (uint32_t)(((buf[3] << 16) | (buf[4] << 8) | buf[5]) >> 4);
+	if (adc_T == 0x80000 || adc_T == 0xfffff)
+		return 0;
+	lua_pushinteger(L, bme280_compensate_T(adc_T));
+
+	uint32_t adc_P = (uint32_t)(((buf[0] << 16) | (buf[1] << 8) | buf[2]) >> 4);
+	if (adc_P ==0x80000 || adc_P == 0xfffff) {
+		lua_pushnil(L);
+		calc_qnh = 0;
+	} else {
+		qfe = bme280_compensate_P(adc_P);
+		lua_pushinteger(L, qfe);
+	}
+
+	uint32_t adc_H = (uint32_t)((buf[6] << 8) | buf[7]);
+	if (!bme280_isbme || adc_H == 0x8000 || adc_H == 0xffff)
+		lua_pushnil(L);
+	else
+		lua_pushinteger(L, bme280_compensate_H(adc_H));
+
+	if (calc_qnh) { // have altitude
+		int32_t h = luaL_checkinteger(L, 1);
+		double qnh = bme280_qfe2qnh(qfe, h);
+		lua_pushinteger(L, (int32_t)(qnh + 0.5));
+		return 4;
+	}
+	return 3;
+}
+
 static int bme280_lua_temp(lua_State* L) {
-	uint32_t adc_T = bme280_adc_T();
+	uint8_t buf[3];
+	r8u_n(BME280_REGISTER_TEMP, 3, buf); // registers are P[3], T[3], H[2]
+	uint32_t adc_T = (uint32_t)(((buf[0] << 16) | (buf[1] << 8) | buf[2]) >> 4);
 	if (adc_T == 0x80000 || adc_T == 0xfffff)
 		return 0;
 	lua_pushinteger(L, bme280_compensate_T(adc_T));
@@ -349,9 +414,11 @@ static int bme280_lua_temp(lua_State* L) {
 }
 
 static int bme280_lua_baro(lua_State* L) {
-	uint32_t adc_T = bme280_adc_T();
+	uint8_t buf[6];
+	r8u_n(BME280_REGISTER_PRESS, 6, buf); // registers are P[3], T[3], H[2]
+	uint32_t adc_T = (uint32_t)(((buf[3] << 16) | (buf[4] << 8) | buf[5]) >> 4);
 	uint32_t T = bme280_compensate_T(adc_T);
-	uint32_t adc_P = bme280_adc_P();
+	uint32_t adc_P = (uint32_t)(((buf[0] << 16) | (buf[1] << 8) | buf[2]) >> 4);
 	if (adc_T == 0x80000 || adc_T == 0xfffff || adc_P ==0x80000 || adc_P == 0xfffff)
 		return 0;
 	lua_pushinteger(L, bme280_compensate_P(adc_P));
@@ -361,9 +428,12 @@ static int bme280_lua_baro(lua_State* L) {
 
 static int bme280_lua_humi(lua_State* L) {
 	if (!bme280_isbme) return 0;
-	uint32_t adc_T = bme280_adc_T();
+	uint8_t buf[5];
+	r8u_n(BME280_REGISTER_TEMP, 5, buf); // registers are P[3], T[3], H[2]
+
+	uint32_t adc_T = (uint32_t)(((buf[0] << 16) | (buf[1] << 8) | buf[2]) >> 4);
 	uint32_t T = bme280_compensate_T(adc_T);
-	uint32_t adc_H = bme280_adc_H();
+	uint32_t adc_H = (uint32_t)((buf[3] << 8) | buf[4]);
 	if (adc_T == 0x80000 || adc_T == 0xfffff || adc_H == 0x8000 || adc_H == 0xffff)
 		return 0;
 	lua_pushinteger(L, bme280_compensate_H(adc_H));
@@ -377,15 +447,7 @@ static int bme280_lua_qfe2qnh(lua_State* L) {
 	}
 	int32_t qfe = luaL_checkinteger(L, 1);
 	int32_t h = luaL_checkinteger(L, 2);
-	
-	double hc;
-	if (bme280_h == h) {
-		hc = bme280_hc;
-	} else {
-		hc = pow((double)(1.0 - 2.25577e-5 * h), (double)(-5.25588));
-		bme280_hc = hc; bme280_h = h;
-	}
-	double qnh = (double)qfe * hc;
+	double qnh = bme280_qfe2qnh(qfe, h);
 	lua_pushinteger(L, (int32_t)(qnh + 0.5));
 	return 1;
 }
@@ -396,33 +458,24 @@ static int bme280_lua_altitude(lua_State* L) {
 	}
 	int32_t P = luaL_checkinteger(L, 1);
 	int32_t qnh = luaL_checkinteger(L, 2);
-
 	double h = (1.0 - pow((double)P/(double)qnh, 1.0/5.25588)) / 2.25577e-5 * 100.0;
+
 	lua_pushinteger(L, (int32_t)(h + (((h<0)?-1:(h>0)) * 0.5)));
 	return 1;
 }
 
-static double ln(double x) {
-	double y = (x-1)/(x+1);
-	double y2 = y*y;
-	double r = 0;
-	for (int8_t i=33; i>0; i-=2) { //we've got the power
-		r = 1.0/(double)i + y2 * r;
-	}
-	return 2*y*r;
-}
-
 static int bme280_lua_dewpoint(lua_State* L) {
-	const double c243 = 243.5;
-	const double c17 = 17.67;
 	if (!lua_isnumber(L, 2)) {
 		return luaL_error(L, "wrong arg range");
 	}
 	double H = luaL_checkinteger(L, 1)/100000.0;
 	double T = luaL_checkinteger(L, 2)/100.0;
 
+	const double c243 = 243.5;
+	const double c17 = 17.67;
 	double c = ln(H) + ((c17 * T) / (c243 + T));
 	double d = (c243 * c)/(c17 - c) * 100.0;
+
 	lua_pushinteger(L, (int32_t)(d + (((d<0)?-1:(d>0)) * 0.5)));
 	return 1;
 }
@@ -436,6 +489,7 @@ static const LUA_REG_TYPE bme280_map[] = {
 	{ LSTRKEY( "qfe2qnh" ),  LFUNCVAL(bme280_lua_qfe2qnh)},
 	{ LSTRKEY( "altitude" ),  LFUNCVAL(bme280_lua_altitude)},
 	{ LSTRKEY( "dewpoint" ),  LFUNCVAL(bme280_lua_dewpoint)},
+	{ LSTRKEY( "read" ),  LFUNCVAL(bme280_lua_read)},
 	{ LNILKEY, LNILVAL}
 };
 

--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -82,6 +82,7 @@ Initializes module. Initialization is mandatory before read values.
 - (optional) `sensor_mode` - Controls the sensor mode of the device. Default sensor more is normal.
 - (optional) `inactive_duration` - Controls inactive duration in normal mode. Default inactive duration is 20ms.
 - (optional) `IIR_filter` - Controls the time constant of the IIR filter. Default fitler coefficient is 16.
+- (optional) `cold_start` - If 0 then the BME280 chip is not initialised. Usefull in a battery operated setup when the ESP deep sleeps and on wakeup needs to initialise the driver (the module) but not the chip itself. The chip was kept powered (sleeping too) and is holding the latest reading that should be fetched quickly before another reading starts (`bme280.startreadout()`). By default the chip is initialised.
 
 |`temp_oss`, `press_oss`, `humi_oss`|Data oversampling|
 |-----|-----------------|
@@ -146,13 +147,34 @@ P = bme280.baro()
 curAlt = bme280.altitude(P, QNH)
 print(string.format("altitude=%d.%02d", curAlt/100, curAlt%100))
 ```
+
+Or simpler and more efficient
+```lua
+alt=320 -- altitude of the measurement place
+
+bme280.init(3, 4)
+
+T, P, H, QNH = bme280.read(alt)
+print(string.format("T=%d.%02d", T/100, T%100))
+print(string.format("QFE=%d.%03d", P/1000, P%1000))
+print(string.format("QNH=%d.%03d", QNH/1000, QNH%1000))
+print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
+D = bme280.dewpoint(H, T)
+print(string.format("dew_point=%d.%02d", D/100, D%100))
+
+-- altimeter function - calculate altitude based on current sea level pressure (QNH) and measure pressure
+P = bme280.baro()
+curAlt = bme280.altitude(P, QNH)
+print(string.format("altitude=%d.%02d", curAlt/100, curAlt%100))
+```
+
 Use `bme280.init(sda, scl, 1, 3, 0, 3, 0, 4)` for "game mode" - Oversampling settings  pressure ×4, temperature ×1, humidity ×0, sensor mode: normal mode, inactive duration  = 0.5 ms, IIR filter settings  filter coefficient 16.
 
 Example of readout in forced mode (asynchronous)
 ```lua
 bme280.init(3, 4, nil, nil, nil, 0) -- initialize to sleep mode
 bme280.startreadout(0, function ()
-  T = bme280.temp()
+  T, P = bme280.read()
   print(string.format("T=%d.%02d", T/100, T%100))
 end)
 ```
@@ -170,6 +192,24 @@ For given altitude converts the air pressure to sea level air pressure.
 
 #### Returns  
 sea level pressure
+
+
+## bme280.read()
+
+Reads the sensor and returns the temperature, the air pressure, the air relative humidity and 
+
+#### Syntax
+`bme280.read([altitude])`
+
+#### Parameters
+- (optional) `altitude`- altitude in meters of measurement point. If provided also the air pressure converted to sea level air pressure is returned.
+
+#### Returns  
+- `T` temperature in celsius as an integer multiplied with 100
+- `P` air pressure in hectopascals multiplied by 1000
+- `H` relative humidity in percent multiplied by 1000
+- `QNH` air pressure in hectopascals multiplied by 1000 converted to sea level
+Any of these variables is `nil` if the readout of given measure was not successful.
 
 ## bme280.startreadout()
 Starts readout (turns the sensor into forced mode). After the readout the sensor turns to sleep mode.


### PR DESCRIPTION
Fixes https://github.com/nodemcu/nodemcu-firmware/issues/1631 and https://github.com/nodemcu/nodemcu-firmware/issues/1632.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This PR improves reliability of the measurement by implementing the I2C burst mode reading as suggested by the [BME280 datasheet](https://cdn-shop.adafruit.com/datasheets/BST-BME280_DS001-10.pdf) discussed here https://github.com/nodemcu/nodemcu-firmware/pull/1652 and here https://github.com/nodemcu/nodemcu-firmware/issues/1632.
>To read out data after a conversion, it is strongly recommended to use a burst read and not
address every register individually. This will prevent a possible mix-up of bytes belonging to
different measurements and reduce interface traffic. Note that in I²C mode, even when pressure
was not measured, reading the unused registers is faster than reading temperature and
humidity data separately.

It speeds up initialization and readouts which should improve the endurance when run on batteries.

It also implements the `cold_start` parameter to `init()` method as suggested in https://github.com/nodemcu/nodemcu-firmware/issues/1631.

New method `read()` is implemented (and documented) which allows to read all measured parameters at once.

It is based on the modifications proposed of @eyaleb.
