### PR TITLE
Add deprecation message to wifi.sta.config() for argument style cfg

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -836,6 +836,8 @@ static int wifi_station_config( lua_State* L )
   }
   else //to be deprecated
   {
+    platform_print_deprecation_note("Argument style station configuration is replaced by table style station configuration", "in the next version");
+
     const char *ssid = luaL_checklstring( L, 1, &sl );
     luaL_argcheck(L, (sl>=0 && sl<sizeof(sta_conf.ssid)), 1, "length:0-32"); /* Zero-length SSID is valid as a way to clear config */
 


### PR DESCRIPTION
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.

The documentation for the old(argument) style of station configuration was removed in a previous PR, but at the time the function `platform_print_deprecation_note()` did not exist, so I wasn't able to add a message informing of the removal.

Now that the function exists, I decided it was time to add a deprecation message to inform the developer of the upcoming removal the argument style of station configuration.