### PR TITLE
Fix crash in sntp and add more reliable defaults servers

### DIFF
--- a/app/modules/sntp.c
+++ b/app/modules/sntp.c
@@ -200,7 +200,7 @@ static ip_addr_t* get_free_server() {
 static void handle_error (lua_State *L, ntp_err_t err, const char *msg)
 {
   sntp_dbg("sntp: handle_error\n");
-  if (state->err_cb_ref != LUA_NOREF)
+  if (state->err_cb_ref != LUA_NOREF && state->err_cb_ref != LUA_REFNIL)
   {
     lua_rawgeti (L, LUA_REGISTRYINDEX, state->err_cb_ref);
     lua_pushinteger (L, err);
@@ -229,7 +229,7 @@ static void sntp_handle_result(lua_State *L) {
     return;
   }
 
-  bool have_cb = (state->sync_cb_ref != LUA_NOREF);
+  bool have_cb = (state->sync_cb_ref != LUA_NOREF && state->sync_cb_ref != LUA_REFNIL);
 
   state->last_server_pos = state->best.server_pos;    // Remember for next time
 

--- a/app/modules/sntp.c
+++ b/app/modules/sntp.c
@@ -420,6 +420,11 @@ static void update_offset()
       next_midnight = get_next_midnight(tv.tv_sec);
       // is this the first day of the month
       // Number of days since 1/mar/0000
+      // 1970 * 365 is the number of days in full years
+      // 1970 / 4 is the number of leap days (ignoring century rules)
+      // 19 is the number of centuries
+      // 4 is the number of 400 years (where there was a leap day)
+      // 31 & 28 are the number of days in Jan 1970 and Feb 1970
       int day = (tv.tv_sec - the_offset) / 86400 + 1970 * 365 + 1970 / 4 - 19 + 4 - 31 - 28;
 
       int century = (4 * day + 3) / 146097;
@@ -429,6 +434,7 @@ static void update_offset()
       int month = (5 * day + 2) / 153;
       day = day - (153 * month + 2) / 5;
 
+      // Months 13 & 14 are really Jan and Feb in the following year.
       sntp_dbg("century=%d, year=%d, month=%d, day=%d\n", century, year, month + 3, day + 1);
 
       if (day == 0) {

--- a/docs/en/modules/sntp.md
+++ b/docs/en/modules/sntp.md
@@ -4,6 +4,7 @@
 | 2015-06-30 | [DiUS](https://github.com/DiUS), [Johny Mattsson](https://github.com/jmattsson) | [Johny Mattsson](https://github.com/jmattsson) | [sntp.c](../../../app/modules/sntp.c)|
 
 The SNTP module implements a [Simple Network Time Procotol](https://en.wikipedia.org/wiki/Network_Time_Protocol#SNTP) client. This includes support for the "anycast" [NTP](https://en.wikipedia.org/wiki/Network_Time_Protocol) mode where, if supported by the NTP server(s) in your network, it is not necessary to even know the IP address of the NTP server.
+By default, this will use the servers 0.nodemcu.pool.ntp.org through 3.nodemcu.pool.ntp.org. These servers will be adequate for nearly all usages.
 
 When compiled together with the [rtctime](rtctime.md) module it also offers seamless integration with it, potentially reducing the process of obtaining NTP synchronization to a simple `sntp.sync()` call without any arguments.
 
@@ -20,7 +21,7 @@ Note that either a single server can be provided as an argument (name or address
 `sntp.sync({ server1, server2, .. }, [callback], [errcallback], [autorepeat])`
 
 #### Parameters
-- `server_ip` if non-`nil`, that server is used. If `nil`, then the last contacted server is used. This ties in with the NTP anycast mode, where the first responding server is remembered for future synchronization requests. The easiest way to use anycast is to always pass nil for the server argument.
+- `server_ip` if non-`nil`, that server is used. If `nil`, then the last contacted server is used. If there is no previous server, then the pool ntp servers are used. If the anycast server was used, then the first responding server will be saved. 
 - `server1`, `server2` these are either the ip address or dns name of one or more servers to try.
 - `callback` if provided it will be invoked on a successful synchronization, with four parameters: seconds, microseconds, server and info. Note that when the [rtctime](rtctime.md) module is available, there is no need to explicitly call [`rtctime.set()`](rtctime.md#rtctimeset) - this module takes care of doing so internally automatically, for best accuracy. The info parameter is a table of (semi) interesting values. These are described below.
 - `errcallback` failure callback with two parameters. The first is an integer describing the type of error. The module automatically performs a number of retries before giving up and reporting the error. The second is a string containing supplementary information (if any). Error codes:
@@ -44,12 +45,12 @@ This is passed to the success callback and contains useful information about the
 
 #### Example
 ```lua
--- Best effort, use the last known NTP server(s) (or the NTP "anycast" address 224.0.1.1 initially)
-sntp.sync()
+-- Use the nodemcu specific pool servers and keep the time synced forever (this has the autorepeat flag set).
+sntp.sync(nil, nil, nil, 1)
 ```
 ```lua
--- Sync time with some servers from the NTP pool and print the result, or that it failed
-sntp.sync({ '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org' },
+-- Single shot sync time with a server on the local network.
+sntp.sync("224.0.1.1",
   function(sec, usec, server, info)
     print('sync', sec, usec, server)
   end,


### PR DESCRIPTION
Fixes #1679.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

The sntp code juts made the assumption that errors could be reported at any time. This was a bad assumption. The changes now make use of the task interface to schedule the error callback.

Other changes:

* Now defaults to using the nodemcu specific servers in the ntp pool (0 - 3 .nodemcu.pool.ntp.org). This makes the simplest configuration work in all (internet connected) cases.
* Fixes a problem in leap second calculation (it got the day offset from 1-mar-0000 wrong)
* Adds support for the KoD packet. This is required to use ntp pool servers.
* Speeds up the uint64 division by 1,000,000 dramatically.
* Gives priority to the previous ntp server chosen - this reduces server switching.

On the subject of division -- this is *really* slow -- especially the 64 bit division (this is what I discovered from the fixed version of the perf code -- this is in the random cleanup PR). Unfortunately there isn't a general mechanism for the compiler to use to convert uint64 division into something fast. (On many platforms, 32 bit division is converted into 64 bit multiplication with a shift afterwards). These constants were found by searching (~12 hours of x86 CPU time). 