### PR TITLE
Update wifi event monitor documentation

### DIFF
--- a/app/modules/wifi_eventmon.c
+++ b/app/modules/wifi_eventmon.c
@@ -63,6 +63,8 @@ static void wifi_status_cb(int arg)
 // wifi.sta.eventMonReg()
 int wifi_station_event_mon_reg(lua_State* L)
 {
+  platform_print_deprecation_note("wifi.sta.eventmonreg() is replaced by wifi.eventmon.register()", "in the next version");
+
   uint8 id=(uint8)luaL_checknumber(L, 1);
   if ((id > 5)) // verify user specified a valid wifi status
   {

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -399,7 +399,7 @@ none
 Registers callbacks for WiFi station status events.
 
 !!! note
-    Please update your program to use the [`wifi.eventmon`](#wifieventmon-module) API, as the `wifi.sta.eventmon___()` API is to be depreciated. 
+    Please update your program to use the [`wifi.eventmon`](#wifieventmon-module) API, as the `wifi.sta.eventmon___()` API is deprecated. 
 
 ####  Syntax
 - `wifi.sta.eventMonReg(wifi_status[, function([previous_state])])`

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -398,8 +398,8 @@ none
 
 Registers callbacks for WiFi station status events.
 
-  !!! Note
-   Please update your program to use the [`wifi.eventmon`](#wifieventmon-module) API, as the `wifi.sta.eventmon___()` API is to be depreciated. 
+!!! note
+    Please update your program to use the [`wifi.eventmon`](#wifieventmon-module) API, as the `wifi.sta.eventmon___()` API is to be depreciated. 
 
 ####  Syntax
 - `wifi.sta.eventMonReg(wifi_status[, function([previous_state])])`
@@ -1377,7 +1377,7 @@ Register/unregister callbacks for WiFi event monitor.
  - After a callback is registered, this function may be called to update a callback's function at any time
 
 !!! note
-	To ensure all WiFi events are caught, the Wifi event monitor callbacks should be registered as early as possible in `init.lua`. Any events that occur before callbacks are registered will be discarded!
+    To ensure all WiFi events are caught, the Wifi event monitor callbacks should be registered as early as possible in `init.lua`. Any events that occur before callbacks are registered will be discarded!
 
 #### Syntax
 wifi.eventmon.register(Event[, function(T)])

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -398,6 +398,9 @@ none
 
 Registers callbacks for WiFi station status events.
 
+  !!! Note
+   Please update your program to use the [`wifi.eventmon`](#wifieventmon-module) API, as the `wifi.sta.eventmon___()` API is to be depreciated. 
+
 ####  Syntax
 - `wifi.sta.eventMonReg(wifi_status[, function([previous_state])])`
 
@@ -1371,6 +1374,10 @@ Note: The functions `wifi.sta.eventMon___()` and `wifi.eventmon.___()` are compl
 ## wifi.eventmon.register()
 
 Register/unregister callbacks for WiFi event monitor.
+ - After a callback is registered, this function may be called to update a callback's function at any time
+
+!!! note
+	To ensure all WiFi events are caught, the Wifi event monitor callbacks should be registered as early as possible in `init.lua`. Any events that occur before callbacks are registered will be discarded!
 
 #### Syntax
 wifi.eventmon.register(Event[, function(T)])


### PR DESCRIPTION
Update wifi event monitor documentation.

Fixes #1737.

- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] This PR is for the `dev` branch rather than for `master`.

A lack of information about when the wifi event monitor callbacks should be registered is causing confusion, the new information provided should help to clarify the function of the event monitor .