### PR TITLE
Add string support for spi.set_mosi() and spi.get_miso()

### DIFF
--- a/app/include/driver/spi.h
+++ b/app/include/driver/spi.h
@@ -8,8 +8,8 @@
 #include "os_type.h"
 
 /*SPI number define*/
-#define SPI 			0
-#define HSPI			1
+#define SPI_SPI 		0
+#define SPI_HSPI		1
 
 #define SPI_ORDER_LSB 0
 #define SPI_ORDER_MSB 1

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -755,6 +755,8 @@ int platform_i2c_recv_byte( unsigned id, int ack ){
 uint32_t platform_spi_setup( uint8_t id, int mode, unsigned cpol, unsigned cpha, uint32_t clock_div )
 {
   spi_master_init( id, cpol, cpha, clock_div );
+  // all platform functions assume LSB order for MOSI & MISO buffer
+  spi_mast_byte_order( id, SPI_ORDER_LSB );
   return 1;
 }
 
@@ -779,8 +781,6 @@ spi_data_type platform_spi_send_recv( uint8_t id, uint8_t bitlen, spi_data_type 
 
 int platform_spi_blkwrite( uint8_t id, size_t len, const uint8_t *data )
 {
-  spi_mast_byte_order( id, SPI_ORDER_LSB );
-
   while (len > 0) {
     size_t chunk_len = len > 64 ? 64 : len;
 
@@ -791,8 +791,6 @@ int platform_spi_blkwrite( uint8_t id, size_t len, const uint8_t *data )
     len -= chunk_len;
   }
 
-  spi_mast_byte_order( id, SPI_ORDER_MSB );
-
   return PLATFORM_OK;
 }
 
@@ -801,8 +799,6 @@ int platform_spi_blkread( uint8_t id, size_t len, uint8_t *data )
   uint8_t mosi_idle[64];
 
   os_memset( (void *)mosi_idle, 0xff, len > 64 ? 64 : len );
-
-  spi_mast_byte_order( id, SPI_ORDER_LSB );
 
   while (len > 0 ) {
     size_t chunk_len = len > 64 ? 64 : len;
@@ -815,27 +811,7 @@ int platform_spi_blkread( uint8_t id, size_t len, uint8_t *data )
     len -= chunk_len;
   }
 
-  spi_mast_byte_order( id, SPI_ORDER_MSB );
-
   return PLATFORM_OK;
-}
-
-int platform_spi_set_mosi( uint8_t id, uint16_t offset, uint8_t bitlen, spi_data_type data )
-{
-  if (offset + bitlen > 512)
-    return PLATFORM_ERR;
-
-  spi_mast_set_mosi( id, offset, bitlen, data );
-
-  return PLATFORM_OK;
-}
-
-spi_data_type platform_spi_get_miso( uint8_t id, uint16_t offset, uint8_t bitlen )
-{
-  if (offset + bitlen > 512)
-    return 0;
-
-  return spi_mast_get_miso( id, offset, bitlen );
 }
 
 int platform_spi_transaction( uint8_t id, uint8_t cmd_bitlen, spi_data_type cmd_data,

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -113,8 +113,6 @@ void platform_spi_select( unsigned id, int is_select );
 
 int platform_spi_blkwrite( uint8_t id, size_t len, const uint8_t *data );
 int platform_spi_blkread( uint8_t id, size_t len, uint8_t *data );
-int platform_spi_set_mosi( uint8_t id, uint16_t offset, uint8_t bitlen, spi_data_type data );
-spi_data_type platform_spi_get_miso( uint8_t id, uint16_t offset, uint8_t bitlen );
 int platform_spi_transaction( uint8_t id, uint8_t cmd_bitlen, spi_data_type cmd_data,
                               uint8_t addr_bitlen, spi_data_type addr_data,
                               uint16_t mosi_bitlen, uint8_t dummy_bitlen, int16_t miso_bitlen );

--- a/docs/en/modules/spi.md
+++ b/docs/en/modules/spi.md
@@ -119,7 +119,10 @@ transactions are initiated with full control over the hardware features.
 Extract data items from MISO buffer after `spi.transaction()`.
 
 #### Syntax
-`data1[, data2[, ..., datan]] = spi.get_miso(id, offset, bitlen, num)`
+```lua
+data1[, data2[, ..., datan]] = spi.get_miso(id, offset, bitlen, num)
+string = spi.get_miso(id, num)
+```
 
 #### Parameters
 - `id` SPI ID number: 0 for SPI, 1 for HSPI
@@ -128,7 +131,7 @@ Extract data items from MISO buffer after `spi.transaction()`.
 - `num` number of data items to retrieve
 
 ####Returns
-`num` data items
+`num` data items or `string`
 
 #### See also
 [spi.transaction()](#spitransaction)
@@ -137,13 +140,17 @@ Extract data items from MISO buffer after `spi.transaction()`.
 Insert data items into MOSI buffer for `spi.transaction()`.
 
 #### Syntax
-`spi.set_mosi(id, offset, bitlen, data1[, data2[, ..., datan]])`
+```lua
+spi.set_mosi(id, offset, bitlen, data1[, data2[, ..., datan]])
+spi.set_mosi(id, string)
+```
 
 ####Parameters
 - `id` SPI ID number: 0 for SPI, 1 for HSPI
 - `offset` bit offset into MOSI buffer for inserting data1 and subsequent items
 - `bitlen` bit length of data1, data2, ...
 - `data` data items where `bitlen` number of bits are considered for the transaction.
+- `string` send data to be copied into MOSI buffer at offset 0, bit length 8
 
 #### Returns
 `nil`


### PR DESCRIPTION
Fixes #1745.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This PR adds variants of `spi.set_mosi()` and `spi.get_miso()` that accept and return data as string, respectively.
Along with the API extension, the endianess handling in the spi driver has been unified.
