### PR TITLE
update user_Config.h to enable WIFI_SMART_ENABLE

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -110,7 +110,7 @@ extern void luaL_assertfail(const char *file, int line, const char *message);
 //#define WIFI_STA_HOSTNAME "NodeMCU"
 //#define WIFI_STA_HOSTNAME_APPEND_MAC
 
-//#define WIFI_SMART_ENABLE
+#define WIFI_SMART_ENABLE
 
 #define WIFI_STATION_STATUS_MONITOR_ENABLE
 #define WIFI_SDK_EVENT_MONITOR_ENABLE


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is for the `dev` branch rather than for `master`.
- [ ] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rational behind this PR\>
Enable WIFI_SMART_ENABLE
//#define WIFI_STA_HOSTNAME "NodeMCU"
 //#define WIFI_STA_HOSTNAME_APPEND_MAC
 
-//#define WIFI_SMART_ENABLE
+#define WIFI_SMART_ENABLE
 
 #define WIFI_STATION_STATUS_MONITOR_ENABLE
 #define WIFI_SDK_EVENT_MONITOR_ENABLE