### PR TITLE
Deprecation messages for convenient net.create(Server/Connection) calls

### DIFF
--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -297,7 +297,10 @@ int net_createServer( lua_State *L ) {
   type = luaL_optlong(L, 1, TYPE_TCP);
   timeout = luaL_optlong(L, 2, 30);
 
-  if (type == TYPE_UDP) return net_createUDPSocket( L );
+  if (type == TYPE_UDP) {
+    platform_print_deprecation_note("net.createServer with net.UDP type", "in next version");
+    return net_createUDPSocket( L );
+  }
   if (type != TYPE_TCP) return luaL_error(L, "invalid type");
 
   lnet_userdata *u = net_create(L, TYPE_TCP_SERVER);
@@ -312,9 +315,13 @@ int net_createConnection( lua_State *L ) {
   type = luaL_optlong(L, 1, TYPE_TCP);
   secure = luaL_optlong(L, 2, 0);
 
-  if (type == TYPE_UDP) return net_createUDPSocket( L );
+  if (type == TYPE_UDP) {
+    platform_print_deprecation_note("net.createConnection with net.UDP type", "in next version");
+    return net_createUDPSocket( L );
+  }
   if (type != TYPE_TCP) return luaL_error(L, "invalid type");
   if (secure) {
+    platform_print_deprecation_note("net.createConnection with secure flag", "in next version");
 #ifdef TLS_MODULE_PRESENT
     return tls_socket_create( L );
 #else

--- a/docs/en/modules/net.md
+++ b/docs/en/modules/net.md
@@ -13,11 +13,11 @@ Constants to be used in other functions: `net.TCP`, `net.UDP`
 Creates a client.
 
 #### Syntax
-`net.createConnection(type, secure)`
+`net.createConnection([type[, secure]])`
 
 #### Parameters
-- `type` `net.TCP` or `net.UDP`. UDP connections chained to [net.createUDPSocket()](#netcreateudpsocket)
-- `secure` 1 for encrypted, 0 for plain. Secure connections chained to [tls.createConnection()](tls.md#tlscreateconnection)
+- `type` `net.TCP` (default) or `net.UDP`
+- `secure` 1 for encrypted, 0 for plain (default)
 
 !!! attention
     This will change in upcoming releases so that `net.createConnection` will always create an unencrypted TCP connection.
@@ -44,11 +44,11 @@ net.createConnection(net.TCP, 0)
 Creates a server.
 
 #### Syntax
-`net.createServer(type, timeout)`
+`net.createServer([type[, timeout]])`
 
 #### Parameters
-- `type` `net.TCP` or `net.UDP`. UDP connections chained to [net.createUDPSocket()](#netcreateudpsocket)
-- `timeout` for a TCP server timeout is 1~28'800 seconds (for an inactive client to be disconnected)
+- `type` `net.TCP` (default) or `net.UDP`
+- `timeout` for a TCP server timeout is 1~28'800 seconds, 30 sec by default (for an inactive client to be disconnected)
 
 !!! attention
     The `type` parameter will be removed in upcoming releases so that `net.createServer` will always create a TCP-based server. For UDP use [net.createUDPSocket()](#netcreateudpsocket) instead.


### PR DESCRIPTION
Fixes #1762 (pt. 3), also add default parameter values in docs.