### PR TITLE
Documenting creating integer build

### DIFF
--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -57,11 +57,18 @@ the firmware to lock onto that baud rate (between 1200 and 230400).
 
 ### Integer build
 By default a build will be generated supporting floating-point variables.
-To reduce memory size an integer build can be created.  You can change this by
-uncommenting `LUA_NUMBER_INTEGRAL` in `app/include/user_config.h`:
+To reduce memory size an integer build can be created.  You can change this 
+either by uncommenting `LUA_NUMBER_INTEGRAL` in `app/include/user_config.h`:
 
 ```c
 #define LUA_NUMBER_INTEGRAL
+```
+
+OR by overriding this with the `make` command as it's [done during the CI
+build](https://github.com/nodemcu/nodemcu-firmware/blob/master/.travis.yml#L30):
+
+```
+make EXTRA_CCFLAGS="-DLUA_NUMBER_INTEGRAL ....
 ```
 
 ### Tag Your Build

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -55,6 +55,15 @@ editing `BIT_RATE_DEFAULT` in `app/include/user_config.h`:
 Note that, by default, the firmware runs an auto-baudrate detection algorithm so that typing a few characters at boot time will cause
 the firmware to lock onto that baud rate (between 1200 and 230400).
 
+### Integer build
+By default a build will be generated supporting floating-point variables.
+To reduce memory size an integer build can be created.  You can change this by
+uncommenting `LUA_NUMBER_INTEGRAL` in `app/include/user_config.h`:
+
+```c
+#define LUA_NUMBER_INTEGRAL
+```
+
 ### Tag Your Build
 Identify your firmware builds by editing `app/include/user_version.h`
 


### PR DESCRIPTION
Fixes #1957 .

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Documenting how to create an integer build.