### PR TITLE
Leave only some parts of SDK in iram

### DIFF
--- a/ld/nodemcu.ld
+++ b/ld/nodemcu.ld
@@ -103,7 +103,11 @@ SECTIONS
     *(.init.literal)
     *(.init)
     
-    *sdk/esp_iot_sdk_*lib/lib*.a:*(.literal .text)
+    *libmain.a:*(.literal .text)
+    *libnet80211.a:*(.literal .text)
+    *libphy.a:*(.literal .text)
+    *libpp.a:*(.literal .text)
+    *libgcc.a:*(.literal .text)
 
     *(.iram.text .iram0.text)
 

--- a/ld/nodemcu.ld
+++ b/ld/nodemcu.ld
@@ -103,11 +103,24 @@ SECTIONS
     *(.init.literal)
     *(.init)
     
+    /* SDK libraries that used in bootup process, interruption handling
+     * and other ways where flash cache (iROM) is unavailable: */
     *libmain.a:*(.literal .text)
     *libnet80211.a:*(.literal .text)
     *libphy.a:*(.literal .text)
     *libpp.a:*(.literal .text)
     *libgcc.a:*(.literal .text)
+    
+    /* Following SDK libraries have .text sections, but not included in iRAM: */
+    /* *libat.a:*(.literal .text) - not used anywhere in NodeMCU */
+    /* *libcrypto.a:*(.literal .text) - tested that safe to keep in iROM */
+    /* *libdriver.a:*(.literal .text) - not used anywhere in NodeMCU */
+    /* *libespnow.a:*(.literal .text) - not used anywhere in NodeMCU */
+    /* *libmesh.a:*(.literal .text) - not used anywhere in NodeMCU */
+    /* *liblwip_536.a:*(.literal .text) - source-based library used instead */
+    /* *libpwm.a:*(.literal .text) - our own implementation used instead */
+    /* *libwpa.a:*(.literal .text) - tested that safe to keep in iROM */
+    /* *libwps.a:*(.literal .text) - tested that safe to keep in iROM */
 
     *(.iram.text .iram0.text)
 


### PR DESCRIPTION
Amendment for #1562/#1566, follow-up #1694 [comment](https://github.com/nodemcu/nodemcu-firmware/pull/1694#issuecomment-270260399).

As we decided, for example, `libwps` is safe to put it into `irom` (although Espressif marked some parts as "iram-forced"). And we cannot fit it into `iram` anyway (because `iram` segment size overflow).

So I bring back my original proposal to keep only some parts of SDK in iram. For now this is `main`, `net80211`, `phy`, `pp` and `gcc` libs (they're used in bootup process, in interrupts, and in other ways where iROM is unavailable). For another parts it is safe to put them in flash and free some instruction RAM.