### PR TITLE
rtctime: change to lua_setfield for populating the table

### DIFF
--- a/app/modules/rtctime.c
+++ b/app/modules/rtctime.c
@@ -180,12 +180,9 @@ static int rtctime_dsleep_aligned (lua_State *L)
 }
 
 
-static void add_table_item (lua_State *L, const char *key, int val)
-{
-  lua_pushstring (L, key);
-  lua_pushinteger (L, val);
-  lua_rawset (L, -3);
-}
+#define ADD_TABLE_ITEM(L, key, val) \
+  lua_pushinteger (L, val);	    \
+  lua_setfield (L, -2, key);
 
 // rtctime.epoch2cal (stamp)
 static int rtctime_epoch2cal (lua_State *L)
@@ -198,14 +195,14 @@ static int rtctime_epoch2cal (lua_State *L)
 
   /* construct Lua table */
   lua_createtable (L, 0, 8);
-  add_table_item (L, "yday", date.tm_yday + 1);
-  add_table_item (L, "wday", date.tm_wday + 1);
-  add_table_item (L, "year", date.tm_year + 1900);
-  add_table_item (L, "mon",  date.tm_mon + 1);
-  add_table_item (L, "day",  date.tm_mday);
-  add_table_item (L, "hour", date.tm_hour);
-  add_table_item (L, "min",  date.tm_min);
-  add_table_item (L, "sec",  date.tm_sec);
+  ADD_TABLE_ITEM (L, "yday", date.tm_yday + 1);
+  ADD_TABLE_ITEM (L, "wday", date.tm_wday + 1);
+  ADD_TABLE_ITEM (L, "year", date.tm_year + 1900);
+  ADD_TABLE_ITEM (L, "mon",  date.tm_mon + 1);
+  ADD_TABLE_ITEM (L, "day",  date.tm_mday);
+  ADD_TABLE_ITEM (L, "hour", date.tm_hour);
+  ADD_TABLE_ITEM (L, "min",  date.tm_min);
+  ADD_TABLE_ITEM (L, "sec",  date.tm_sec);
 
   return 1;
 }


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

Just some clean-up according to the feedback to #1724: use `lua_setfield()` to populate the table.
