### PR TITLE
added 31250 baud rate for MIDI support

### DIFF
--- a/app/include/driver/uart.h
+++ b/app/include/driver/uart.h
@@ -41,6 +41,7 @@ typedef enum {
     BIT_RATE_4800    = 4800,
     BIT_RATE_9600    = 9600,
     BIT_RATE_19200   = 19200,
+    BIT_RATE_31250   = 31250,
     BIT_RATE_38400   = 38400,
     BIT_RATE_57600   = 57600,
     BIT_RATE_74880   = 74880,

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -361,6 +361,7 @@ uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int pari
     case BIT_RATE_4800:
     case BIT_RATE_9600:
     case BIT_RATE_19200:
+    case BIT_RATE_31250:
     case BIT_RATE_38400:
     case BIT_RATE_57600:
     case BIT_RATE_74880:

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -40,6 +40,7 @@ static const int uart_bitrates[] = {
     BIT_RATE_4800,
     BIT_RATE_9600,
     BIT_RATE_19200,
+    BIT_RATE_31250,
     BIT_RATE_38400,
     BIT_RATE_57600,
     BIT_RATE_74880,

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -74,7 +74,7 @@ end, 0)
 
 #### Parameters
 - `id` always zero, only one uart supported
-- `baud` one of 300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 256000, 460800, 921600, 1843200, 3686400
+- `baud` one of 300, 600, 1200, 2400, 4800, 9600, 19200, 31250, 38400, 57600, 74880, 115200, 230400, 256000, 460800, 921600, 1843200, 3686400
 - `databits` one of 5, 6, 7, 8
 - `parity` `uart.PARITY_NONE`, `uart.PARITY_ODD`, or `uart.PARITY_EVEN`
 - `stopbits` `uart.STOPBITS_1`, `uart.STOPBITS_1_5`, or `uart.STOPBITS_2`


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

MIDI works on 31250 baud rate so it makes sense to have this as an option