### PR TITLE
Upgrade to SDK 2.1.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .NOTPARALLEL:
 
 # SDK version NodeMCU is locked to
-SDK_VER:=2.0.0
+SDK_VER:=2.1.0
 
 # no patch: SDK_BASE_VER equals SDK_VER and sdk dir depends on sdk_extracted
 SDK_BASE_VER:=$(SDK_VER)
@@ -12,8 +12,8 @@ SDK_DIR_DEPENDS:=sdk_extracted
 #SDK_BASE_VER:=1.5.4
 #SDK_DIR_DEPENDS:=sdk_patched
 
-SDK_FILE_VER:=$(SDK_BASE_VER)_16_08_10
-SDK_FILE_SHA1:=b0127a99b45b3778be4a752387ab8dc0f6dd7810
+SDK_FILE_VER:=$(SDK_BASE_VER)
+SDK_FILE_SHA1:=66a4272894dc1bcec19f5f8bf79fee80f60a021b
 #SDK_PATCH_VER:=$(SDK_VER)_patch_20160704
 #SDK_PATCH_SHA1:=388d9e91df74e3b49fca126da482cf822cf1ebf1
 # Ensure we search "our" SDK before the tool-chain's SDK (if any)
@@ -203,10 +203,10 @@ all:	$(SDK_DIR_DEPENDS) pre_build .subdirs $(OBJS) $(OLIBS) $(OIMAGES) $(OBINS) 
 sdk_extracted: $(TOP_DIR)/sdk/.extracted-$(SDK_BASE_VER)
 sdk_patched: sdk_extracted $(TOP_DIR)/sdk/.patched-$(SDK_VER)
 
-$(TOP_DIR)/sdk/.extracted-$(SDK_BASE_VER): $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip
+$(TOP_DIR)/sdk/.extracted-$(SDK_BASE_VER): $(TOP_DIR)/cache/v$(SDK_FILE_VER).zip
 	mkdir -p "$(dir $@)"
