### PR TITLE
added noob 7bit address info

### DIFF
--- a/docs/en/modules/i2c.md
+++ b/docs/en/modules/i2c.md
@@ -11,8 +11,10 @@ Setup I²C address and read/write mode for the next transfer.
 
 #### Parameters
 - `id` always 0
-- `device_addr` device address
+- `device_addr` device address (7-bit)<sup>[1](#7bit)</sup>
 - `direction` `i2c.TRANSMITTER` for writing mode , `i2c. RECEIVER` for reading mode
+
+<a name="7bit">[1]</a>: 8bit frame = 7bit address + R/W bit as LSB
 
 #### Returns
 `true` if ack received, `false` if no ack received.


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rational behind this PR\>
to make the first i2c implementation for any noob (like me) more transparent, I propose to add the information that the address is 7bit only. Some datasheets don't include that, and it's just nice to have.
[Yes, one could just follow the link into `i2c.c`, but that's not very noob proof :) ]