### PR TITLE
default flash mode to dio in fw image header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ endef
 
 $(BINODIR)/%.bin: $(IMAGEODIR)/%.out
 	@mkdir -p $(BINODIR)
-	$(ESPTOOL) elf2image $< -o $(FIRMWAREDIR)
+	$(ESPTOOL) elf2image --flash_mode dio --flash_freq 40m $< -o $(FIRMWAREDIR)
 
 #############################################################
 # Rules base

--- a/docs/en/flash.md
+++ b/docs/en/flash.md
@@ -30,6 +30,7 @@ Run the following command to flash an *aggregated* binary as is produced for exa
 
 - See [below](#determine-flash-size) if you don't know or are uncertain about the capacity of the flash chip on your device. It might help to double check as e.g. some ESP-01 modules come with 512kB while others are equipped with 1MB.
 - esptool.py is under heavy development. It's advised you run the latest version (check with `esptool.py version`). Since this documentation may not have been able to keep up refer to the [esptool flash modes documentation](https://github.com/themadinventor/esptool#flash-modes) for current options and parameters.
+- The firmware image file contains default settings `dio` for flash mode and `40m` for flash frequency.
 - In some uncommon cases, the [SDK init data](#sdk-init-data) may be invalid and NodeMCU may fail to boot. The easiest solution is to fully erase the chip before flashing:
 `esptool.py --port <serial-port-of-ESP8266> erase_flash`
 


### PR DESCRIPTION
Follow-up to #2009.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

#2009 revealed that esptool.py changed defaults for flash mode and flash frequency to `keep` during `write_flash`, exposing the related content in the firmware image files we produce during build.
To ensure a safe default configuration (mainly for flash mode) which is expected to work for any board, this PR forces flash mode to `dio` and flash frequency to `40m` inside the image.
