### PR TITLE
ESP32: Establish flushing of uart to leverage buffering putchar().

### DIFF
--- a/components/base_nodemcu/uart.c
+++ b/components/base_nodemcu/uart.c
@@ -131,6 +131,7 @@ static int uart_write( lua_State* L )
       if( len > 255 )
         return luaL_error( L, "invalid number" );
       platform_uart_send( id, (uint8_t)len );
+      platform_uart_flush( id );
     }
     else
     {
@@ -138,6 +139,7 @@ static int uart_write( lua_State* L )
       buf = lua_tolstring( L, s, &len );
       for( i = 0; i < len; i ++ )
         platform_uart_send( id, buf[ i ] );
+      platform_uart_flush( id );
     }
   }
   return 0;

--- a/components/platform/include/platform.h
+++ b/components/platform/include/platform.h
@@ -72,6 +72,7 @@ enum
 static inline int platform_uart_exists( unsigned id ) { return id < NUM_UART; }
 uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int parity, int stopbits );
 void platform_uart_send( unsigned id, uint8_t data );
+void platform_uart_flush( unsigned id );
 int platform_uart_set_flow_control( unsigned id, int type );
 
 

--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -68,6 +68,12 @@ void platform_uart_send( unsigned id, uint8_t data )
     putchar (data);
 }
 
+void platform_uart_flush( unsigned id )
+{
+  if (id == CONSOLE_UART)
+    fflush (stdout);
+}
+
 // *****************************************************************************
 // Sigma-Delta platform interface
 


### PR DESCRIPTION
I observed that `uart.write()` seems to be lagging behind when the provided string is not terminated by a newline character. You need to write a lot of data until it's finally sent to through the UART. This broke e.g. the upload functionality of ESPlorer.

The underlying root cause for this change in behavior appears to the buffering attempts of `putchar()` which is now used in `platform_uart_send()` to forward the characters. Reminded me of the good ole days of Unix coding, banging my head against the terminal because the output won't show up 🙄 

Well, this PR introduces `platform_uart_flush()` function to push the output onto the wire.
