### PR TITLE
Fix self.pin when specifying lpin for readTemp()

### DIFF
--- a/lua_modules/ds18b20/ds18b20.lua
+++ b/lua_modules/ds18b20/ds18b20.lua
@@ -29,10 +29,10 @@ return({
   end,
 
   readTemp = function(self, cb, lpin)
+    if lpin then self.pin = lpin end
     local pin = self.pin
     self.cb = cb
     self.temp={}
-    if lpin then pin = lpin end
     ow.setup(pin)
 
     self.sens={}


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

The selected `lpin` for `readTemp()` is not stored in `self.pin`. Using any other pin than 3 doesn't work.
