### PR TITLE
Fix missing return code for ws2812_init()

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -27,7 +27,7 @@ typedef struct {
 // Init UART1 to be able to stream WS2812 data to GPIO2 pin
 // If DUAL mode is selected, init UART0 to stream to TXD0 as well
 // You HAVE to redirect LUA's output somewhere else
-static void ws2812_init(lua_State* L) {
+static int ws2812_init(lua_State* L) {
   const int mode = luaL_optinteger(L, 1, MODE_SINGLE);
   luaL_argcheck(L, mode == MODE_SINGLE || mode == MODE_DUAL, 1, "ws2812.SINGLE or ws2812.DUAL expected");
 
@@ -57,6 +57,8 @@ static void ws2812_init(lua_State* L) {
   GPIO_REG_WRITE(GPIO_ENABLE_W1TC_ADDRESS, BIT2);
   // Enable Function 2 for GPIO2 (U1TXD)
   PIN_FUNC_SELECT(PERIPHS_IO_MUX_GPIO2_U, FUNC_U1TXD_BK);
+
+  return 0;
 }
 
 // Stream data using UART1 routed to GPIO2

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -15,14 +15,17 @@ through the serial port (it will be reconfigured to support WS2812-like
 protocol). If you want to keep access to Lua's console, you will have to 
 use an other input channel like a TCP server (see [example](https://github.com/nodemcu/nodemcu-firmware/blob/master/examples/telnet.lua))
 
-## ws2812.init(mode)
+## ws2812.init()
 Initialize UART1 and GPIO2, should be called once and before write().
 Initialize UART0 (TXD0) too if `ws2812.MODE_DUAL` is set.
 
+#### Syntax
+`ws2812.init([mode])`
+
 #### Parameters
-- `mode` (optional) either `ws2812.MODE_SINGLE` (default if omitted) or `ws2812.MODE_DUAL`.
-In `ws2812.MODE_DUAL` mode you will be able to handle two strips in parallel but will lose access
-to Lua's serial console as it shares the same UART and PIN.
+- `mode` (optional) either `ws2812.MODE_SINGLE` (default if omitted) or `ws2812.MODE_DUAL`
+
+In `ws2812.MODE_DUAL` mode you will be able to handle two strips in parallel but will lose access to Lua's serial console as it shares the same UART and PIN.
 
 #### Returns
 `nil`


### PR DESCRIPTION
Fixes #1815.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Like all Lua functions, `ws2812_init()` must return number of pushed elements onto stack.

Small corrections for `ws2812.init()` API doc formatting.