### PR TITLE
fix typo

### DIFF
--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -307,7 +307,7 @@ int platform_gpio_register_intr_hook(uint32_t bits, platform_hook_function hook)
 #endif // GPIO_INTERRUPT_HOOK_ENABLE
 
 /*
- * Initialise GPIO interrupt mode. Optionally in RAM because interrupts are dsabled
+ * Initialise GPIO interrupt mode. Optionally in RAM because interrupts are disabled
  */
 void NO_INTR_CODE platform_gpio_intr_init( unsigned pin, GPIO_INT_TYPE type )
 {


### PR DESCRIPTION
dsabled -> disabled

Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is for the `dev` branch rather than for `master`.
- [ ] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rational behind this PR\>