### PR TITLE
Update documentation for wifi.sta.setaplimit()

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -899,7 +899,10 @@ Set Maximum number of Access Points to store in flash.
  - This value is written to flash
 
 !!! Attention
-		If 5 Access Points are stored and AP limit is set to 4, the AP at index 5 will remain until [`node.restore()`](node.md#noderestore) is called or AP limit is set to 5 and AP is overwritten.  
+	New setting will not take effect until restart. 
+
+!!! Note
+	If 5 Access Points are stored and AP limit is set to 4, the AP at index 5 will remain until [`node.restore()`](node.md#noderestore) is called or AP limit is set to 5 and AP is overwritten.
 
 #### Syntax
 `wifi.sta.setaplimit(qty)`
@@ -913,7 +916,7 @@ Set Maximum number of Access Points to store in flash.
 
 #### Example
 ```lua
-wifi.sta.setaplimit(true)
+wifi.sta.setaplimit(5)
 ```
 
 #### See also


### PR DESCRIPTION
Fixes #2010

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

This PR adds a note to the `wifi.sta.setaplimit()` documentation that lets the developer know that the new setting will not take effect until restart.