### PR TITLE
invert signal on rfswitch pin

### DIFF
--- a/app/modules/rfswitch.c
+++ b/app/modules/rfswitch.c
@@ -63,9 +63,9 @@ static const Protocol proto[] = {
  * Transmit a single high-low pulse.
  */
 void transmit(HighLow pulses, bool invertedSignal, int pulseLength, int pin) {
-  platform_gpio_write(pin, invertedSignal);
-  os_delay_us(pulseLength * pulses.high);
   platform_gpio_write(pin, !invertedSignal);
+  os_delay_us(pulseLength * pulses.high);
+  platform_gpio_write(pin, invertedSignal);
   os_delay_us(pulseLength * pulses.low);
 }
 
@@ -85,7 +85,6 @@ void send(unsigned long protocol_id, unsigned long pulse_length, unsigned long r
         transmit(p.zero, p.invertedSignal, pulse_length, pin);
     }
     transmit(p.syncFactor, p.invertedSignal, pulse_length, pin);
-    platform_gpio_write(pin, false);
   }
 }
 


### PR DESCRIPTION
since that code was migrated from arduino, I should to invert pin

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.
