### PR TITLE
Fix incorrect documentation for wifi.sta.setaplimit

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -905,7 +905,7 @@ Set Maximum number of Access Points to store in flash.
 `wifi.sta.setaplimit(qty)`
 
 #### Parameters
-`qty` Quantity of Access Points to store in flash. Range: 1-5 (Default: 5)
+`qty` Quantity of Access Points to store in flash. Range: 1-5 (Default: 1)
 
 #### Returns
 - `true`  Success


### PR DESCRIPTION
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

While doing some testing I discovered that the default value for `wifi.sta.setaplimit()` was 5 as opposed to 1 (the Espressif SDK default value is 1). 
I'm not sure if this is something I got wrong initially or something Espressif changed. Either way, here is the correction for the documentation.