### PR TITLE
Unbreak build when SPIFFS_CACHE==0.

### DIFF
--- a/app/spiffs/spiffs_config.h
+++ b/app/spiffs/spiffs_config.h
@@ -91,6 +91,11 @@
 #ifndef  SPIFFS_CACHE_STATS
 #define SPIFFS_CACHE_STATS              1
 #endif
+#else
+// No SPIFFS_CACHE, also disable SPIFFS_CACHE_WR
+#ifndef SPIFFS_CACHE_WR
+#define SPIFFS_CACHE_WR                 0
+#endif
 #endif
 
 // Always check header of each accessed page to ensure consistent state.


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

It seems at some point we lost the ability to build if `SPIFFS_CACHE` is defined to be `0` in `user_config.h`. The spiffs code bails out due to `SPIFFS_CACHE_WR` not being defined. This fixes that problem by providing a default definition for it.