### PR TITLE
Fix the adjusting of the time when there is a rollover in gpio interrupts

### DIFF
--- a/app/modules/gpio.c
+++ b/app/modules/gpio.c
@@ -43,7 +43,8 @@ static void gpio_intr_callback_task (task_param_t param, uint8 priority)
 
   // Now must be >= then . Add the missing bits
   if (then > (now & 0xffffff)) {
-    then += 0x1000000;
+    // Now must have rolled over since the interrupt -- back it down
+    now -= 0x1000000;
   }
   then = (then + (now & 0x7f000000)) & 0x7fffffff;
 


### PR DESCRIPTION
Fixes #1782 .



- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

The code that adjusted the time reported when the system time rolled over 2^24 boundary between the interrupt happening and when it was dispatched was backwards. It ended up adding 2^24 microseconds instead of subtracting the same number. This is the reason that the "time travel" offsets were almost exactly 2^25 microseconds.