### PR TITLE
BME280: Correct code samples for negative values - more elegant solution

### DIFF
--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -137,27 +137,20 @@ QNH = bme280.qfe2qnh(P, alt)
 print(string.format("QNH=%d.%03d", QNH/1000, QNH%1000))
 
 H, T = bme280.humi()
-if T<0 then    
-  print(string.format("T=-%d.%02d", -T/100, -T%100))
-else
-  print(string.format("T=%d.%02d", T/100, T%100))
-end
+
+local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
+print(string.format("T=%s%d.%02d", Tsgn<0 and "-" or "", T/100, T%100))
 print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
+
 D = bme280.dewpoint(H, T)
-if D<0 then
-  print(string.format("dew_point=-%d.%02d", -D/100, -D%100))
-else
-  print(string.format("dew_point=%d.%02d", D/100, D%100))
-end
+local Dsgn = (D < 0 and -1 or 1); D = Dsgn*D
+print(string.format("dew_point=%s%d.%02d", Dsgn<0 and "-" or "", D/100, D%100))
 
 -- altimeter function - calculate altitude based on current sea level pressure (QNH) and measure pressure
 P = bme280.baro()
 curAlt = bme280.altitude(P, QNH)
-if curAlt<0 then
-  print(string.format("altitude=-%d.%02d", -curAlt/100, -curAlt%100))
-else
-  print(string.format("altitude=%d.%02d", curAlt/100, curAlt%100))
-end
+local curAltsgn = (curAlt < 0 and -1 or 1); curAlt = curAltsgn*curAlt
+print(string.format("altitude=%s%d.%02d", curAltsgn<0 and "-" or "", curAlt/100, curAlt%100))
 ```
 
 Or simpler and more efficient
@@ -167,29 +160,20 @@ alt=320 -- altitude of the measurement place
 bme280.init(3, 4)
 
 T, P, H, QNH = bme280.read(alt)
-if T<0 then
-  print(string.format("T=-%d.%02d", -T/100, -T%100))
-else
-  print(string.format("T=%d.%02d", T/100, T%100))
-end
+local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
+print(string.format("T=%s%d.%02d", Tsgn<0 and "-" or "", T/100, T%100))
 print(string.format("QFE=%d.%03d", P/1000, P%1000))
 print(string.format("QNH=%d.%03d", QNH/1000, QNH%1000))
 print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
 D = bme280.dewpoint(H, T)
-if D<0 then
-  print(string.format("dew_point=-%d.%02d", -D/100, -D%100))
-else
-  print(string.format("dew_point=%d.%02d", D/100, D%100))
-end
+local Dsgn = (D < 0 and -1 or 1); D = Dsgn*D
+print(string.format("dew_point=%s%d.%02d", Dsgn<0 and "-" or "", D/100, D%100))
 
 -- altimeter function - calculate altitude based on current sea level pressure (QNH) and measure pressure
 P = bme280.baro()
 curAlt = bme280.altitude(P, QNH)
-if curAlt<0 then
-  print(string.format("altitude=-%d.%02d", -curAlt/100, -curAlt%100))
-else
-  print(string.format("altitude=%d.%02d", curAlt/100, curAlt%100))
-end
+local curAltsgn = (curAlt < 0 and -1 or 1); curAlt = curAltsgn*curAlt
+print(string.format("altitude=%s%d.%02d", curAltsgn<0 and "-" or "", curAlt/100, curAlt%100))
 ```
 
 Use `bme280.init(sda, scl, 1, 3, 0, 3, 0, 4)` for "game mode" - Oversampling settings  pressure ×4, temperature ×1, humidity ×0, sensor mode: normal mode, inactive duration  = 0.5 ms, IIR filter settings  filter coefficient 16.
@@ -199,11 +183,8 @@ Example of readout in forced mode (asynchronous)
 bme280.init(3, 4, nil, nil, nil, 0) -- initialize to sleep mode
 bme280.startreadout(0, function ()
   T, P = bme280.read()
-  if T<0 then
-    print(string.format("T=-%d.%02d", -T/100, -T%100))
-  else
-    print(string.format("T=%d.%02d", T/100, T%100))
-  end
+  local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
+  print(string.format("T=%s%d.%02d", Tsgn<0 and "-" or "", T/100, T%100))
 end)
 ```
 


### PR DESCRIPTION
Fixes #1734.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This PR modifies the BME280 module documentation. The bug has been already fixed with PR https://github.com/nodemcu/nodemcu-firmware/pull/1735 but this PR presents more elegant fix of the problem.