### PR TITLE
Deprecate init() in favor of setup(), removing inherent i2c configuration: adxl345, am2320, bme280, bmp085, hmc5883l, l3g4200d

### DIFF
--- a/app/modules/adxl345.c
+++ b/app/modules/adxl345.c
@@ -12,7 +12,7 @@
 static const uint32_t adxl345_i2c_id = 0;
 static const uint8_t adxl345_i2c_addr = 0x53;
 
-static uint8_t ICACHE_FLASH_ATTR r8u(uint32_t id, uint8_t reg) {
+static uint8_t r8u(uint32_t id, uint8_t reg) {
     uint8_t ret;
 
     platform_i2c_send_start(id);
@@ -26,19 +26,9 @@ static uint8_t ICACHE_FLASH_ATTR r8u(uint32_t id, uint8_t reg) {
     return ret;
 }
 
-static int ICACHE_FLASH_ATTR adxl345_init(lua_State* L) {
-
-    uint32_t sda;
-    uint32_t scl;
+static int adxl345_setup(lua_State* L) {
     uint8_t  devid;
 
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
-
-    platform_i2c_setup(adxl345_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-    
     devid = r8u(adxl345_i2c_id, 0x00);
 
     if (devid != 229) {
@@ -55,7 +45,24 @@ static int ICACHE_FLASH_ATTR adxl345_init(lua_State* L) {
     return 0;
 }
 
-static int ICACHE_FLASH_ATTR adxl345_read(lua_State* L) {
+static int adxl345_init(lua_State* L) {
+
+    uint32_t sda;
+    uint32_t scl;
+
+    platform_print_deprecation_note("adxl345.init() is replaced by adxl345.setup()", "in the next version");
+
+    sda = luaL_checkinteger(L, 1);
+    scl = luaL_checkinteger(L, 2);
+
+    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
+
+    platform_i2c_setup(adxl345_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
+    
+    return adxl345_setup(L);
+}
+
+static int adxl345_read(lua_State* L) {
 
     uint8_t data[6];
     int x,y,z;
@@ -88,6 +95,8 @@ static int ICACHE_FLASH_ATTR adxl345_read(lua_State* L) {
 
 static const LUA_REG_TYPE adxl345_map[] = {
     { LSTRKEY( "read" ),         LFUNCVAL( adxl345_read )},
+    { LSTRKEY( "setup" ),        LFUNCVAL( adxl345_setup )},
+    /// init() is deprecated
     { LSTRKEY( "init" ),         LFUNCVAL( adxl345_init )},
     { LNILKEY, LNILVAL}
 };

--- a/app/modules/bmp085.c
+++ b/app/modules/bmp085.c
@@ -21,7 +21,7 @@ static struct {
     int16_t  MD;
 } bmp085_data;
 
-static uint8_t ICACHE_FLASH_ATTR r8u(uint32_t id, uint8_t reg) {
+static uint8_t r8u(uint32_t id, uint8_t reg) {
     uint8_t ret;
 
     platform_i2c_send_start(id);
@@ -35,32 +35,18 @@ static uint8_t ICACHE_FLASH_ATTR r8u(uint32_t id, uint8_t reg) {
     return ret;
 }
 
-static uint16_t ICACHE_FLASH_ATTR r16u(uint32_t id, uint8_t reg) {
+static uint16_t r16u(uint32_t id, uint8_t reg) {
     uint8_t high = r8u(id, reg);
     uint8_t low  = r8u(id, reg + 1);
     return (high << 8) | low;
 }
 
-static int16_t ICACHE_FLASH_ATTR r16(uint32_t id, uint8_t reg) {
+static int16_t r16(uint32_t id, uint8_t reg) {
     return (int16_t) r16u(id, reg);
 }
 
-static int ICACHE_FLASH_ATTR bmp085_init(lua_State* L) {
-    uint32_t sda;
-    uint32_t scl;
-
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
-        return luaL_error(L, "wrong arg range");
-    }
-
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    if (scl == 0 || sda == 0) {
-        return luaL_error(L, "no i2c for D0");
-    }
-
-    platform_i2c_setup(bmp085_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
+static int bmp085_setup(lua_State* L) {
+    (void)L;
 
     bmp085_data.AC1 = r16(bmp085_i2c_id, 0xAA);
     bmp085_data.AC2 = r16(bmp085_i2c_id, 0xAC);
@@ -75,6 +61,28 @@ static int ICACHE_FLASH_ATTR bmp085_init(lua_State* L) {
     bmp085_data.MD  = r16(bmp085_i2c_id, 0xBE);
 
     return 0;
+}
+
+static int bmp085_init(lua_State* L) {
+    uint32_t sda;
+    uint32_t scl;
+
+    platform_print_deprecation_note("bmp085.init() is replaced by bmp085.setup()", "in the next version");
+
+    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
+        return luaL_error(L, "wrong arg range");
+    }
+
+    sda = luaL_checkinteger(L, 1);
+    scl = luaL_checkinteger(L, 2);
+
+    if (scl == 0 || sda == 0) {
+        return luaL_error(L, "no i2c for D0");
+    }
+
+    platform_i2c_setup(bmp085_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
+
+    return bmp085_setup(L);
 }
 
 static uint32_t bmp085_temperature_raw_b5(void) {
@@ -96,16 +104,16 @@ static uint32_t bmp085_temperature_raw_b5(void) {
     return X1 + X2;
 }
 
-static int16_t ICACHE_FLASH_ATTR bmp085_temperature(void) {
+static int16_t bmp085_temperature(void) {
     return (bmp085_temperature_raw_b5() + 8) >> 4;
 }
 
-static int ICACHE_FLASH_ATTR bmp085_lua_temperature(lua_State* L) {
+static int bmp085_lua_temperature(lua_State* L) {
     lua_pushinteger(L, bmp085_temperature());
     return 1;
 }
 
-static int32_t ICACHE_FLASH_ATTR bmp085_pressure_raw(int oss) {
+static int32_t bmp085_pressure_raw(int oss) {
     int32_t p;
     int32_t p1, p2, p3;
 
@@ -132,7 +140,7 @@ static int32_t ICACHE_FLASH_ATTR bmp085_pressure_raw(int oss) {
     return p;
 }
 
-static int ICACHE_FLASH_ATTR bmp085_lua_pressure_raw(lua_State* L) {
+static int bmp085_lua_pressure_raw(lua_State* L) {
     uint8_t oss = 0;
     int32_t p;
 
@@ -148,7 +156,7 @@ static int ICACHE_FLASH_ATTR bmp085_lua_pressure_raw(lua_State* L) {
     return 1;
 }
 
-static int ICACHE_FLASH_ATTR bmp085_lua_pressure(lua_State* L) {
+static int bmp085_lua_pressure(lua_State* L) {
     uint8_t oss = 0;
     int32_t p;
     int32_t X1, X2, X3, B3, B4, B5, B6, B7;
@@ -187,6 +195,8 @@ static const LUA_REG_TYPE bmp085_map[] = {
     { LSTRKEY( "temperature" ),  LFUNCVAL( bmp085_lua_temperature )},
     { LSTRKEY( "pressure" ),     LFUNCVAL( bmp085_lua_pressure )},
     { LSTRKEY( "pressure_raw" ), LFUNCVAL( bmp085_lua_pressure_raw )},
+    { LSTRKEY( "setup" ),        LFUNCVAL( bmp085_setup )},
+    // init() is deprecated
     { LSTRKEY( "init" ),         LFUNCVAL( bmp085_init )},
     { LNILKEY, LNILVAL}
 };

--- a/app/modules/hmc5883l.c
+++ b/app/modules/hmc5883l.c
@@ -12,7 +12,7 @@
 static const uint32_t hmc5883_i2c_id = 0;
 static const uint8_t hmc5883_i2c_addr = 0x1E;
 
-static uint8_t ICACHE_FLASH_ATTR r8u(uint32_t id, uint8_t reg) {
+static uint8_t r8u(uint32_t id, uint8_t reg) {
     uint8_t ret;
 
     platform_i2c_send_start(id);
@@ -26,7 +26,7 @@ static uint8_t ICACHE_FLASH_ATTR r8u(uint32_t id, uint8_t reg) {
     return ret;
 }
 
-static void ICACHE_FLASH_ATTR w8u(uint32_t id, uint8_t reg, uint8_t val) {
+static void w8u(uint32_t id, uint8_t reg, uint8_t val) {
     platform_i2c_send_start(hmc5883_i2c_id);
     platform_i2c_send_address(hmc5883_i2c_id, hmc5883_i2c_addr, PLATFORM_I2C_DIRECTION_TRANSMITTER);
     platform_i2c_send_byte(hmc5883_i2c_id, reg);
@@ -34,19 +34,9 @@ static void ICACHE_FLASH_ATTR w8u(uint32_t id, uint8_t reg, uint8_t val) {
     platform_i2c_send_stop(hmc5883_i2c_id);
 }
 
-static int ICACHE_FLASH_ATTR hmc5883_init(lua_State* L) {
-
-    uint32_t sda;
-    uint32_t scl;
+static int hmc5883_setup(lua_State* L) {
     uint8_t  devid_a, devid_b, devid_c;
 
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
-
-    platform_i2c_setup(hmc5883_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-    
     devid_a = r8u(hmc5883_i2c_id, 10);
     devid_b = r8u(hmc5883_i2c_id, 11);
     devid_c = r8u(hmc5883_i2c_id, 12);
@@ -67,7 +57,24 @@ static int ICACHE_FLASH_ATTR hmc5883_init(lua_State* L) {
     return 0;
 }
 
-static int ICACHE_FLASH_ATTR hmc5883_read(lua_State* L) {
+static int hmc5883_init(lua_State* L) {
+
+    uint32_t sda;
+    uint32_t scl;
+
+    platform_print_deprecation_note("hmc5883l.init() is replaced by hmc5883l.setup()", "in the next version");
+
+    sda = luaL_checkinteger(L, 1);
+    scl = luaL_checkinteger(L, 2);
+
+    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
+
+    platform_i2c_setup(hmc5883_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
+
+    return hmc5883_setup(L);
+}
+
+static int hmc5883_read(lua_State* L) {
 
     uint8_t data[6];
     int x,y,z;
@@ -101,6 +108,8 @@ static int ICACHE_FLASH_ATTR hmc5883_read(lua_State* L) {
 
 static const LUA_REG_TYPE hmc5883_map[] = {
     { LSTRKEY( "read" ),         LFUNCVAL( hmc5883_read )},
+    { LSTRKEY( "setup" ),        LFUNCVAL( hmc5883_setup )},
+    // init() is deprecated
     { LSTRKEY( "init" ),         LFUNCVAL( hmc5883_init )},
     { LNILKEY, LNILVAL}
 };

--- a/app/modules/l3g4200d.c
+++ b/app/modules/l3g4200d.c
@@ -12,7 +12,7 @@
 static const uint32_t i2c_id = 0;
 static const uint8_t i2c_addr = 0x69;
 
-static uint8_t ICACHE_FLASH_ATTR r8u(uint32_t id, uint8_t reg) {
+static uint8_t r8u(uint32_t id, uint8_t reg) {
     uint8_t ret;
 
     platform_i2c_send_start(id);
@@ -26,7 +26,7 @@ static uint8_t ICACHE_FLASH_ATTR r8u(uint32_t id, uint8_t reg) {
     return ret;
 }
 
-static void ICACHE_FLASH_ATTR w8u(uint32_t id, uint8_t reg, uint8_t val) {
+static void w8u(uint32_t id, uint8_t reg, uint8_t val) {
     platform_i2c_send_start(i2c_id);
     platform_i2c_send_address(i2c_id, i2c_addr, PLATFORM_I2C_DIRECTION_TRANSMITTER);
     platform_i2c_send_byte(i2c_id, reg);
@@ -34,19 +34,9 @@ static void ICACHE_FLASH_ATTR w8u(uint32_t id, uint8_t reg, uint8_t val) {
     platform_i2c_send_stop(i2c_id);
 }
 
-static int ICACHE_FLASH_ATTR l3g4200d_init(lua_State* L) {
-
-    uint32_t sda;
-    uint32_t scl;
+static int l3g4200d_setup(lua_State* L) {
     uint8_t  devid;
 
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
-
-    platform_i2c_setup(i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-    
     devid = r8u(i2c_id, 0xF);
 
     if (devid != 0xD3) {
@@ -58,7 +48,24 @@ static int ICACHE_FLASH_ATTR l3g4200d_init(lua_State* L) {
     return 0;
 }
 
-static int ICACHE_FLASH_ATTR l3g4200d_read(lua_State* L) {
+static int l3g4200d_init(lua_State* L) {
+
+    uint32_t sda;
+    uint32_t scl;
+
+    platform_print_deprecation_note("l3g4200d.init() is replaced by l3g4200d.setup()", "in the next version");
+
+    sda = luaL_checkinteger(L, 1);
+    scl = luaL_checkinteger(L, 2);
+
+    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
+
+    platform_i2c_setup(i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
+
+    return l3g4200d_setup(L);
+}
+
+static int l3g4200d_read(lua_State* L) {
 
     uint8_t data[6];
     int x,y,z;
@@ -91,6 +98,8 @@ static int ICACHE_FLASH_ATTR l3g4200d_read(lua_State* L) {
 
 static const LUA_REG_TYPE l3g4200d_map[] = {
     { LSTRKEY( "read" ),         LFUNCVAL( l3g4200d_read )},
+    { LSTRKEY( "setup" ),        LFUNCVAL( l3g4200d_setup )},
+    // init() is deprecated
     { LSTRKEY( "init" ),         LFUNCVAL( l3g4200d_init )},
     { LNILKEY, LNILVAL}
 };

--- a/docs/en/modules/adxl345.md
+++ b/docs/en/modules/adxl345.md
@@ -17,7 +17,9 @@ X,Y,Z data (integers)
 
 #### Example
 ```lua
-adxl345.init(1, 2)
+local sda, scl = 1, 2
+i2c.setup(0, sda, scl, i2c.SLOW)  -- call i2c.setup() only once
+adxl345.setup()
 local x,y,z = adxl345.read()
 print(string.format("X = %d, Y = %d, Z = %d", x, y, z))
 ```
@@ -25,12 +27,28 @@ print(string.format("X = %d, Y = %d, Z = %d", x, y, z))
 ## adxl345.init()
 Initializes the module and sets the pin configuration.
 
+!!! attention
+
+    This function is deprecated and will be removed in upcoming releases. Use `adxl345.setup()` instead.
+
 #### Syntax
 `adxl345.init(sda, scl)`
 
 #### Parameters
 - `sda` data pin
 - `scl` clock pin
+
+#### Returns
+`nil`
+
+## adxl345.setup()
+Initializes the module.
+
+#### Syntax
+`adxl345.setup()`
+
+#### Parameters
+None
 
 #### Returns
 `nil`

--- a/docs/en/modules/am2320.md
+++ b/docs/en/modules/am2320.md
@@ -9,6 +9,10 @@ This module provides access to the [AM2320](https://akizukidenshi.com/download/d
 ## am2320.init()
 Initializes the module and sets the pin configuration. Returns model, version, serial but is seams these where all zero on my model.
 
+!!! attention
+
+    This function is deprecated and will be removed in upcoming releases. Use `am2320.setup()` instead.
+
 #### Syntax
 `model, version, serial = am2320.init(sda, scl)`
 
@@ -35,9 +39,26 @@ Samples the sensor and returns the relative humidity in % and temperature in cel
 
 #### Example
 ```lua
-am2320.init(1, 2)
+sda, scl = 1, 2
+i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
+am2320.setup()
 rh, t = am2320.read()
 print(string.format("RH: %s%%", rh / 10))
 print(string.format("Temperature: %s degrees C", t / 10))
 ```
 
+## am2320.setup()
+Initializes the module. Returns model, version, serial but is seams these where all zero on my model.
+
+#### Syntax
+`model, version, serial = am2320.setup()`
+
+#### Parameters
+None
+
+#### Returns
+- `model`  16 bits number of model
+- `version`  8 bits version number
+- `serial`  32 bits serial number
+
+   Note: I have only observed values of 0 for all of these, maybe other sensors return more sensible readings.

--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -5,7 +5,7 @@
 
 This module provides a simple interface to [BME280/BMP280 temperature/air presssure/humidity sensors](http://www.bosch-sensortec.com/bst/products/all_products/bme280) (Bosch Sensortec).
 
-Note that you must call [`init()`](#bme280init) before you can start reading values!
+Note that you must call [`setup()`](#bme280setup) before you can start reading values!
 
 ## bme280.altitude()
 
@@ -69,13 +69,72 @@ none
 
 Initializes module. Initialization is mandatory before read values.
 
+!!! attention
+
+    This function is deprecated and will be removed in upcoming releases. Use `bme280.setup()` instead.
+
 #### Syntax
 
 `bme280.init(sda, scl, [temp_oss, press_oss, humi_oss, power_mode, inactive_duration, IIR_filter])`
 
 #### Parameters
-- `sda` - SDA pin  
-- `scl` - SCL pin
+See [`setup()`](#bme280setup).
+
+## bme280.qfe2qnh()
+
+For given altitude converts the air pressure to sea level air pressure.
+
+#### Syntax
+`bme280.qfe2qnh(P, altitude)`
+
+#### Parameters
+- `P` measured pressure
+- `altitude` altitude in meters of measurement point
+
+#### Returns  
+sea level pressure
+
+
+## bme280.read()
+
+Reads the sensor and returns the temperature, the air pressure, the air relative humidity and 
+
+#### Syntax
+`bme280.read([altitude])`
+
+#### Parameters
+- (optional) `altitude`- altitude in meters of measurement point. If provided also the air pressure converted to sea level air pressure is returned.
+
+#### Returns  
+- `T` temperature in celsius as an integer multiplied with 100
+- `P` air pressure in hectopascals multiplied by 1000
+- `H` relative humidity in percent multiplied by 1000
+- `QNH` air pressure in hectopascals multiplied by 1000 converted to sea level
+
+Any of these variables is `nil` if the readout of given measure was not successful.
+
+## bme280.startreadout()
+Starts readout (turns the sensor into forced mode). After the readout the sensor turns to sleep mode.
+
+#### Syntax
+`bme280.startreadout(delay, callback)`
+
+#### Parameters
+- `delay` sets sensor to forced mode and calls the `callback` (if provided) after given number of milliseconds. For 0 the default delay is set to 113ms (sufficient time to perform reading for oversampling settings 16x). For different oversampling setting please refer to [BME280 Final Datasheet - Appendix B: Measurement time and current calculation](http://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280_DS001-11.pdf#page=51).
+- `callback` if provided it will be invoked after given `delay`. The sensor reading should be finalized by then so.
+
+#### Returns  
+`nil`
+
+## bme280.setup()
+
+Initializes module. Initialization is mandatory before read values.
+
+#### Syntax
+
+`bme280.setup([temp_oss, press_oss, humi_oss, power_mode, inactive_duration, IIR_filter])`
+
+#### Parameters
 - (optional) `temp_oss` - Controls oversampling of temperature data. Default oversampling is 16x.
 - (optional) `press_oss` - Controls oversampling of pressure data. Default oversampling is 16x.
 - (optional) `humi_oss` - Controls oversampling of humidity data. Default oversampling is 16x
@@ -127,7 +186,9 @@ Using forced mode is recommended for applications which require low sampling rat
 ```lua
 alt=320 -- altitude of the measurement place
 
-bme280.init(3, 4)
+sda, scl = 3, 4
+i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
+bme280.setup()
 
 P, T = bme280.baro()
 print(string.format("QFE=%d.%03d", P/1000, P%1000))
@@ -157,7 +218,9 @@ Or simpler and more efficient
 ```lua
 alt=320 -- altitude of the measurement place
 
-bme280.init(3, 4)
+sda, scl = 3, 4
+i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
+bme280.setup()
 
 T, P, H, QNH = bme280.read(alt)
 local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
@@ -176,63 +239,19 @@ local curAltsgn = (curAlt < 0 and -1 or 1); curAlt = curAltsgn*curAlt
 print(string.format("altitude=%s%d.%02d", curAltsgn<0 and "-" or "", curAlt/100, curAlt%100))
 ```
 
-Use `bme280.init(sda, scl, 1, 3, 0, 3, 0, 4)` for "game mode" - Oversampling settings  pressure ×4, temperature ×1, humidity ×0, sensor mode: normal mode, inactive duration  = 0.5 ms, IIR filter settings  filter coefficient 16.
+Use `bme280.setup(1, 3, 0, 3, 0, 4)` for "game mode" - Oversampling settings  pressure ×4, temperature ×1, humidity ×0, sensor mode: normal mode, inactive duration  = 0.5 ms, IIR filter settings  filter coefficient 16.
 
 Example of readout in forced mode (asynchronous)
 ```lua
-bme280.init(3, 4, nil, nil, nil, 0) -- initialize to sleep mode
+sda, scl = 3, 4
+i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
+bme280.setup(nil, nil, nil, 0) -- initialize to sleep mode
 bme280.startreadout(0, function ()
   T, P = bme280.read()
   local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
   print(string.format("T=%s%d.%02d", Tsgn<0 and "-" or "", T/100, T%100))
 end)
 ```
-
-## bme280.qfe2qnh()
-
-For given altitude converts the air pressure to sea level air pressure.
-
-#### Syntax
-`bme280.qfe2qnh(P, altitude)`
-
-#### Parameters
-- `P` measured pressure
-- `altitude` altitude in meters of measurement point
-
-#### Returns  
-sea level pressure
-
-
-## bme280.read()
-
-Reads the sensor and returns the temperature, the air pressure, the air relative humidity and 
-
-#### Syntax
-`bme280.read([altitude])`
-
-#### Parameters
-- (optional) `altitude`- altitude in meters of measurement point. If provided also the air pressure converted to sea level air pressure is returned.
-
-#### Returns  
-- `T` temperature in celsius as an integer multiplied with 100
-- `P` air pressure in hectopascals multiplied by 1000
-- `H` relative humidity in percent multiplied by 1000
-- `QNH` air pressure in hectopascals multiplied by 1000 converted to sea level
-
-Any of these variables is `nil` if the readout of given measure was not successful.
-
-## bme280.startreadout()
-Starts readout (turns the sensor into forced mode). After the readout the sensor turns to sleep mode.
-
-#### Syntax
-`bme280.startreadout(delay, callback)`
-
-#### Parameters
-- `delay` sets sensor to forced mode and calls the `callback` (if provided) after given number of milliseconds. For 0 the default delay is set to 113ms (sufficient time to perform reading for oversampling settings 16x). For different oversampling setting please refer to [BME280 Final Datasheet - Appendix B: Measurement time and current calculation](http://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280_DS001-11.pdf#page=51).
-- `callback` if provided it will be invoked after given `delay`. The sensor reading should be finalized by then so.
-
-#### Returns  
-`nil`
 
 ## bme280.temp()
 

--- a/docs/en/modules/bmp085.md
+++ b/docs/en/modules/bmp085.md
@@ -9,12 +9,28 @@ This module provides access to the [BMP085](https://www.sparkfun.com/tutorials/2
 ## bmp085.init()
 Initializes the module and sets the pin configuration.
 
+!!! attention
+
+    This function is deprecated and will be removed in upcoming releases. Use `bmp085.setup()` instead.
+
 #### Syntax
 `bmp085.init(sda, scl)`
 
 #### Parameters
 - `sda` data pin
 - `scl` clock pin
+
+#### Returns
+`nil`
+
+## bmp085.setup()
+Initializes the module.
+
+#### Syntax
+`bmp085.setup()`
+
+#### Parameters
+None
 
 #### Returns
 `nil`
@@ -30,7 +46,9 @@ temperature multiplied with 10 (integer)
 
 #### Example
 ```lua
-bmp085.init(1, 2)
+local sda, scl = 1, 2
+i2c.setup(0, sda, scl, i2c.SLOW)
+bmp085.setup()
 local t = bmp085.temperature()
 print(string.format("Temperature: %s.%s degrees C", t / 10, t % 10))
 ```
@@ -53,7 +71,9 @@ pressure in pascals (integer)
 
 #### Example
 ```lua
-bmp085.init(1, 2)
+local sda, scl = 1, 2
+i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
+bmp085.setup()
 local p = bmp085.pressure()
 print(string.format("Pressure: %s.%s mbar", p / 100, p % 100))
 ```

--- a/docs/en/modules/hmc5883l.md
+++ b/docs/en/modules/hmc5883l.md
@@ -18,7 +18,9 @@ temperature multiplied with 10 (integer)
 
 #### Example
 ```lua
-hmc58831.init(1, 2)
+local sda, scl = 1, 2
+i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
+hmc58831.setup()
 local x,y,z = hmc5883l.read()
 print(string.format("x = %d, y = %d, z = %d", x, y, z))
 ```
@@ -26,12 +28,28 @@ print(string.format("x = %d, y = %d, z = %d", x, y, z))
 ## hmc5883l.init()
 Initializes the module and sets the pin configuration.
 
+!!! attention
+
+    This function is deprecated and will be removed in upcoming releases. Use `hmc5883l.setup()` instead.
+
 #### Syntax
 `hmc5883l.init(sda, scl)`
 
 #### Parameters
 - `sda` data pin
 - `scl` clock pin
+
+#### Returns
+`nil`
+
+## hmc5883l.setup()
+Initializes the module.
+
+#### Syntax
+`hmc5883l.setup()`
+
+#### Parameters
+None
 
 #### Returns
 `nil`

--- a/docs/en/modules/l3g4200d.md
+++ b/docs/en/modules/l3g4200d.md
@@ -17,7 +17,9 @@ X,Y,Z gyroscope output
 
 #### Example
 ```lua
-l3g4200d.init(1, 2)
+local sda, scl = 1, 2
+i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
+l3g4200d.setup()
 local x,y,z = l3g4200d.read()
 print(string.format("X = %d, Y = %d, Z = %d", x, y, z)
 ```
@@ -25,12 +27,28 @@ print(string.format("X = %d, Y = %d, Z = %d", x, y, z)
 ## l3g4200d.init()
 Initializes the module and sets the pin configuration.
 
+!!! attention
+
+    This function is deprecated and will be removed in upcoming releases. Use `l3g4200d.setup()` instead.
+
 #### Syntax
 `l3g4200d.init(sda, scl)`
 
 #### Parameters
 - `sda` data pin
 - `scl` clock pin
+
+#### Returns
+`nil`
+
+## l3g4200d.setup()
+Initializes the module.
+
+#### Syntax
+`l3g4200d.setup()`
+
+#### Parameters
+None
 
 #### Returns
 `nil`


### PR DESCRIPTION
Fixes #1845.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Having the I2C configuration included in the modules' init functions is an issue for a shared bus. In worst case it prevents coexistence with other I2C slaves on the same bus:
- adxl345.c @jschmidlapp
- am2320.c @hvegh
- bme280.c @vsky279
- bmp085.c @kbeckmann
- hmc5883l.c @jschmidlapp
- l3g4200d.c @jschmidlapp

This PR introduces a `setup()` function for each listed module which performs the core hardware initialization and avoids any (re) configuration of the I2C bus. The existing `init()` function is kept and tagged as deprecated with planned removal in (one of) the next master drop.

I don't have any of the sensors on my desk - my verification is therefore restricted to compilation and basic call tests. Tagged the related originators / maintainers of the modules, please double check the changes on real hardware.
