### PR TITLE
Expose WiFi event OPMODE_CHANGED

### DIFF
--- a/app/modules/wifi_eventmon.c
+++ b/app/modules/wifi_eventmon.c
@@ -154,9 +154,10 @@ static void wifi_event_monitor_handle_event_cb(System_Event_t *evt)
 
   if((wifi_event_cb_ref[evt->event] != LUA_NOREF) || ((wifi_event_cb_ref[EVENT_MAX] != LUA_NOREF) &&
       !(evt->event == EVENT_STAMODE_CONNECTED || evt->event == EVENT_STAMODE_DISCONNECTED ||
-          evt->event == EVENT_STAMODE_AUTHMODE_CHANGE||evt->event==EVENT_STAMODE_GOT_IP ||
-          evt->event == EVENT_STAMODE_DHCP_TIMEOUT||evt->event==EVENT_SOFTAPMODE_STACONNECTED ||
-          evt->event == EVENT_SOFTAPMODE_STADISCONNECTED||evt->event==EVENT_SOFTAPMODE_PROBEREQRECVED)))
+          evt->event == EVENT_STAMODE_AUTHMODE_CHANGE || evt->event == EVENT_STAMODE_GOT_IP ||
+          evt->event == EVENT_STAMODE_DHCP_TIMEOUT || evt->event == EVENT_SOFTAPMODE_STACONNECTED ||
+          evt->event == EVENT_SOFTAPMODE_STADISCONNECTED || evt->event == EVENT_SOFTAPMODE_PROBEREQRECVED ||
+          evt->event == EVENT_OPMODE_CHANGED)))
   {
     evt_queue_t *temp = (evt_queue_t*)c_malloc(sizeof(evt_queue_t)); //allocate memory for new queue item
     temp->evt = (System_Event_t*)c_malloc(sizeof(System_Event_t)); //allocate memory to hold event structure
@@ -279,7 +280,16 @@ static void wifi_event_monitor_process_event_queue(task_param_t param, uint8 pri
           evt->event_info.ap_probereqrecved.rssi);
       break;
 
-    default://if event is not implemented, push table with userdata containing event data
+    case EVENT_OPMODE_CHANGED:
+      EVENT_DBG("\n\tOPMODE_CHANGED\n");
+      wifi_add_int_field(L, "old_mode", evt->event_info.opmode_changed.old_opmode);
+      wifi_add_int_field(L, "new_mode", evt->event_info.opmode_changed.new_opmode);
+      EVENT_DBG("\topmode: %u -> %u\n",
+          evt->event_info.opmode_changed.old_opmode,
+          evt->event_info.opmode_changed.new_opmode);
+      break;
+
+    default://if event is not implemented, return event id
       EVENT_DBG("\n\tswitch/case default\n");
       wifi_add_sprintf_field(L, "info", "event %u not implemented", evt->event);
       break;
@@ -350,6 +360,7 @@ const LUA_REG_TYPE wifi_event_monitor_map[] =
   { LSTRKEY( "AP_STACONNECTED" ),     LNUMVAL( EVENT_SOFTAPMODE_STACONNECTED ) },
   { LSTRKEY( "AP_STADISCONNECTED" ),  LNUMVAL( EVENT_SOFTAPMODE_STADISCONNECTED ) },
   { LSTRKEY( "AP_PROBEREQRECVED" ),   LNUMVAL( EVENT_SOFTAPMODE_PROBEREQRECVED ) },
+  { LSTRKEY( "WIFI_MODE_CHANGED" ),   LNUMVAL( EVENT_OPMODE_CHANGED ) },
   { LSTRKEY( "EVENT_MAX" ),           LNUMVAL( EVENT_MAX ) },
 #ifdef WIFI_EVENT_MONITOR_DISCONNECT_REASON_LIST_ENABLE
   { LSTRKEY( "reason" ),              LROVAL( wifi_event_monitor_reason_map ) },

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -1523,6 +1523,9 @@ T: Table returned by event.
 - `wifi.eventmon.AP_PROBEREQRECVED`: A probe request was received.  
 	- `MAC`: MAC address of the client that is probing the access point.  
 	- `RSSI`: Received Signal Strength Indicator of client.  
+- `wifi.eventmon.WIFI_MODE_CHANGE`: WiFi mode has changed.    
+	- `old_auth_mode`: Old WiFi mode.  
+	- `new_auth_mode`: New WiFi mode.  
 
 #### Example
 
@@ -1537,7 +1540,7 @@ T: Table returned by event.
  T.BSSID.."\n\treason: "..T.reason)
  end)
 
- wifi.eventmon.register(wifi.eventmon.STA_AUTHMODE_CHANGE, Function(T)
+ wifi.eventmon.register(wifi.eventmon.STA_AUTHMODE_CHANGE, function(T)
  print("\n\tSTA - AUTHMODE CHANGE".."\n\told_auth_mode: "..
  T.old_auth_mode.."\n\tnew_auth_mode: "..T.new_auth_mode)
  end)
@@ -1561,6 +1564,11 @@ T: Table returned by event.
 
  wifi.eventmon.register(wifi.eventmon.AP_PROBEREQRECVED, function(T)
  print("\n\tAP - PROBE REQUEST RECEIVED".."\n\tMAC: ".. T.MAC.."\n\tRSSI: "..T.RSSI)
+ end)
+
+ wifi.eventmon.register(wifi.eventmon.WIFI_MODE_CHANGED, function(T)
+ print("\n\tSTA - WIFI MODE CHANGED".."\n\told_mode: "..
+ T.old_mode.."\n\tnew_mode: "..T.new_mode)
  end)
 ```
 #### See also
@@ -1588,6 +1596,7 @@ Event: WiFi event you would like to set a callback for.
 	- wifi.eventmon.AP_STACONNECTED  
 	- wifi.eventmon.AP_STADISCONNECTED  
 	- wifi.eventmon.AP_PROBEREQRECVED  
+	- wifi.eventmon.WIFI_MODE_CHANGED  
 
 #### Returns
 `nil`


### PR DESCRIPTION
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

With the upgrade to SDK ver. 2.1.0, a new WiFi event (EVENT_OPMODE_CHANGED) was added.
This PR adds the new event to the WiFi event monitor.