### PR TITLE
make user/pass optional in MQTT client doc

### DIFF
--- a/docs/en/modules/mqtt.md
+++ b/docs/en/modules/mqtt.md
@@ -11,7 +11,7 @@ The client adheres to version 3.1.1 of the [MQTT](https://en.wikipedia.org/wiki/
 Creates a MQTT client.
 
 #### Syntax
-`mqtt.Client(clientid, keepalive, username, password[, cleansession])`
+`mqtt.Client(clientid, keepalive[, username, password, cleansession])`
 
 #### Parameters
 - `clientid` client ID
@@ -25,7 +25,10 @@ MQTT client
 
 #### Example
 ```lua
--- init mqtt client with keepalive timer 120sec
+-- init mqtt client without logins, keepalive timer 120s
+m = mqtt.Client("clientid", 120)
+
+-- init mqtt client with logins, keepalive timer 120sec
 m = mqtt.Client("clientid", 120, "user", "password")
 
 -- setup Last Will and Testament (optional)


### PR DESCRIPTION
In the MQTT module documentation, about creating a MQTT client object, the "user" and "password" parameters are presented as mandatory. Having just started to use NodeMCU, I though I had to provide "fake" logins to be compatible with the API, hoping it would be ignored when connecting to a broker with no logins check (unfortunately, providing logins in this case prevent the module from connecting, tested with test.mosquitto.org).
It would be nice to aknowledge that those parameters are not necessary if the broker does not wait for logins.