### PR TITLE
Extend node.dsleep() to support instant sleep.

### DIFF
--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -53,6 +53,9 @@ static int node_deepsleep( lua_State* L )
     else
       system_deep_sleep_set_option( option );
   }
+  bool instant = false;
+  if (lua_isnumber(L, 3))
+    instant = lua_tointeger(L, 3);
   // Set deleep time, skip if nil
   if ( lua_isnumber(L, 1) )
   {
@@ -61,7 +64,12 @@ static int node_deepsleep( lua_State* L )
     if ( us < 0 )
       return luaL_error( L, "wrong arg range" );
     else
-      system_deep_sleep( us );
+    {
+      if (instant)
+        system_deep_sleep_instant(us);
+      else
+        system_deep_sleep( us );
+    }
   }
   return 0;
 }

--- a/docs/en/modules/node.md
+++ b/docs/en/modules/node.md
@@ -95,7 +95,7 @@ Firmware from before 05 Jan 2016 have a maximum sleeptime of ~35 minutes.
     This function can only be used in the condition that esp8266 PIN32(RST) and PIN8(XPD_DCDC aka GPIO16) are connected together. Using sleep(0) will set no wake up timer, connect a GPIO to pin RST, the chip will wake up by a falling-edge on pin RST.
 
 #### Syntax
-`node.dsleep(us, option)`
+`node.dsleep(us, option, instant)`
 
 #### Parameters
  - `us` number (integer) or `nil`, sleep time in micro second. If `us == 0`, it will sleep forever. If `us == nil`, will not set sleep time.
@@ -107,6 +107,10 @@ Firmware from before 05 Jan 2016 have a maximum sleeptime of ~35 minutes.
 	- 1, RF_CAL after deep-sleep wake up, there will be large current
 	- 2, no RF_CAL after deep-sleep wake up, there will only be small current
 	- 4, disable RF after deep-sleep wake up, just like modem sleep, there will be the smallest current
+ - `instant` number (integer) or `nil`. If present and non-zero, do not use
+    the normal grace time before entering deep sleep.  This is a largely
+    undocumented feature, and is only briefly mentioned in Espressif's
+    [low power solutions](https://espressif.com/sites/default/files/documentation/9b-esp8266_low_power_solutions_en.pdf) document.
 
 #### Returns
 `nil`

--- a/docs/en/modules/node.md
+++ b/docs/en/modules/node.md
@@ -110,7 +110,7 @@ Firmware from before 05 Jan 2016 have a maximum sleeptime of ~35 minutes.
  - `instant` number (integer) or `nil`. If present and non-zero, do not use
     the normal grace time before entering deep sleep.  This is a largely
     undocumented feature, and is only briefly mentioned in Espressif's
-    [low power solutions](https://espressif.com/sites/default/files/documentation/9b-esp8266_low_power_solutions_en.pdf) document.
+    [low power solutions](https://espressif.com/sites/default/files/documentation/9b-esp8266_low_power_solutions_en.pdf#page=10) document (chapter 4.5).
 
 #### Returns
 `nil`

--- a/sdk-overrides/include/user_interface.h
+++ b/sdk-overrides/include/user_interface.h
@@ -12,5 +12,7 @@ enum ext_flash_size_map {
     FLASH_SIZE_128M_MAP = 9
 };
 
+// Documented in section 4.5 of 9b-esp8266_low_power_solutions_en.pdf
+void system_deep_sleep_instant(uint32 time_in_us);
 
 #endif /* SDK_OVERRIDES_INCLUDE_USER_INTERFACE_H_ */


### PR DESCRIPTION
Fixes #1776.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution. **I have not, but @eyaleb has quite comprehensively done it in #1776**
- [X] The code changes are reflected in the documentation at `docs/en/*`.

This introduces the "instant" deep sleep feature which Espressif added but largely hid away. See #1776 for further details. Instant deep sleep effectively shaves off ~100ms on the going-to-sleep, which can be quite significant for battery-powered devices.

Due to the lack of documentation, I haven't made the instant deep sleep the default since I don't fully know what the difference between the two deep sleep functions are.