### PR TITLE
ESP32: Use fwrite() instead of printf() for printing strings from Lua.

### DIFF
--- a/components/lua/luaconf.h
+++ b/components/lua/luaconf.h
@@ -331,7 +331,7 @@ extern int readline4lua(const char *prompt, char *buffer, int length);
 ** avoids including 'stdio.h' everywhere.)
 */
 #if !defined(LUA_USE_STDIO)
-#define luai_writestring(s, l)  printf(s)
+#define luai_writestring(s, l)  fputs(s, stdout)
 #define luai_writeline()        puts("")
 #endif // defined(LUA_USE_STDIO)
 

--- a/components/lua/luaconf.h
+++ b/components/lua/luaconf.h
@@ -331,7 +331,7 @@ extern int readline4lua(const char *prompt, char *buffer, int length);
 ** avoids including 'stdio.h' everywhere.)
 */
 #if !defined(LUA_USE_STDIO)
-#define luai_writestring(s, l)  fputs(s, stdout)
+#define luai_writestring(s, l)  fwrite(s, 1, l, stdout)
 #define luai_writeline()        puts("")
 #endif // defined(LUA_USE_STDIO)
 


### PR DESCRIPTION
Fixes #1914.

Title says all.
Johny, please check whether this is an acceptable fix.
