### PR TITLE
Wifi password of 64 byte length is accepted

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -737,7 +737,7 @@ static int wifi_station_config( lua_State* L )
     memcpy(sta_conf.ssid, ssid, sl);
 
     const char *password = luaL_checklstring( L, 2, &pl );
-    luaL_argcheck(L, (pl==0||(pl>=8 && pl<sizeof(sta_conf.password)) ), 2, "length:0 or 8-64");
+    luaL_argcheck(L, (pl==0||(pl>=8 && pl<=sizeof(sta_conf.password)) ), 2, "length:0 or 8-64");
 
     memcpy(sta_conf.password, password, pl);
 


### PR DESCRIPTION
Fixes #1726 .

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

Allows usage of a 64 character long WiFi password as reported by @neilyoung.
Could not test it though.