### PR TITLE
uncommented #define WIFI_SMART_ENABLE

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -110,7 +110,7 @@ extern void luaL_assertfail(const char *file, int line, const char *message);
 //#define WIFI_STA_HOSTNAME "NodeMCU"
 //#define WIFI_STA_HOSTNAME_APPEND_MAC
 
-//#define WIFI_SMART_ENABLE
+#define WIFI_SMART_ENABLE
 
 #define WIFI_STATION_STATUS_MONITOR_ENABLE
 #define WIFI_SDK_EVENT_MONITOR_ENABLE


### PR DESCRIPTION
WIFI_SMART_ENABLE is useful feature by default it should be enabled

Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

WIFI_SMART_ENABLE is useful feature if you are using WIFI module. By default it should be enabled