-	(cd "$(dir $@)" && rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK && unzip $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip ESP8266_NONOS_SDK/lib/* ESP8266_NONOS_SDK/ld/eagle.rom.addr.v6.ld ESP8266_NONOS_SDK/include/* ESP8266_NONOS_SDK/bin/esp_init_data_default.bin)
-	mv $(dir $@)/ESP8266_NONOS_SDK $(dir $@)/esp_iot_sdk_v$(SDK_VER)
+	(cd "$(dir $@)" && rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK-$(SDK_VER) && unzip $(TOP_DIR)/cache/v$(SDK_FILE_VER).zip ESP8266_NONOS_SDK-$(SDK_VER)/lib/* ESP8266_NONOS_SDK-$(SDK_VER)/ld/eagle.rom.addr.v6.ld ESP8266_NONOS_SDK-$(SDK_VER)/include/* ESP8266_NONOS_SDK-$(SDK_VER)/bin/esp_init_data_default.bin)
+	mv $(dir $@)/ESP8266_NONOS_SDK-$(SDK_VER) $(dir $@)/esp_iot_sdk_v$(SDK_VER)
 	rm -f $(SDK_DIR)/lib/liblwip.a
 	touch $@
 
@@ -217,9 +217,9 @@ $(TOP_DIR)/sdk/.patched-$(SDK_VER): $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_PATCH_VE
 	rm -f $(SDK_DIR)/lib/liblwip.a
 	touch $@
 
-$(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_FILE_VER).zip:
+$(TOP_DIR)/cache/v$(SDK_FILE_VER).zip:
 	mkdir -p "$(dir $@)"
-	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused http://espressif.com/sites/default/files/sdks/esp8266_nonos_sdk_v$(SDK_FILE_VER).zip -O $@ || { rm -f "$@"; exit 1; }
+	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused https://github.com/espressif/ESP8266_NONOS_SDK/archive/v$(SDK_FILE_VER).zip -O $@ || { rm -f "$@"; exit 1; }
 	(echo "$(SDK_FILE_SHA1)  $@" | sha1sum -c -) || { rm -f "$@"; exit 1; }
 
 $(TOP_DIR)/cache/esp_iot_sdk_v$(SDK_PATCH_VER).zip:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **NodeMCU 2.0.0** #
+# **NodeMCU 2.1.0** #
 
 [![Join the chat at https://gitter.im/nodemcu/nodemcu-firmware](https://img.shields.io/gitter/room/badges/shields.svg)](https://gitter.im/nodemcu/nodemcu-firmware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/nodemcu/nodemcu-firmware.svg)](https://travis-ci.org/nodemcu/nodemcu-firmware)
@@ -7,7 +7,7 @@
 
 ### A Lua based firmware for ESP8266 WiFi SOC
 
-NodeMCU is an [eLua](http://www.eluaproject.net/) based firmware for the [ESP8266 WiFi SOC from Espressif](http://espressif.com/en/products/esp8266/). The firmware is based on the [Espressif NON-OS SDK 2.0.0](https://espressif.com/sites/default/files/sdks/esp8266_nonos_sdk_v2.0.0_16_08_10.zip) and uses a file system based on [spiffs](https://github.com/pellepl/spiffs). The code repository consists of 98.1% C-code that glues the thin Lua veneer to the SDK.
+NodeMCU is an [eLua](http://www.eluaproject.net/) based firmware for the [ESP8266 WiFi SOC from Espressif](http://espressif.com/en/products/esp8266/). The firmware is based on the [Espressif NON-OS SDK 2.1.0](https://github.com/espressif/ESP8266_NONOS_SDK/releases/tag/v2.1.0) and uses a file system based on [spiffs](https://github.com/pellepl/spiffs). The code repository consists of 98.1% C-code that glues the thin Lua veneer to the SDK.
 
 The NodeMCU *firmware* is a companion project to the popular [NodeMCU dev kits](https://github.com/nodemcu/nodemcu-devkit-v1.0), ready-made open source development boards with ESP8266-12E chips.
 

--- a/app/include/rom.h
+++ b/app/include/rom.h
@@ -46,7 +46,6 @@ extern void mem_init(void * start_addr);
 
 // Interrupt Service Routine functions
 typedef void (*ets_isr_fn) (void *arg);
-extern int ets_isr_attach (unsigned int interrupt, ets_isr_fn, void *arg);
 extern void ets_isr_mask (unsigned intr);
 extern void ets_isr_unmask (unsigned intr);
 
@@ -119,13 +118,10 @@ void *ets_memset (void *dst, int c, size_t n);
 int ets_memcmp (const void *s1, const void *s2, size_t n);
 
 char *ets_strcpy (char *dst, const char *src);
-size_t ets_strlen (const char *s);
 int ets_strcmp (const char *s1, const char *s2);
 int ets_strncmp (const char *s1, const char *s2, size_t n);
 char *ets_strncpy(char *dest, const char *src, size_t n);
 char *ets_strstr(const char *haystack, const char *needle);
-
-void ets_delay_us (uint32_t us);
 
 int ets_printf(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
 
@@ -140,12 +136,8 @@ void Cache_Read_Disable(void);
 void ets_intr_lock(void);
 void ets_intr_unlock(void);
 
-void ets_install_putc1(void *routine);
-
 int rand(void);
 void srand(unsigned int);
-
-void uart_div_modify(int no, unsigned int freq);
 
 /* Returns 0 on success, 1 on failure */
 uint8_t SPIRead(uint32_t src_addr, uint32_t *des_addr, uint32_t size);

--- a/app/include/user_version.h
+++ b/app/include/user_version.h
@@ -2,11 +2,11 @@
 #define __USER_VERSION_H__
 
 #define NODE_VERSION_MAJOR		2U
-#define NODE_VERSION_MINOR		0U
+#define NODE_VERSION_MINOR		1U
 #define NODE_VERSION_REVISION	0U
 #define NODE_VERSION_INTERNAL   0U
 
-#define NODE_VERSION	"NodeMCU 2.0.0"
+#define NODE_VERSION	"NodeMCU 2.1.0"
 #ifndef BUILD_DATE
 #define BUILD_DATE	  "unspecified"
 #endif

--- a/app/modules/tmr.c
+++ b/app/modules/tmr.c
@@ -128,9 +128,9 @@ static int tmr_delay( lua_State* L ){
 	sint32_t us = luaL_checkinteger(L, 1);
 	if(us <= 0)
 		return luaL_error(L, "wrong arg range");
-	while(us >= 1000000){
-		us -= 1000000;
-		os_delay_us(1000000);
+	while(us >= 10000){
+		us -= 10000;
+		os_delay_us(10000);
 		system_soft_wdt_feed ();
 	}
 	if(us>0){

--- a/app/tsl2561/tsl2561.c
+++ b/app/tsl2561/tsl2561.c
@@ -76,6 +76,12 @@ static tsl2561Gain_t _tsl2561Gain = TSL2561_GAIN_1X;
 static tsl2561Address_t tsl2561Address = TSL2561_ADDRESS_FLOAT;
 static tsl2561Package_t tsl2561Package = TSL2561_PACKAGE_T_FN_CL;
 
+static void delay_ms(uint16_t ms)
+{
+  while (ms--)
+    os_delay_us(1000);
+}
+
 /**************************************************************************/
 /*! 
  @brief  Writes an 8 bit values over I2C
@@ -230,13 +236,13 @@ tsl2561Error_t tsl2561GetLuminosity(uint16_t *broadband, uint16_t *ir) {
 	// Wait x ms for ADC to complete
 	switch (_tsl2561IntegrationTime) {
 	case TSL2561_INTEGRATIONTIME_13MS:
-		os_delay_us(14000); //systickDelay(14);
+		delay_ms(14); //systickDelay(14);
 		break;
 	case TSL2561_INTEGRATIONTIME_101MS:
-		os_delay_us(102000); //systickDelay(102);
+		delay_ms(102); //systickDelay(102);
 		break;
 	default:
-		os_delay_us(404000); //systickDelay(404);
+		delay_ms(404); //systickDelay(404);
 		break;
 	}
 

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -59,7 +59,7 @@ the firmware to lock onto that baud rate (between 1200 and 230400).
 Identify your firmware builds by editing `app/include/user_version.h`
 
 ```c
-#define NODE_VERSION    "NodeMCU 2.0.0+myname"
+#define NODE_VERSION    "NodeMCU 2.1.0+myname"
 #ifndef BUILD_DATE
 #define BUILD_DATE      "YYYYMMDD"
 #endif

--- a/ld/nodemcu.ld
+++ b/ld/nodemcu.ld
@@ -105,7 +105,7 @@ SECTIONS
     
     /* SDK libraries that used in bootup process, interruption handling
      * and other ways where flash cache (iROM) is unavailable: */
-    *libmain.a:*(.literal .text)
+    *libmain.a:*(.literal .literal.* .text .text.*)
     *libnet80211.a:*(.literal .text)
     *libphy.a:*(.literal .text)
     *libpp.a:*(.literal .text)

--- a/sdk-overrides/include/osapi.h
+++ b/sdk-overrides/include/osapi.h
@@ -2,7 +2,6 @@
 #define _SDK_OVERRIDE_OSAPI_H_
 
 #include "rom.h"
-void ets_timer_arm_new (ETSTimer *a, int b, int c, int isMstimer);
 
 int atoi(const char *nptr);
 int os_printf(const char *format, ...) __attribute__ ((format (printf, 1, 2)));

--- a/sdk-overrides/include/user_interface.h
+++ b/sdk-overrides/include/user_interface.h
@@ -7,13 +7,9 @@ bool wifi_softap_deauth(uint8 mac[6]);
 uint8 get_fpm_auto_sleep_flag(void);
 
 enum ext_flash_size_map {
-    FLASH_SIZE_32M_MAP_2048_2048 = 7,
     FLASH_SIZE_64M_MAP = 8,
     FLASH_SIZE_128M_MAP = 9
 };
-
-// Documented in section 4.5 of 9b-esp8266_low_power_solutions_en.pdf
-void system_deep_sleep_instant(uint32 time_in_us);
 
 //force sleep API
 #define FPM_SLEEP_MAX_TIME 268435455 //0xFFFFFFF


### PR DESCRIPTION
Fixes #1810.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This updates the SDK to [upstream 2.1.0 release](https://github.com/espressif/ESP8266_NONOS_SDK/releases/tag/v2.1.0).
Notable changes:
- Some ROM functions are now defined in sdk headers and had to be removed from our sdk-overrides etc.
- Especially `ets_delay_us()`, which had its parameter reduced from uint32 to uint16. This enforced code changes in `tmr` and `tsl2561`.
- IRAM vs. IROM section handling changed.
  `libmain.a` seems to be the only library that exposes per-function-sections.

Feel free to add commits.
