### PR TITLE
Fix for for errors in documentation added with PR #1231

### DIFF
--- a/docs/en/modules/node.md
+++ b/docs/en/modules/node.md
@@ -128,9 +128,9 @@ node.dsleep(nil,4)
 ```
 
 #### See also
-[`wifi.suspend()`](wifi.md#wifisuspend)
-[`wifi.resume()`](wifi.md#wifiresume)
-[`node.sleep()`](#nodesleep)
+- [`wifi.suspend()`](wifi.md#wifisuspend)
+- [`wifi.resume()`](wifi.md#wifiresume)
+- [`node.sleep()`](#nodesleep)
 
 ## node.flashid()
 
@@ -387,9 +387,9 @@ Put NodeMCU in light sleep mode to reduce current consumption.
 ```
 
 #### See also
-[`wifi.suspend()`](wifi.md#wifisuspend)
-[`wifi.resume()`](wifi.md#wifiresume)
-[`node.dsleep()`](#nodedsleep)
+- [`wifi.suspend()`](wifi.md#wifisuspend)
+- [`wifi.resume()`](wifi.md#wifiresume)
+- [`node.dsleep()`](#nodedsleep)
 
 ## node.stripdebug()
 

--- a/docs/en/modules/tmr.md
+++ b/docs/en/modules/tmr.md
@@ -209,9 +209,9 @@ tmr.resume(mytimer)
 
 ```
 #### See also
-[`tmr.suspend()`](#tmrsuspend)
-[`tmr.suspend_all()`](#tmrsuspendall)
-[`tmr.resume_all()`](#tmrresumeall)
+- [`tmr.suspend()`](#tmrsuspend)
+- [`tmr.suspend_all()`](#tmrsuspendall)
+- [`tmr.resume_all()`](#tmrresumeall)
 
 ## tmr.resume_all()
 
@@ -235,9 +235,9 @@ tmr.resume_all()
 
 ```
 #### See also
-[`tmr.suspend()`](#tmrsuspend)
-[`tmr.suspend_all()`](#tmrsuspendall)
-[`tmr.resume()`](#tmrresume)
+- [`tmr.suspend()`](#tmrsuspend)
+- [`tmr.suspend_all()`](#tmrsuspendall)
+- [`tmr.resume()`](#tmrresume)
 
 ## tmr.softwd()
 
@@ -362,9 +362,9 @@ tmr.suspend(mytimer)
 
 ```
 #### See also
-[`tmr.suspend_all()`](#tmrsuspendall)
-[`tmr.resume()`](#tmrresume)
-[`tmr.resume_all()`](#tmrresumeall)
+- [`tmr.suspend_all()`](#tmrsuspendall)
+- [`tmr.resume()`](#tmrresume)
+- [`tmr.resume_all()`](#tmrresumeall)
 
 
 ## tmr.suspend_all()
@@ -392,9 +392,9 @@ tmr.suspend_all()
 
 ```
 #### See also
-[`tmr.suspendl()`](#tmrsuspend)
-[`tmr.resume()`](#tmrresume)
-[`tmr.resume_all()`](#tmrresumeall)
+- [`tmr.suspendl()`](#tmrsuspend)
+- [`tmr.resume()`](#tmrresume)
+- [`tmr.resume_all()`](#tmrresumeall)
 
 
 ## tmr.time()

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -101,9 +101,9 @@ wifi.resume(function() print("WiFi resume") end)
 ```
 
 #### See also
-[`wifi.suspend()`](#wifisuspend)
-[`node.sleep()`](node.md#nodesleep)
-[`node.dsleep()`](node.md#nodedsleep)
+- [`wifi.suspend()`](#wifisuspend)
+- [`node.sleep()`](node.md#nodesleep)
+- [`node.dsleep()`](node.md#nodedsleep)
 
 ## wifi.setmode()
 
@@ -304,9 +304,9 @@ print(wifi.suspend())
 ```
 
 #### See also
-[`wifi.resume()`](#wifiresume)
-[`node.sleep()`](node.md#nodesleep)
-[`node.dsleep()`](node.md#nodedsleep)
+- [`wifi.resume()`](#wifiresume)
+- [`node.sleep()`](node.md#nodesleep)
+- [`node.dsleep()`](node.md#nodedsleep)
 
 # wifi.sta Module
 


### PR DESCRIPTION
Fixes errors in documentation mentioned in PR [#1231](https://github.com/nodemcu/nodemcu-firmware/pull/1231#issuecomment-291747921) .

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] The code changes are reflected in the documentation at `docs/en/*`.

When writing the documentation for the functions added with PR#1231, I had forgotten to properly format the "See also" sections for each of the added functions. This PR fixes those formatting errors.