### PR TITLE
dhcps: ensure standard message length when sending response to clients

### DIFF
--- a/app/include/lwip/app/dhcpserver.h
+++ b/app/include/lwip/app/dhcpserver.h
@@ -5,6 +5,8 @@
 
 #define USE_DNS
 
+#define DHCP_MSGOPTIONS_MIN_LEN 312
+
 typedef struct dhcps_state{
         sint16_t state;
 } dhcps_state;

--- a/app/lwip/app/dhcpserver.c
+++ b/app/lwip/app/dhcpserver.c
@@ -298,7 +298,8 @@ static void ICACHE_FLASH_ATTR send_offer(struct dhcps_msg *m)
         end = add_offer_options(end);
         end = add_end(end);
 
-	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg), PBUF_RAM);
+        // ensure that not more than the minimum options length is transmitted
+        p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) - sizeof(m->options) + DHCP_MSGOPTIONS_MIN_LEN, PBUF_RAM);
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_offer>>p->ref = %d\n", p->ref);
 #endif
@@ -358,7 +359,8 @@ static void ICACHE_FLASH_ATTR send_nak(struct dhcps_msg *m)
         end = add_msg_type(&m->options[4], DHCPNAK);
         end = add_end(end);
 
-	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg), PBUF_RAM);
+        // ensure that not more than the minimum options length is transmitted
+	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) - sizeof(m->options) + DHCP_MSGOPTIONS_MIN_LEN, PBUF_RAM);
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_nak>>p->ref = %d\n", p->ref);
 #endif
@@ -418,8 +420,9 @@ static void ICACHE_FLASH_ATTR send_ack(struct dhcps_msg *m)
         end = add_msg_type(&m->options[4], DHCPACK);
         end = add_offer_options(end);
         end = add_end(end);
-	    
-	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg), PBUF_RAM);
+
+        // ensure that not more than the minimum options length is transmitted
+	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) - sizeof(m->options) + DHCP_MSGOPTIONS_MIN_LEN, PBUF_RAM);
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_ack>>p->ref = %d\n", p->ref);
 #endif


### PR DESCRIPTION
Fixes #1577, #1979.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have **sort of** tested my contribution, courtesy of @RafNie.

This change is supposed to address the long-standing issue with certain clients that cannot cope with the extended response size of the dhcp server. I rate this fix somewhere between a workaround and a proper solution since it doesn't target the root cause of all the headaches: unclear coverage of RFC2131 requirements.
I hope to see a better overall solution in response to espressif/esp-idf#631, which we then should probably port back into our firmware.
