### PR TITLE
include gdbstub.md in doc generation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ pages:
         - 'encoder': 'en/modules/encoder.md'
         - 'enduser setup': 'en/modules/enduser-setup.md'
         - 'file': 'en/modules/file.md'
+        - 'gdbstub': 'en/modules/gdbstub.md'
         - 'gpio': 'en/modules/gpio.md'
         - 'hmc5883l': 'en/modules/hmc5883l.md'
         - 'http': 'en/modules/http.md'


### PR DESCRIPTION
gdbstub's doc is missing in the doc build - it wasn't skipped on purpose?
