### PR TITLE
Update wifi.sta.config to save configuration to flash by default 

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -829,7 +829,7 @@ static int wifi_station_config( lua_State* L )
     }
     else 
     {
-      save_to_flash=false;
+      save_to_flash=true;
     }
     lua_pop(L, 1);
 

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -410,8 +410,8 @@ Sets the WiFi station configuration.
 			- "AC-1D-1C-B1-0B-22"
 			- "DE AD BE EF 7A C0"
 	- `save` Save station configuration to flash. 
-		- `true` configuration **will** be retained through power cycle. 
-		- `false` configuration **will not** be retained through power cycle. (Default).
+		- `true` configuration **will** be retained through power cycle.  (Default).
+		- `false` configuration **will not** be retained through power cycle.
 	- Event callbacks will only be available if `WIFI_SDK_EVENT_MONITOR_ENABLE` is uncommented in `user_config.h`
 		- Please note: To ensure all station events are handled at boot time, all relevant callbacks must be registered as early as possible in `init.lua` with either `wifi.sta.config()` or `wifi.eventmon.register()`.     
 		- `connected_cb`: Callback to execute when station is connected to an access point. (Optional)

--- a/docs/en/upload.md
+++ b/docs/en/upload.md
@@ -111,7 +111,7 @@ wifi.eventmon.register(wifi.eventmon.STA_DISCONNECTED, wifi_disconnect_event)
 
 print("Connecting to WiFi access point...")
 wifi.setmode(wifi.STATION)
-wifi.sta.config({ssid=SSID, pwd=PASSWORD, save=true})
+wifi.sta.config({ssid=SSID, pwd=PASSWORD})
 -- wifi.sta.connect() not necessary because config() uses auto-connect=true by default
 
 ```


### PR DESCRIPTION
Fixes #1940.
 
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

This PR updates `wifi.sta.config()` to save configuration by default.
