### PR TITLE
ESP32: added functions wifi.sta.getmac() and wifi.ap.getmac()

### DIFF
--- a/components/modules/wifi_ap.c
+++ b/components/modules/wifi_ap.c
@@ -168,6 +168,10 @@ static int wifi_ap_config (lua_State *L)
     0 : luaL_error (L, "failed to set wifi config, code %d", err);
 }
 
+static int wifi_ap_getmac (lua_State *L)
+{
+  return wifi_getmac(WIFI_IF_AP, L);
+}
 
 static int wifi_ap_on (lua_State *L)
 {
@@ -179,6 +183,7 @@ const LUA_REG_TYPE wifi_ap_map[] =
 {
   { LSTRKEY( "config" ),              LFUNCVAL( wifi_ap_config )        },
   { LSTRKEY( "on" ),                  LFUNCVAL( wifi_ap_on )            },
+  { LSTRKEY( "getmac" ),              LFUNCVAL( wifi_ap_getmac )        },
 
   { LNILKEY, LNILVAL }
 };

--- a/components/modules/wifi_common.c
+++ b/components/modules/wifi_common.c
@@ -76,4 +76,18 @@ int wifi_on (lua_State *L, const event_desc_t *table, unsigned n, int *event_cb)
 
   return 0;
 }
- 
+
+int wifi_getmac (wifi_interface_t interface, lua_State *L)
+{
+  uint8_t mac[6];
+  esp_err_t err = esp_wifi_get_mac(interface, mac);
+  if (err != ESP_OK)
+    return luaL_error (L, "failed to get mac, code %d", err);
+
+  char mac_str[MAC_STR_SZ];
+  macstr (mac_str, mac);
+  lua_pushstring (L, mac_str);
+
+  return 1;
+}
+

--- a/components/modules/wifi_common.h
+++ b/components/modules/wifi_common.h
@@ -71,4 +71,6 @@ int wifi_on (lua_State *L, const event_desc_t *table, unsigned n, int *event_cb)
 #define STR_WIFI_SECOND_CHAN_BELOW "HT40_BELOW"
 extern const char * const wifi_second_chan_names[];
 
+int wifi_getmac (wifi_interface_t interface, lua_State *L);
+
 #endif

--- a/components/modules/wifi_sta.c
+++ b/components/modules/wifi_sta.c
@@ -278,6 +278,10 @@ static int wifi_sta_getconfig (lua_State *L)
   return 1;
 }
 
+static int wifi_sta_getmac (lua_State *L)
+{
+  return wifi_getmac(WIFI_IF_STA, L);
+}
 
 static void on_scan_done (const system_event_t *evt)
 {
@@ -385,6 +389,7 @@ const LUA_REG_TYPE wifi_sta_map[] = {
   { LSTRKEY( "connect" ),     LFUNCVAL( wifi_sta_connect )    },
   { LSTRKEY( "disconnect" ),  LFUNCVAL( wifi_sta_disconnect ) },
   { LSTRKEY( "getconfig" ),   LFUNCVAL( wifi_sta_getconfig )  },
+  { LSTRKEY( "getmac" ),      LFUNCVAL( wifi_sta_getmac )     },
   { LSTRKEY( "on" ),          LFUNCVAL( wifi_sta_on )         },
   { LSTRKEY( "scan" ),        LFUNCVAL( wifi_sta_scan )       },
 

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -320,6 +320,17 @@ end)
 wifi.sta.on("got_ip", nil)
 ```
 
+
+## wifi.sta.getmac()
+Gets MAC address in station mode.
+
+#### Syntax
+`wifi.sta.getmac()`
+
+#### Parameters
+None
+
+
 ## wifi.sta.scan()
 
 Scan for available networks.
@@ -436,3 +447,16 @@ Event information provided for each event is as follows:
 - `probe_req`: information about the probing client
     - `from`: MAC address of the probing client
     - `rssi`: Received Signal Strength Indicator value
+
+## wifi.ap.getmac()
+
+Gets MAC address in access point mode.
+
+#### Syntax
+`wifi.ap.getmac()`
+
+#### Parameters
+None
+
+#### Returns
+MAC address as string e.g. "18:fe:34:a2:d7:34"


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Messed up old pull request, so here is a new attempt.