### PR TITLE
ESP32: Fix gpio pin mask generation and clarify available gpios.

### DIFF
--- a/components/modules/gpio.c
+++ b/components/modules/gpio.c
@@ -102,7 +102,7 @@ static int lgpio_config (lua_State *L)
     lua_getfield(L, i, "gpio");
     int type = lua_type (L, -1);
     if (type == LUA_TNUMBER)
-      cfg.pin_bit_mask = 1 << lua_tointeger (L, -1);
+      cfg.pin_bit_mask = 1ULL << lua_tointeger (L, -1);
     else if (type == LUA_TTABLE)
     {
       lua_pushnil (L);
@@ -111,7 +111,7 @@ static int lgpio_config (lua_State *L)
         lua_pushvalue (L, -1); // copy, so lua_tonumber() doesn't break iter
         int pin = lua_tointeger (L, -1);
         lua_pop (L, 2); // leave key
-        cfg.pin_bit_mask |= 1 << pin;
+        cfg.pin_bit_mask |= 1ULL << pin;
       }
     }
     else

--- a/docs/en/modules/gpio.md
+++ b/docs/en/modules/gpio.md
@@ -6,6 +6,13 @@
 
 This module provides access to the [GPIO](https://en.wikipedia.org/wiki/General-purpose_input/output) (General Purpose Input/Output) subsystem.
 
+# GPIO Overview
+The ESP32 chip features 40 physical GPIO pads. Some GPIO pads cannot be used or do not have the corresponding pin on the chip package (refer to the [ESP32 Datasheet](http://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)).
+
+- GPIO6-11 are usually used for SPI flash.
+- GPIO20, GPIO24, and GPIO28-31 are not available as pins.
+- GPIO34-39 can only be set as input mode and do not have software pullup or pulldown functions.
+
 
 ## gpio.config()
 Configure GPIO mode for one or more pins.
@@ -23,7 +30,7 @@ gpio.config({
 #### Parameters
 List of configuration tables:
 
-- `gpio` one or more (given as list) pins, 0 ~ 33 I/O index
+- `gpio` one or more (given as list) pins, see [GPIO Overview](#gpio-overview)
 - `dir` direction, one of
     - `gpio.IN`
     - `gpio.OUT`


### PR DESCRIPTION
Fixes #1964.

Generation of the pin_bit_mask did not work for indices >=32.
PR also adds an explanation which GPIOs are actually available. I intend to change the default statement in other module docs regarding pins with a reference to this section.

@capella-ben, @jmattsson please review for any additions or corrections.
