### PR TITLE
Sync uart configuration to Tx FIFO level

### DIFF
--- a/app/driver/uart.c
+++ b/app/driver/uart.c
@@ -43,6 +43,22 @@ static void (*alt_uart0_tx)(char txchar);
 LOCAL void ICACHE_RAM_ATTR
 uart0_rx_intr_handler(void *para);
 
+
+/******************************************************************************
+ * FunctionName : uart_wait_tx_empty
+ * Description  : Internal used function
+ *                Wait for TX FIFO to become empty.
+ * Parameters   : uart_no, use UART0 or UART1 defined ahead
+ * Returns      : NONE
+*******************************************************************************/
+LOCAL void ICACHE_FLASH_ATTR
+uart_wait_tx_empty(uint8 uart_no)
+{
+    while ((READ_PERI_REG(UART_STATUS(uart_no)) & (UART_TXFIFO_CNT<<UART_TXFIFO_CNT_S)) > 0)
+        ;
+}
+
+
 /******************************************************************************
  * FunctionName : uart_config
  * Description  : Internal used function
@@ -54,6 +70,8 @@ uart0_rx_intr_handler(void *para);
 LOCAL void ICACHE_FLASH_ATTR
 uart_config(uint8 uart_no)
 {
+    uart_wait_tx_empty(uart_no);
+
     if (uart_no == UART1) {
         PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO2_U, FUNC_U1TXD_BK);
     } else {
@@ -98,6 +116,8 @@ uart_config(uint8 uart_no)
 void ICACHE_FLASH_ATTR
 uart0_alt(uint8 on)
 {
+    uart_wait_tx_empty(UART0);
+
     if (on)
     {
         PIN_PULLUP_DIS(PERIPHS_IO_MUX_MTDO_U);

--- a/app/driver/uart.c
+++ b/app/driver/uart.c
@@ -368,6 +368,8 @@ uart_setup(uint8 uart_no)
 #ifdef BIT_RATE_AUTOBAUD
     uart_stop_autobaud();
 #endif
+    // poll Tx FIFO empty outside before disabling interrupts
+    uart_wait_tx_empty(uart_no);
     ETS_UART_INTR_DISABLE();
     uart_config(uart_no);
     ETS_UART_INTR_ENABLE();

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -74,7 +74,7 @@ end, 0)
     Bytes sent to the UART can get lost if this function re-configures the UART while reception is in progress.
 
 #### Syntax
-`uart.setup(id, baud, databits, parity, stopbits, echo)`
+`uart.setup(id, baud, databits, parity, stopbits[, echo])`
 
 #### Parameters
 - `id` always zero, only one uart supported
@@ -82,7 +82,7 @@ end, 0)
 - `databits` one of 5, 6, 7, 8
 - `parity` `uart.PARITY_NONE`, `uart.PARITY_ODD`, or `uart.PARITY_EVEN`
 - `stopbits` `uart.STOPBITS_1`, `uart.STOPBITS_1_5`, or `uart.STOPBITS_2`
-- `echo` if 0, disable echo, otherwise enable echo
+- `echo` if 0, disable echo, otherwise enable echo (default if omitted)
 
 #### Returns
 configured baud rate (number)

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -67,7 +67,11 @@ end, 0)
 
 ## uart.setup()
 
-(Re-)configures the communication parameters of the UART. 
+(Re-)configures the communication parameters of the UART.
+
+!!! note
+
+    Bytes sent to the UART can get lost if this function re-configures the UART while reception is in progress.
 
 #### Syntax
 `uart.setup(id, baud, databits, parity, stopbits, echo)`


### PR DESCRIPTION
Relates to #1800.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Reconfiguration of the UART parameters (`uart.setup()` and `uart.alt()`) can happen while a transmission or reception is ongoing. Bytes being sent or received might be lost.

This PR synchronizes the configuration update to the Tx FIFO level by delaying the update until Tx FIFO is empty. There seems to be no method to detect an ongoing reception (bytes already in the Rx FIFO are safe).