### PR TITLE
backport fix for https://github.com/espressif/esp-idf/issues/631

### DIFF
--- a/app/include/lwip/app/dhcpserver.h
+++ b/app/include/lwip/app/dhcpserver.h
@@ -23,9 +23,7 @@ typedef struct dhcps_msg {
         uint8_t chaddr[16];
         uint8_t sname[64];
         uint8_t file[128];
-	// Recommendation from Espressif:
-	// To avoid crash in DHCP big packages modify option length from 312 to MTU - IPHEAD(20) - UDPHEAD(8) - DHCPHEAD(236).
-        uint8_t options[IP_FRAG_MAX_MTU - 20 - 8 - 236];
+        uint8_t options[312];
 }dhcps_msg;
 
 #ifndef LWIP_OPEN_SRC

--- a/app/include/lwip/app/dhcpserver.h
+++ b/app/include/lwip/app/dhcpserver.h
@@ -5,8 +5,6 @@
 
 #define USE_DNS
 
-#define DHCP_MSGOPTIONS_MIN_LEN 312
-
 typedef struct dhcps_state{
         sint16_t state;
 } dhcps_state;

--- a/app/lwip/app/dhcpserver.c
+++ b/app/lwip/app/dhcpserver.c
@@ -277,6 +277,21 @@ static void ICACHE_FLASH_ATTR create_msg(struct dhcps_msg *m)
         uint32 magic_cookie1 = magic_cookie;
         os_memcpy((char *) m->options, &magic_cookie1, sizeof(magic_cookie1));
 }
+
+struct pbuf * dhcps_pbuf_alloc(u16_t len)
+{
+    u16_t mlen = sizeof(struct dhcps_msg);
+
+    if (len > mlen) {
+#if DHCPS_DEBUG
+        DHCPS_LOG("dhcps: len=%d mlen=%d", len, mlen);
+#endif
+        mlen = len;
+    }
+
+    return pbuf_alloc(PBUF_TRANSPORT, mlen, PBUF_RAM);
+}
+
 ///////////////////////////////////////////////////////////////////////////////////
 /*
  * ����һ��OFFER
@@ -284,7 +299,7 @@ static void ICACHE_FLASH_ATTR create_msg(struct dhcps_msg *m)
  * @param -- m ָ����Ҫ���͵�DHCP msg����
  */
 ///////////////////////////////////////////////////////////////////////////////////
-static void ICACHE_FLASH_ATTR send_offer(struct dhcps_msg *m)
+static void ICACHE_FLASH_ATTR send_offer(struct dhcps_msg *m, u16_t len)
 {
         uint8_t *end;
 	    struct pbuf *p, *q;
@@ -298,8 +313,7 @@ static void ICACHE_FLASH_ATTR send_offer(struct dhcps_msg *m)
         end = add_offer_options(end);
         end = add_end(end);
 
-        // ensure that not more than the minimum options length is transmitted
-        p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) - sizeof(m->options) + DHCP_MSGOPTIONS_MIN_LEN, PBUF_RAM);
+        p = dhcps_pbuf_alloc(len);
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_offer>>p->ref = %d\n", p->ref);
 #endif
@@ -345,7 +359,7 @@ static void ICACHE_FLASH_ATTR send_offer(struct dhcps_msg *m)
  * @param m ָ����Ҫ���͵�DHCP msg����
  */
 ///////////////////////////////////////////////////////////////////////////////////
-static void ICACHE_FLASH_ATTR send_nak(struct dhcps_msg *m)
+static void ICACHE_FLASH_ATTR send_nak(struct dhcps_msg *m, u16_t len)
 {
 
     	u8_t *end;
@@ -359,8 +373,7 @@ static void ICACHE_FLASH_ATTR send_nak(struct dhcps_msg *m)
         end = add_msg_type(&m->options[4], DHCPNAK);
         end = add_end(end);
 
-        // ensure that not more than the minimum options length is transmitted
-	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) - sizeof(m->options) + DHCP_MSGOPTIONS_MIN_LEN, PBUF_RAM);
+	    p = dhcps_pbuf_alloc(len);
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_nak>>p->ref = %d\n", p->ref);
 #endif
