### PR TITLE
Fix admonition formatting error in wifi module docs added with #1910

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -79,10 +79,11 @@ The current physical mode as one of `wifi.PHYMODE_B`, `wifi.PHYMODE_G` or `wifi.
 [`wifi.setphymode()`](#wifisetphymode)
 
 ## wifi.resume()
-Wake up WiFi from suspended state or cancel pending wifi suspension
+
+Wake up WiFi from suspended state or cancel pending wifi suspension.
 
 !!! note
-   Wifi resume occurs asynchronously, this means that the resume request will only be processed when control of the processor is passed back to the SDK (after MyResumeFunction() has completed). The resume callback also occurs asynchronously and will only execute after wifi has resumed normal operation. 
+	Wifi resume occurs asynchronously, this means that the resume request will only be processed when control of the processor is passed back to the SDK (after MyResumeFunction() has completed). The resume callback also executes asynchronously and will only execute after wifi has resumed normal operation. 
 
 #### Syntax
 `wifi.resume([resume_cb])`
@@ -263,7 +264,7 @@ none
 Suspend Wifi to reduce current consumption. 
 
 !!! note
-   Wifi suspension occurs asynchronously, this means that the suspend request will only be processed when control of the processor is passed back to the SDK (after MySuspendFunction() has completed). The suspend callback also occurs asynchronously and will only execute after wifi has been successfully been suspended. 
+	Wifi suspension occurs asynchronously, this means that the suspend request will only be processed when control of the processor is passed back to the SDK (after MySuspendFunction() has completed). The suspend callback also executes asynchronously and will only execute after wifi has been successfully been suspended. 
 
 
 #### Syntax

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -79,12 +79,10 @@ The current physical mode as one of `wifi.PHYMODE_B`, `wifi.PHYMODE_G` or `wifi.
 [`wifi.setphymode()`](#wifisetphymode)
 
 ## wifi.resume()
-
 Wake up WiFi from suspended state or cancel pending wifi suspension
 
 !!! note
-   Wifi resume occurs asynchronously, this means that the resume request will only be processed when control of the processor is passed back to the SDK (after MyResumeFunction() has completed)
-   The resume callback also occurs asynchronously and will only execute after wifi has resumed normal operation. 
+   Wifi resume occurs asynchronously, this means that the resume request will only be processed when control of the processor is passed back to the SDK (after MyResumeFunction() has completed). The resume callback also occurs asynchronously and will only execute after wifi has resumed normal operation. 
 
 #### Syntax
 `wifi.resume([resume_cb])`
@@ -262,12 +260,10 @@ none
 [`wifi.startsmart()`](#wifistartsmart)
 
 ## wifi.suspend()
-
 Suspend Wifi to reduce current consumption. 
 
 !!! note
-   Wifi suspension occurs asynchronously, this means that the suspend request will only be processed when control of the processor is passed back to the SDK (after MySuspendFunction() has completed)
-   The suspend callback also occurs asynchronously and will only execute after wifi has been successfully been suspended. 
+   Wifi suspension occurs asynchronously, this means that the suspend request will only be processed when control of the processor is passed back to the SDK (after MySuspendFunction() has completed). The suspend callback also occurs asynchronously and will only execute after wifi has been successfully been suspended. 
 
 
 #### Syntax


### PR DESCRIPTION
Fixes documentation error introduced with PR #1910
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).

I discovered an additional error in the admonition formatting for the functions wifi.suspend() and wifi.resume()