### PR TITLE
ws2812 mix: add all, then divide 

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -399,17 +399,19 @@ static int ws2812_buffer_mix(lua_State* L) {
 
   size_t i;
   for (i = 0; i < cells; i++) {
-    int val = 0;
+    int32_t val = 0;
     for (src = 0; src < n_sources; src++) {
-      val += ((int)(source[src].values[i] * source[src].factor) >> 8);
+      val += (int32_t)(source[src].values[i] * source[src].factor);
     }
+
+    val >>= 8;
 
     if (val < 0) {
       val = 0;
     } else if (val > 255) {
       val = 255;
     }
-    buffer->values[i] = val;
+    buffer->values[i] = (uint8_t)val;
   }
 
   return 0;


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This flips the ws2812 framebuffer `mix` function to add all the contributions together before dividing; this allows one to, as I do, ensure that a channel stays on even in light of other operations: `basefb:fill(1,1,1) ; outfb:mix(255,basefb,256/dimfactor,infb)`, which results in dimming that doesn't zero out color channels.

No docs changes necessary, I think.