@@ -406,7 +419,7 @@ static void ICACHE_FLASH_ATTR send_nak(struct dhcps_msg *m)
  * @param m ָ����Ҫ���͵�DHCP msg����
  */
 ///////////////////////////////////////////////////////////////////////////////////
-static void ICACHE_FLASH_ATTR send_ack(struct dhcps_msg *m)
+static void ICACHE_FLASH_ATTR send_ack(struct dhcps_msg *m, u16_t len)
 {
 
 		u8_t *end;
@@ -421,8 +434,7 @@ static void ICACHE_FLASH_ATTR send_ack(struct dhcps_msg *m)
         end = add_offer_options(end);
         end = add_end(end);
 
-        // ensure that not more than the minimum options length is transmitted
-	    p = pbuf_alloc(PBUF_TRANSPORT, sizeof(struct dhcps_msg) - sizeof(m->options) + DHCP_MSGOPTIONS_MIN_LEN, PBUF_RAM);
+	    p = dhcps_pbuf_alloc(len);
 #if DHCPS_DEBUG
 		os_printf("udhcp: send_ack>>p->ref = %d\n", p->ref);
 #endif
@@ -605,7 +617,7 @@ static void ICACHE_FLASH_ATTR handle_dhcp(void *arg,
 									uint16_t port)
 {
 		struct dhcps_msg *pmsg_dhcps = NULL;
-		sint16_t tlen = 0;
+		sint16_t tlen = 0, malloc_len;
         u16_t i = 0;
 	    u16_t dhcps_msg_cnt = 0;
 	    u8_t *p_dhcps_msg = NULL;
@@ -616,11 +628,21 @@ static void ICACHE_FLASH_ATTR handle_dhcp(void *arg,
 #endif
 	    if (p==NULL) return;
 
-	    pmsg_dhcps = (struct dhcps_msg *)os_zalloc(sizeof(struct dhcps_msg));
+	    malloc_len = sizeof(struct dhcps_msg);
+#if DHCPS_DEBUG
+	    DHCPS_LOG("dhcps: handle_dhcp malloc_len=%d rx_len=%d", malloc_len, p->tot_len);
+#endif
+	    if (malloc_len < p->tot_len) {
+			malloc_len = p->tot_len;
+	    }
+
+	    pmsg_dhcps = (struct dhcps_msg *)os_malloc(malloc_len);
 	    if (NULL == pmsg_dhcps){
 	    	pbuf_free(p);
 	    	return;
 	    }
+	    memset(pmsg_dhcps , 0x00 , malloc_len);
+
 	    p_dhcps_msg = (u8_t *)pmsg_dhcps;
 		tlen = p->tot_len;
 	    data = p->payload;
@@ -660,19 +682,19 @@ static void ICACHE_FLASH_ATTR handle_dhcp(void *arg,
 #if DHCPS_DEBUG            
             	 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_OFFER\n");
 #endif			
-	             send_offer(pmsg_dhcps);
+	             send_offer(pmsg_dhcps, malloc_len);
 	             break;
 	        case DHCPS_STATE_ACK://3
 #if DHCPS_DEBUG
             	 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_ACK\n");
 #endif			
-	             send_ack(pmsg_dhcps);
+	             send_ack(pmsg_dhcps, malloc_len);
 	             break;
 	        case DHCPS_STATE_NAK://4
 #if DHCPS_DEBUG            
             	 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_NAK\n");
 #endif
-	             send_nak(pmsg_dhcps);
+	             send_nak(pmsg_dhcps, malloc_len);
 	             break;
 			default :
 				 break;


### PR DESCRIPTION
Follow-up to #1985.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

Backport of fix provided with espressif/esp-idf#631.
