### PR TITLE
Update ds18b20.lua

### DIFF
--- a/lua_modules/ds18b20/ds18b20.lua
+++ b/lua_modules/ds18b20/ds18b20.lua
@@ -105,7 +105,11 @@ function readNumber(addr, unit)
 		if (addr:byte(1) == 0x28) then
 		  t = t * 625  -- DS18B20, 4 fractional bits
 		else
-		  t = t * 5000 -- DS18S20, 1 fractional bit
+		  -- 12 bits resolution. If you need 9 bits only comment the
+		  -- two following lines and un-comment the third
+		  c = (((data:byte(8)-data:byte(7))/data:byte(8)) - 0.25) * 10000
+		  t = (t * 5000) + c
+		  -- t = t * 5000 -- DS18S20, 1 fractional bit			
 		end
 
         if(unit == nil or unit == 'C') then


### PR DESCRIPTION
I have some 1wire temperature sensors. Some DS18B20 and some DS18S20
This DS18B20 one wire module works fine with both sensor types, however the temperature reading for the DS18S20 is 9 bits only (12 bits for the DS18B20).
9 bits is default for DS18S20 however it's possible to have 12 bits as explained here:
https://datasheets.maximintegrated.com/en/ds/DS18S20.pdf
and here in this Maxim application note: comparison of both sensors 
https://www.maximintegrated.com/en/app-notes/index.mvp/id/4377
9 bits is annoying because you get only half degree precision (i.e. 22; 22.5; 23; 23.5; 24 etc..) you cannot get something like 22.3. So even if I don't need the 4 figures after the decimal point, 12 bits resolution is better. 
So I propose this change.
Apologize if I miss something this is my very first PR

Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [ ] This PR is for the `dev` branch rather than for `master`.
- [ ] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rational behind this PR\>