### PR TITLE
Fix debug message for wifi.sta.getrssi()

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1168,7 +1168,7 @@ static int wifi_station_status( lua_State* L )
 // Lua: wifi.sta.getrssi()
 static int wifi_station_getrssi( lua_State* L ){
   sint8 rssival=wifi_station_get_rssi();
-  NODE_DBG("\n\tRSSI is %i\n", rssival);
+  NODE_DBG("\n\tRSSI is %d\n", rssival);
   if (rssival<10)
   {
     lua_pushinteger(L, rssival);


### PR DESCRIPTION
Fixes #1813.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.

This PR fixes a formatting error in the debug message for `wifi.sta.getrssi()`. 
This error was caused by the merge of PR #1564, which changed the function used to print debug messages to the UART from `c_printf()` to `dbg_printf()`.