### PR TITLE
Apply ow power selection at the end of the write slot while irqs are masked

### DIFF
--- a/app/include/driver/onewire.h
+++ b/app/include/driver/onewire.h
@@ -74,7 +74,7 @@ void onewire_read_bytes(uint8_t pin, uint8_t *buf, uint16_t count);
 
 // Write a bit. The bus is always left powered at the end, see
 // note in write() about that.
-static void onewire_write_bit(uint8_t pin, uint8_t v);
+static void onewire_write_bit(uint8_t pin, uint8_t v, uint8_t power);
 
 // Read a bit.
 static uint8_t onewire_read_bit(uint8_t pin);


### PR DESCRIPTION
Fixes #1797.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

The strong output driver is activated at the end of the last write slot for power=1 case while interrupts are still masked. This ensures that T<sub>SPON</sub>(max) is not violated when an interrupt is pending.
I couldn't stimulate the suspected failure case due to the tight timing requirements (have an interrupt triggered at exactly the right time slot). But tests with 2 DS18B20s in powered and parasite mode on the bus didn't reveal any regressions at least.
