### PR TITLE
fix #2007 http: Call callback in all cases

### DIFF
--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -456,7 +456,7 @@ static void ICACHE_FLASH_ATTR http_timeout_callback( void *arg )
 	}
 	if ( conn->reverse == NULL )
 	{
-		HTTPCLIENT_DEBUG( "reverse is NULL" );
+		HTTPCLIENT_DEBUG( "Connection request data (reverse) is NULL" );
 		return;
 	}
 	request_args_t * req = (request_args_t *) conn->reverse;

--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -451,20 +451,32 @@ static void ICACHE_FLASH_ATTR http_timeout_callback( void *arg )
 	struct espconn * conn = (struct espconn *) arg;
 	if ( conn == NULL )
 	{
+		HTTPCLIENT_ERR( "Connection is NULL" );
 		return;
 	}
 	if ( conn->reverse == NULL )
 	{
+		HTTPCLIENT_ERR( "reverse is NULL" );
 		return;
 	}
 	request_args_t * req = (request_args_t *) conn->reverse;
+	HTTPCLIENT_ERR( "Calling disconnect" );
 	/* Call disconnect */
+	sint8 result;
 #ifdef CLIENT_SSL_ENABLE
 	if ( req->secure )
-		espconn_secure_disconnect( conn );
+		result = espconn_secure_disconnect( conn );
 	else
 #endif
-		espconn_disconnect( conn );
+		result = espconn_disconnect( conn );
+		
+	if (result == ESPCONN_OK || result == ESPCONN_INPROGRESS)
+		return;
+	else
+	{
+		HTTPCLIENT_ERR( "manually Calling disconnect callback due to error %d", result );
+		http_disconnect_callback( arg );
+	}		
 }
 
 

--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -451,16 +451,16 @@ static void ICACHE_FLASH_ATTR http_timeout_callback( void *arg )
 	struct espconn * conn = (struct espconn *) arg;
 	if ( conn == NULL )
 	{
-		HTTPCLIENT_ERR( "Connection is NULL" );
+		HTTPCLIENT_DEBUG( "Connection is NULL" );
 		return;
 	}
 	if ( conn->reverse == NULL )
 	{
-		HTTPCLIENT_ERR( "reverse is NULL" );
+		HTTPCLIENT_DEBUG( "reverse is NULL" );
 		return;
 	}
 	request_args_t * req = (request_args_t *) conn->reverse;
-	HTTPCLIENT_ERR( "Calling disconnect" );
+	HTTPCLIENT_DEBUG( "Calling disconnect" );
 	/* Call disconnect */
 	sint8 result;
 #ifdef CLIENT_SSL_ENABLE
@@ -474,7 +474,8 @@ static void ICACHE_FLASH_ATTR http_timeout_callback( void *arg )
 		return;
 	else
 	{
-		HTTPCLIENT_ERR( "manually Calling disconnect callback due to error %d", result );
+		/* not connected; execute the callback ourselves. */
+		HTTPCLIENT_DEBUG( "manually Calling disconnect callback due to error %d", result );
 		http_disconnect_callback( arg );
 	}		
 }

--- a/docs/en/modules/http.md
+++ b/docs/en/modules/http.md
@@ -33,7 +33,7 @@ Executes a HTTP DELETE request. Note that concurrent requests are not supported.
 - `url` The URL to fetch, including the `http://` or `https://` prefix
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
 - `body` The body to post; must already be encoded in the appropriate format, but may be empty
-- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1.
 
 #### Returns
 `nil`
@@ -89,7 +89,7 @@ Executes a HTTP POST request. Note that concurrent requests are not supported.
 - `url` The URL to fetch, including the `http://` or `https://` prefix
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
 - `body` The body to post; must already be encoded in the appropriate format, but may be empty
-- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1.
 
 #### Returns
 `nil`
@@ -119,7 +119,7 @@ Executes a HTTP PUT request. Note that concurrent requests are not supported.
 - `url` The URL to fetch, including the `http://` or `https://` prefix
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
 - `body` The body to post; must already be encoded in the appropriate format, but may be empty
-- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1.
 
 #### Returns
 `nil`
@@ -150,7 +150,7 @@ Execute a custom HTTP request for any HTTP method. Note that concurrent requests
 - `method` The HTTP method to use, e.g. "GET", "HEAD", "OPTIONS" etc
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
 - `body` The body to post; must already be encoded in the appropriate format, but may be empty
-- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1.
 
 #### Returns
 `nil`

--- a/docs/en/modules/http.md
+++ b/docs/en/modules/http.md
@@ -33,7 +33,7 @@ Executes a HTTP DELETE request. Note that concurrent requests are not supported.
 - `url` The URL to fetch, including the `http://` or `https://` prefix
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
 - `body` The body to post; must already be encoded in the appropriate format, but may be empty
-- `callback` The callback function to be invoked when the response has been received; it is invoked with the arguments `status_code`, `body` and `headers`
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
 
 #### Returns
 `nil`
@@ -62,7 +62,7 @@ Executes a HTTP GET request. Note that concurrent requests are not supported.
 #### Parameters
 - `url` The URL to fetch, including the `http://` or `https://` prefix
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
-- `callback` The callback function to be invoked when the response has been received; it is invoked with the arguments `status_code`, `body` and `headers`
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
 
 #### Returns
 `nil`
@@ -89,7 +89,7 @@ Executes a HTTP POST request. Note that concurrent requests are not supported.
 - `url` The URL to fetch, including the `http://` or `https://` prefix
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
 - `body` The body to post; must already be encoded in the appropriate format, but may be empty
-- `callback` The callback function to be invoked when the response has been received; it is invoked with the arguments `status_code`, `body` and `headers`
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
 
 #### Returns
 `nil`
@@ -119,7 +119,7 @@ Executes a HTTP PUT request. Note that concurrent requests are not supported.
 - `url` The URL to fetch, including the `http://` or `https://` prefix
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
 - `body` The body to post; must already be encoded in the appropriate format, but may be empty
-- `callback` The callback function to be invoked when the response has been received; it is invoked with the arguments `status_code`, `body` and `headers`
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
 
 #### Returns
 `nil`
@@ -150,7 +150,7 @@ Execute a custom HTTP request for any HTTP method. Note that concurrent requests
 - `method` The HTTP method to use, e.g. "GET", "HEAD", "OPTIONS" etc
 - `headers` Optional additional headers to append, *including \r\n*; may be `nil`
 - `body` The body to post; must already be encoded in the appropriate format, but may be empty
-- `callback` The callback function to be invoked when the response has been received; it is invoked with the arguments `status_code`, `body` and `headers`
+- `callback` The callback function to be invoked when the response has been received or an error occurred; it is invoked with the arguments `status_code`, `body` and `headers`. In case of an error `status_code` is set to -1
 
 #### Returns
 `nil`


### PR DESCRIPTION
Call callback with errorcode -1 if no connection could be establioshed

Fixes #2007 and #1721.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

the PR checks the returnvalue of espconn_(secure_)disconnect. If no connection was established it fails and no disconnected callback is to be expected.
In this case the callback is called directly

I allso added some more error logging which I can remove on request.
