### PR TITLE
Update init.lua example to use new wifi.sta.config() implementation

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -1504,7 +1504,7 @@ T: Table returned by event.
 - `wifi.eventmon.STA_DISCONNECTED`: Station was disconnected from access point.  
 	- `SSID`: SSID of access point.  
 	- `BSSID`: BSSID of access point.  
-	- `REASON`: See [wifi.eventmon.reason](#wifieventmonreason) below.  
+	- `reason`: See [wifi.eventmon.reason](#wifieventmonreason) below.  
 - `wifi.eventmon.STA_AUTHMODE_CHANGE`: Access point has changed authorization mode.    
 	- `old_auth_mode`: Old wifi authorization mode.  
 	- `new_auth_mode`: New wifi authorization mode.  

--- a/docs/en/upload.md
+++ b/docs/en/upload.md
@@ -59,7 +59,7 @@ end
 -- Define WiFi station event callbacks 
 wifi_connect_event = function(T) 
   print("Connection to AP("..T.SSID..") established!")
-  print("Wating for ip...") 
+  print("Waiting for ip...") 
 end
 
 wifi_got_ip_event = function(T) 
@@ -70,6 +70,10 @@ wifi_got_ip_event = function(T)
 end
 
 wifi_disconnect_event = function(T)
+  if T.reason == wifi.eventmon.reason.ASSOC_LEAVE then 
+    --the station has disassociated from a previously connected AP
+    return 
+  end
   local retry_ct = 3
   print("WiFi connection to AP("..T.SSID..") has failed!")
   print("Disconnect reason:"..T.reason)

--- a/docs/en/upload.md
+++ b/docs/en/upload.md
@@ -59,10 +59,13 @@ end
 -- Define WiFi station event callbacks 
 wifi_connect_event = function(T) 
   print("Connection to AP("..T.SSID..") established!")
-  print("Waiting for ip...") 
+  print("Waiting for IP address...")
+  if disconnect_ct ~= nil then disconnect_ct = nil end  
 end
 
 wifi_got_ip_event = function(T) 
+  -- Note: Having an ip address does not mean there is internet access!
+  -- Internet connectivity can be determined with net.dns.resolve().    
   print("Wifi connection is ready! IP address is: "..T.IP)
   print("Startup will resume momentarily, you have 3 seconds to abort.")
   print("Waiting...") 
@@ -75,16 +78,14 @@ wifi_disconnect_event = function(T)
     return 
   end
   -- total_tries: how many times the station will attempt to connect to the AP.
-  local total_tries = 3
-  local reason_string=""
+  local total_tries = 75
   print("\nWiFi connection to AP("..T.SSID..") has failed!")
 
   --There are many possible disconnect reasons, the following iterates through 
   --the list and returns the string corresponding to the disconnect reason.
   for key,val in pairs(wifi.eventmon.reason) do
     if val == T.reason then
-      print("Disconnect reason:"..T.reason.."("..key..")")
-      reason_string=key
+      print("Disconnect reason:"..val.."("..key..")")
       break
     end
   end
@@ -99,7 +100,7 @@ wifi_disconnect_event = function(T)
   else
     wifi.sta.disconnect()
     print("Aborting connection to AP!")
-    disconnect_ct=nil  
+    disconnect_ct = nil  
   end
 end
 
@@ -114,8 +115,6 @@ wifi.sta.config({ssid=SSID, pwd=PASSWORD, save=true})
 -- wifi.sta.connect() not necessary because config() uses auto-connect=true by default
 
 ```
-
-Inspired by [https://github.com/ckuehnel/NodeMCU-applications](https://github.com/ckuehnel/NodeMCU-applications)
 
 # Compiling Lua on your PC for Uploading
 

--- a/docs/en/upload.md
+++ b/docs/en/upload.md
@@ -74,19 +74,31 @@ wifi_disconnect_event = function(T)
     --the station has disassociated from a previously connected AP
     return 
   end
-  local retry_ct = 3
-  print("WiFi connection to AP("..T.SSID..") has failed!")
-  print("Disconnect reason:"..T.reason)
+  -- total_tries: how many times the station will attempt to connect to the AP.
+  local total_tries = 3
+  local reason_string=""
+  print("\nWiFi connection to AP("..T.SSID..") has failed!")
+
+  --There are many possible disconnect reasons, the following iterates through 
+  --the list and returns the string corresponding to the disconnect reason.
+  for key,val in pairs(wifi.eventmon.reason) do
+    if val == T.reason then
+      print("Disconnect reason:"..T.reason.."("..key..")")
+      reason_string=key
+      break
+    end
+  end
+
   if disconnect_ct == nil then 
     disconnect_ct = 1 
   else
     disconnect_ct = disconnect_ct + 1 
   end
-  if disconnect_ct < retry_ct then 
-    print("Retrying connection...(attempt "..(disconnect_ct+1).." of "..retry_ct..")")
+  if disconnect_ct < total_tries then 
+    print("Retrying connection...(attempt "..(disconnect_ct+1).." of "..total_tries..")")
   else
     wifi.sta.disconnect()
-    print("Aborting Connection to AP("..T.SSID..")")
+    print("Aborting connection to AP!")
     disconnect_ct=nil  
   end
 end
@@ -100,6 +112,7 @@ print("Connecting to WiFi access point...")
 wifi.setmode(wifi.STATION)
 wifi.sta.config({ssid=SSID, pwd=PASSWORD, save=true})
 -- wifi.sta.connect() not necessary because config() uses auto-connect=true by default
+
 ```
 
 Inspired by [https://github.com/ckuehnel/NodeMCU-applications](https://github.com/ckuehnel/NodeMCU-applications)


### PR DESCRIPTION
Fixes #1951 .

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

When I updated the function `wifi.sta.config()` to accept a table for station configuration, I forgot to update the `init.lua` example in `docs/en/upload.md` accordingly.

The new version of the example also makes use of the event monitor rather than a timer to catch station events.