### PR TITLE
ESP32: API compatibility layer

### DIFF
--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -6,6 +6,10 @@
 ws2812 is a library to handle ws2812-like led strips.
 It works at least on WS2812, WS2812b, APA104, SK6812 (RGB or RGBW).
 
+!!! note
+
+    The API on ESP32 differs from the API on ESP8266. For backwards compatibility please refer to [`lua_compat/ws2812_compat.lua`](../../../lua_compat/ws2812_compat.lua`).
+
 ## ws2812.write()
 Send data to up to 8 led strip using its native format which is generally Green,Red,Blue for RGB strips and Green,Red,Blue,White for RGBW strips.
 

--- a/lua_compat/ws2812_compat.lua
+++ b/lua_compat/ws2812_compat.lua
@@ -1,0 +1,74 @@
+-- ****************************************************************************
+--
+-- Compatability wrapper for mapping ESP8266's ws2812 module API to ESP32
+--
+-- Usage:
+--
+--   ws2812 = require("ws2812_compat")(pin_strip1[, pin_strip2])
+--
+--     pin_strip1: GPIO pin of first led strip, mandatory
+--     pin_strip2: GPIO pin of second led strip, optional
+--
+-- ****************************************************************************
+
+local M = {}
+
+local _pin_strip1, _pin_strip2
+local _mode
+
+local _ws2812
+
+
+-- ****************************************************************************
+-- Implement esp8266 compatability API
+--
+function M.init(mode)
+  if _pin_strip1 == nil then
+    error("gpio for data1 undefined")
+  end
+
+  if _pin_strip2 == nil and mode == M.MODE_DUAL then
+    error("gpio for data2 undefined")
+  end
+
+  _mode = mode or M.MODE_SINGLE
+end
+
+function M.write(data1, data2)
+  if _mode == nil then
+    error("call init() first")
+  end
+
+  local strip1 = {pin = _pin_strip1, data = data1}
+  local strip2
+
+  if _pin_strip2 and data2 then
+    strip2 = {pin = _pin_strip2, data = data2}
+  end
+
+  _ws2812.write(strip1, strip2)
+end
+
+return function (pin_strip1, pin_strip2)
+  -- cache built-in module
+  _ws2812 = ws2812
+  -- invalidate built-in module
+  ws2812 = nil
+
+  -- forward unchanged functions
+  M.newBuffer = _ws2812.newBuffer
+
+  -- forward constant definitions
+  M.FADE_IN        = _ws2812.FADE_IN
+  M.FADE_OUT       = _ws2812.FADE_OUT
+  M.MODE_SINGLE    = 0   -- encoding from ws2812.c
+  M.MODE_DUAL      = 1   -- encoding from ws2812.c
+  M.SHIFT_LOGICAL  = _ws2812.SHIFT_LOGICAL
+  M.SHIFT_CIRCULAR = _ws2812.SHIFT_CIRCULAR
+
+  _pin_strip1 = pin_strip1
+  _pin_strip2 = pin_strip2
+
+  return M
+end
+


### PR DESCRIPTION
Working on the SPI API for ESP32 over at #1617 triggered me to follow up on the topic of backwards compatibility to ESP8266 more thoroughly.

Previous modules which I ported had just "slight" changes in the API, but this one will turn things upside down if all hardware features are to be made available to Lua layer. Alternatively, full backwards compatibility would hide almost all of these great improvements that Espressif planted into their hardware. I opted for the features when designing the API, against legacy support. With the SPI module being a typical driver function and many user scripts base on it, this decision will probably trash a lot of existing Lua code.

In this PR I'd like to present a generic solution for this dilemma and achieve a common conclusion which can be used as a template.

Intention: For a given module `xyz`, an additional Lua module `xyz_compat` is provided that maps the ESP8266 API of `xyz` onto its ESP32 counterpart (depending on technical/functional aspects).
- The `xyz_compat` module eclipses the built-in `xyz` module completely.
- After loading the `xyz_compat` module, existing scripts for ESP8266 can be executed without further modifications.
- Only functions, constants, etc. of the ESP8266 API are provided.
- Mixed use of ESP8266 and ESP32 API is not supported.

This PR provides the `ws2812_compat` module. Please review the implementation and give feedback on this approach, both technically and from an organizational point of view.
