### PR TITLE
Update wifi suspend documentation

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -4,8 +4,7 @@
 | 2015-05-12 | [Zeroday](https://github.com/funshine) | [dnc40085](https://github.com/dnc40085) | [wifi.c](../../../app/modules/wifi.c)|
 
 !!! important
-The wifi subsystem is maintained by background tasks that must run periodically, any function or task that takes longer than 15 ms (miliseconds) may cause the wifi subsystem to crash.
-To avoid these potential crashes, it is advised that the wifi subsystem be suspended with wifi.suspend() prior to the execution of any tasks or functions that exceed this 15 ms guideline.
+	The WiFi subsystem is maintained by background tasks that must run periodically. Any function or task that takes longer than 15ms (milliseconds) may cause the WiFi subsystem to crash. To avoid these potential crashes, it is advised that the WiFi subsystem be suspended with [wifi.suspend()](#wifisuspend) prior to the execution of any tasks or functions that exceed this 15ms guideline.
 
 
 The NodeMCU WiFi control is spread across several tables:

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -3,6 +3,11 @@
 | :----- | :-------------------- | :---------- | :------ |
 | 2015-05-12 | [Zeroday](https://github.com/funshine) | [dnc40085](https://github.com/dnc40085) | [wifi.c](../../../app/modules/wifi.c)|
 
+!!! important
+The wifi subsystem is maintained by background tasks that must run periodically, any function or task that takes longer than 15 ms (miliseconds) may cause the wifi subsystem to crash.
+To avoid these potential crashes, it is advised that the wifi subsystem be suspended with wifi.suspend() prior to the execution of any tasks or functions that exceed this 15 ms guideline.
+
+
 The NodeMCU WiFi control is spread across several tables:
 
 - `wifi` for overall WiFi configuration
@@ -77,6 +82,10 @@ The current physical mode as one of `wifi.PHYMODE_B`, `wifi.PHYMODE_G` or `wifi.
 ## wifi.resume()
 
 Wake up WiFi from suspended state or cancel pending wifi suspension
+
+!!! note
+   Wifi resume occurs asynchronously, this means that the resume request will only be processed when control of the processor is passed back to the SDK (after MyResumeFunction() has completed)
+   The resume callback also occurs asynchronously and will only execute after wifi has resumed normal operation. 
 
 #### Syntax
 `wifi.resume([resume_cb])`
@@ -257,7 +266,10 @@ none
 
 Suspend Wifi to reduce current consumption. 
 
-This function is also useful for preventing WiFi stack related crashes when executing functions or tasks that take longer than ~500ms 
+!!! note
+   Wifi suspension occurs asynchronously, this means that the suspend request will only be processed when control of the processor is passed back to the SDK (after MySuspendFunction() has completed)
+   The suspend callback also occurs asynchronously and will only execute after wifi has been successfully been suspended. 
+
 
 #### Syntax
 `wifi.suspend({duration[, suspend_cb, resume_cb, preserve_mode]})`


### PR DESCRIPTION
This PR adds additional documentation to wifi module [suggested by @TerryE](https://github.com/nodemcu/nodemcu-firmware/pull/1231#issuecomment-291847159) in PR #1231

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).

The extension developer FAQ has a section that warns the developer about the potential for the wifi subsystem to crash when executing functions that occupy the processor for longer than ~15ms. This PR adds this info to the wifi module documentation.