### PR TITLE
Fix incorrect link in github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Make sure you read and understand http://nodemcu.readthedocs.io/en/dev/en/support/.
+Make sure you read and understand http://nodemcu.readthedocs.io/en/master/en/support/.
 Use one of the two templates below and delete the rest.
 
 8<------------------------ BUG REPORT -----------------------------------------


### PR DESCRIPTION
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

I noticed that the github issue template had a link that pointed to the dev branch as opposed to the master branch and I figured that it might need to be fixed, so here's a PR.
