### PR TITLE
Fix the SPIFFS blocksize issues

### DIFF
--- a/app/spiffs/spiffs.c
+++ b/app/spiffs/spiffs.c
@@ -73,7 +73,7 @@ static bool myspiffs_set_location(spiffs_config *cfg, int align, int offset, int
  * Returns  TRUE if FS was found
  * align must be a power of two
  */
-static bool myspiffs_set_cfg(spiffs_config *cfg, int align, int offset, bool force_create) {
+static bool myspiffs_set_cfg_block(spiffs_config *cfg, int align, int offset, int block_size, bool force_create) {
   cfg->phys_erase_block = INTERNAL_FLASH_SECTOR_SIZE; // according to datasheet
   cfg->log_page_size = LOG_PAGE_SIZE; // as we said
 
@@ -81,10 +81,8 @@ static bool myspiffs_set_cfg(spiffs_config *cfg, int align, int offset, bool for
   cfg->hal_write_f = my_spiffs_write;
   cfg->hal_erase_f = my_spiffs_erase;
 
-  if (!myspiffs_set_location(cfg, align, offset, LOG_BLOCK_SIZE)) {
-    if (!myspiffs_set_location(cfg, align, offset, LOG_BLOCK_SIZE_SMALL_FS)) {
-      return FALSE;
-    }
+  if (!myspiffs_set_location(cfg, align, offset, block_size)) {
+    return FALSE;
   }
 
   NODE_DBG("fs.start:%x,max:%x\n",cfg->phys_addr,cfg->phys_size);
@@ -107,6 +105,16 @@ static bool myspiffs_set_cfg(spiffs_config *cfg, int align, int offset, bool for
 #else
   return TRUE;
 #endif
+}
+
+static bool myspiffs_set_cfg(spiffs_config *cfg, int align, int offset, bool force_create) {
+  if (force_create) {
+    return myspiffs_set_cfg_block(cfg, align, offset, LOG_BLOCK_SIZE         , TRUE) ||
+           myspiffs_set_cfg_block(cfg, align, offset, LOG_BLOCK_SIZE_SMALL_FS, TRUE);
+  }
+
+  return myspiffs_set_cfg_block(cfg, align, offset, LOG_BLOCK_SIZE_SMALL_FS, FALSE) ||
+         myspiffs_set_cfg_block(cfg, align, offset, LOG_BLOCK_SIZE         , FALSE);
 }
 
 static bool myspiffs_find_cfg(spiffs_config *cfg, bool force_create) {


### PR DESCRIPTION
Fixes #2030.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] @jmattsson has thoroughly tested my contribution.

This change makes the mounting code try and mount the filesystem with both the small and the large blocksize. Thus it shouldn't matter which blocksize was used by spiffsimg. 
