### PR TITLE
Use flash size byte to determine the location of the init data for byte 107.

### DIFF
--- a/app/modules/adc.c
+++ b/app/modules/adc.c
@@ -29,7 +29,7 @@ static int adc_init107( lua_State *L )
 {
   uint8_t byte107 = luaL_checkinteger (L, 1);
 
-  uint32 init_sector = flash_safe_get_sec_num () - 4;
+  uint32 init_sector = flash_rom_get_sec_num () - 4;
 
   // Note 32bit alignment so we can safely cast to uint32 for the flash api
   char init_data[SPI_FLASH_SEC_SIZE] __attribute__((aligned(4)));


### PR DESCRIPTION
Fixes #1826.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

The current method to determine the location of the init data sector for byte 107 assumes that it's at offset -4 from the end of the flash. This logic breaks in case the current workaround for >4MB modules is present where init data is *not* located at the end of flash.

Fix is to determine init data location with `flash_rom_get_sec_num()` which relies on the size header byte. Size byte is the single source pointing to the init data location in all cases since the SDK also uses this information to locate init data.
This method is expected to remain valid also for the upcoming support of >4MB flash by the SDK (tagging #1810 for regression testing).

Tested on a 16MB Mini Pro and a stock 4MB NodeMCU devkit.
