### PR TITLE
Modify wifi.sta.get*config() to return AP's MAC

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -666,13 +666,14 @@ static int wifi_station_getconfig( lua_State* L, bool get_flash_cfg)
         lua_setfield(L, -2, "pwd");
       }
 
-      if(sta_conf.bssid_set==1)
-      {
-        memset(temp, 0, sizeof(temp));
-        c_sprintf(temp, MACSTR, MAC2STR(sta_conf.bssid));
-        lua_pushstring( L, temp);
-        lua_setfield(L, -2, "bssid");
-      }
+      lua_pushboolean(L, sta_conf.bssid_set);
+      lua_setfield(L, -2, "bssid_set");
+
+      memset(temp, 0, sizeof(temp));
+      c_sprintf(temp, MACSTR, MAC2STR(sta_conf.bssid));
+      lua_pushstring( L, temp);
+      lua_setfield(L, -2, "bssid");
+
       return 1;
     }
     else

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -735,8 +735,7 @@ If `return_table` is `true`:
 	- `ssid` ssid of Access Point.
 	- `pwd` password to Access Point, `nil` if no password was configured 
 	- `bssid_set` will return `true` if the station was configured specifically to connect to the AP with the matching `bssid`. 
-	- `bssid` MAC address of Access Point. 
-	 - If a connection has been made to the configured AP this field will contain the AP's MAC address. Otherwise "ff:ff:ff:ff:ff:ff" will be returned.
+	- `bssid` If a connection has been made to the configured AP this field will contain the AP's MAC address. Otherwise "ff:ff:ff:ff:ff:ff" will be returned.
  
 
 If `return_table` is `false`:
@@ -785,8 +784,7 @@ If `return_table` is `true`:
 	- `ssid` ssid of Access Point.
 	- `pwd` password to Access Point, `nil` if no password was configured
 	- `bssid_set` will return `true` if the station was configured specifically to connect to the AP with the matching `bssid`. 
-	- `bssid` MAC address of Access Point. 
-	 - If a connection has been made to the configured AP this field will contain the AP's MAC address. Otherwise "ff:ff:ff:ff:ff:ff" will be returned.
+	- `bssid` If a connection has been made to the configured AP this field will contain the AP's MAC address. Otherwise "ff:ff:ff:ff:ff:ff" will be returned.
 
 If `return_table` is `false`:
 

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -734,7 +734,7 @@ If `return_table` is `true`:
 - `config_table`
 	- `ssid` ssid of Access Point.
 	- `pwd` password to Access Point, `nil` if no password was configured 
-	- `bssid_set` will return `true` if the station was configured to specifically connect to the AP with the matching `bssid`. 
+	- `bssid_set` will return `true` if the station was configured specifically to connect to the AP with the matching `bssid`. 
 	- `bssid` MAC address of Access Point. 
 	 - If a connection has been made to the configured AP this field will contain the AP's MAC address. Otherwise "ff:ff:ff:ff:ff:ff" will be returned.
  
@@ -784,7 +784,7 @@ If `return_table` is `true`:
 - `config_table`
 	- `ssid` ssid of Access Point.
 	- `pwd` password to Access Point, `nil` if no password was configured
-	- `bssid_set` will return `true` if the station was configured to specifically connect to the AP with the matching `bssid`. 
+	- `bssid_set` will return `true` if the station was configured specifically to connect to the AP with the matching `bssid`. 
 	- `bssid` MAC address of Access Point. 
 	 - If a connection has been made to the configured AP this field will contain the AP's MAC address. Otherwise "ff:ff:ff:ff:ff:ff" will be returned.
 

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -662,7 +662,8 @@ Get information of APs cached by ESP8266 station.
 	- `1-5` index of AP. (the index corresponds to index used by [`wifi.sta.changeap()`](#wifistachangeap) and [`wifi.sta.getapindex()`](#wifistagetapindex))
 	- `ssid`  ssid of Access Point
 	- `pwd` password for Access Point, `nil` if no password was configured 
-	- `bssid` MAC address of Access Point, `nil` if no MAC address was configured
+	- `bssid` MAC address of Access Point
+	  - `nil` will be returned if no MAC address was configured during station configuration.
 
 #### Example
 ```lua
@@ -733,7 +734,10 @@ If `return_table` is `true`:
 - `config_table`
 	- `ssid` ssid of Access Point.
 	- `pwd` password to Access Point, `nil` if no password was configured 
-	- `bssid` MAC address of Access Point, `nil` if no MAC address was configured 
+	- `bssid_set` will return `true` if the station was configured to specifically connect to the AP with the matching `bssid`. 
+	- `bssid` MAC address of Access Point. 
+	 - If a connection has been made to the configured AP this field will contain the AP's MAC address. Otherwise "ff:ff:ff:ff:ff:ff" will be returned.
+ 
 
 If `return_table` is `false`:
 
@@ -744,8 +748,8 @@ If `return_table` is `false`:
 ```lua
 --Get current Station configuration (NEW FORMAT)
 do
-local def_sta_config=wifi.sta.getconfig(true)
-print(string.format("\tDefault station config\n\tssid:\"%s\"\tpassword:\"%s\"%s", def_sta_config.ssid, def_sta_config.pwd, (type(def_sta_config.bssid)=="string" and "\tbssid:\""..def_sta_config.bssid.."\"" or "")))
+local sta_config=wifi.sta.getconfig(true)
+print(string.format("\tCurrent station config\n\tssid:\"%s\"\tpassword:\"%s\"\n\tbssid:\"%s\"\tbssid_set:%s", sta_config.ssid, sta_config.pwd, sta_config.bssid, (sta_config.bssid_set and "true" or "false")))
 end
 
 --Get current Station configuration (OLD FORMAT)
@@ -780,7 +784,9 @@ If `return_table` is `true`:
 - `config_table`
 	- `ssid` ssid of Access Point.
 	- `pwd` password to Access Point, `nil` if no password was configured
-	- `bssid` MAC address of Access Point, `nil` if no MAC address was configured
+	- `bssid_set` will return `true` if the station was configured to specifically connect to the AP with the matching `bssid`. 
+	- `bssid` MAC address of Access Point. 
+	 - If a connection has been made to the configured AP this field will contain the AP's MAC address. Otherwise "ff:ff:ff:ff:ff:ff" will be returned.
 
 If `return_table` is `false`:
 
@@ -791,8 +797,8 @@ If `return_table` is `false`:
 ```lua
 --Get default Station configuration (NEW FORMAT)
 do
-  local def_sta_config=wifi.sta.getdefaultconfig(true)
-  print(string.format("\tDefault station config\n\tssid:\"%s\"\tpassword:\"%s\"%s", def_sta_config.ssid, def_sta_config.pwd, (type(def_sta_config.bssid)=="string" and "\tbssid:\""..def_sta_config.bssid.."\"" or "")))
+local def_sta_config=wifi.sta.getdefaultconfig(true)
+print(string.format("\tDefault station config\n\tssid:\"%s\"\tpassword:\"%s\"\n\tbssid:\"%s\"\tbssid_set:%s", def_sta_config.ssid, def_sta_config.pwd, def_sta_config.bssid, (def_sta_config.bssid_set and "true" or "false")))
 end
 
 --Get default Station configuration (OLD FORMAT)


### PR DESCRIPTION
Fixes #2025.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

This PR modifies the functions `wifi.sta.getconfig()` and `wifi.sta.getdefaultconfig()` to output the BSSID even if station was originally not configured to connect to an AP with a specific BSSID.