### PR TITLE
Expose UART 1

### DIFF
--- a/app/platform/cpu_esp8266.h
+++ b/app/platform/cpu_esp8266.h
@@ -11,7 +11,7 @@
 // Number of resources (0 if not available/not implemented)
 #define NUM_GPIO              GPIO_PIN_NUM
 #define NUM_SPI               2
-#define NUM_UART              1
+#define NUM_UART              2
 #define NUM_PWM               GPIO_PIN_NUM
 #define NUM_ADC               1
 #define NUM_CAN               0

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -33,7 +33,7 @@ Sets the callback function to handle UART events.
 Currently only the "data" event is supported.
 
 !!! note 
-	Due to limitations of the ESP8266, only UART 0 is capable of recieving data.  
+	Due to limitations of the ESP8266, only UART 0 is capable of receiving data.  
 
 #### Syntax
 `uart.on(method, [number/end_char], [function], [run_input])`

--- a/docs/en/modules/uart.md
+++ b/docs/en/modules/uart.md
@@ -7,6 +7,10 @@ The [UART](https://en.wikipedia.org/wiki/Universal_asynchronous_receiver/transmi
 
 The default setup for the uart is controlled by build-time settings. The default rate is 115,200 bps. In addition, auto-baudrate detection is enabled for the first two minutes
 after platform boot. This will cause a switch to the correct baud rate once a few characters are received. Auto-baudrate detection is disabled when `uart.setup` is called.
+
+!!! important
+	Although there are two UARTs(0 and 1) available to NodeMCU, **UART 1 is not capable of receiving data and is therefore transmit only**.
+	
 ## uart.alt()
 Change UART pin assignment.
 
@@ -27,6 +31,9 @@ Change UART pin assignment.
 Sets the callback function to handle UART events.
 
 Currently only the "data" event is supported.
+
+!!! note 
+	Due to limitations of the ESP8266, only UART 0 is capable of recieving data.  
 
 #### Syntax
 `uart.on(method, [number/end_char], [function], [run_input])`
@@ -77,7 +84,7 @@ end, 0)
 `uart.setup(id, baud, databits, parity, stopbits[, echo])`
 
 #### Parameters
-- `id` always zero, only one uart supported
+- `id` UART id (0 or 1).
 - `baud` one of 300, 600, 1200, 2400, 4800, 9600, 19200, 31250, 38400, 57600, 74880, 115200, 230400, 256000, 460800, 921600, 1843200, 3686400
 - `databits` one of 5, 6, 7, 8
 - `parity` `uart.PARITY_NONE`, `uart.PARITY_ODD`, or `uart.PARITY_EVEN`
@@ -101,7 +108,7 @@ Returns the current configuration parameters of the UART.
 `uart.getconfig(id)`
 
 #### Parameters
-- `id` always zero, only one uart supported
+- `id` UART id (0 or 1).
 
 #### Returns
 Four values as follows:
@@ -127,7 +134,7 @@ Write string or byte to the UART.
 `uart.write(id, data1 [, data2, ...])`
 
 #### Parameters
-- `id` always 0, only one UART supported
+- `id` UART id (0 or 1).
 - `data1`... string or byte to send via UART
 
 #### Returns


### PR DESCRIPTION
Fixes #1907 .

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

The ESP8266 has two hardware UARTs available, unfortunately the second UART is transmit only due to the fact that the receive pin is shared with one of the flash data lines (SD_D1 to be specific), the UART 1 Tx pin however is unused and available for use.