### PR TITLE
dht_read11 DHT12 Fix

### DIFF
--- a/app/dhtlib/dht.c
+++ b/app/dhtlib/dht.c
@@ -41,6 +41,7 @@
 #endif /* ifndef HIGH */
 
 #define COMBINE_HIGH_AND_LOW_BYTE(byte_high, byte_low)  (((byte_high) << 8) | (byte_low))
+#define COMBINE_INT_AND_FRACTION(integer,  fraction)  ((integer * 10) + (fraction))
 
 static double dht_humidity;
 static double dht_temperature;
@@ -141,25 +142,30 @@ int dht_read_universal(uint8_t pin)
 // DHTLIB_ERROR_TIMEOUT
 int dht_read11(uint8_t pin)
 {
-    // READ VALUES
-    int rv = dht_readSensor(pin, DHTLIB_DHT11_WAKEUP);
-    if (rv != DHTLIB_OK)
-    {
-        dht_humidity    = DHTLIB_INVALID_VALUE; // invalid value, or is NaN prefered?
-        dht_temperature = DHTLIB_INVALID_VALUE; // invalid value
-        return rv;
-    }
+  // READ VALUES
+  int rv = dht_readSensor(pin, DHTLIB_DHT_WAKEUP);
+  if (rv != DHTLIB_OK)
+  {
+      dht_humidity    = DHTLIB_INVALID_VALUE;  // invalid value, or is NaN prefered?
+      dht_temperature = DHTLIB_INVALID_VALUE;  // invalid value
+      return rv; // propagate error value
+  }
 
-    // CONVERT AND STORE
-    dht_humidity    = dht_bytes[0];  // dht_bytes[1] == 0;
-    dht_temperature = dht_bytes[2];  // dht_bytes[3] == 0;
+  // CONVERT AND STORE
+  dht_humidity = (double)COMBINE_INT_AND_FRACTION(dht_bytes[0], dht_bytes[1]) * 0.1;
+  dht_temperature = (double)COMBINE_INT_AND_FRACTION(dht_bytes[2] & 0x7F, dht_bytes[3]) * 0.1;
+  if (dht_bytes[2] & 0x80)  // negative dht_temperature
+  {
+      dht_temperature = -dht_temperature;
+  }
 
-    // TEST CHECKSUM
-    // dht_bytes[1] && dht_bytes[3] both 0
-    uint8_t sum = dht_bytes[0] + dht_bytes[2];
-    if (dht_bytes[4] != sum) return DHTLIB_ERROR_CHECKSUM;
-
-    return DHTLIB_OK;
+  // TEST CHECKSUM
+  uint8_t sum = dht_bytes[0] + dht_bytes[1] + dht_bytes[2] + dht_bytes[3];
+  if (dht_bytes[4] != sum)
+  {
+      return DHTLIB_ERROR_CHECKSUM;
+  }
+  return DHTLIB_OK;
 }
 
 

--- a/docs/en/modules/dht.md
+++ b/docs/en/modules/dht.md
@@ -10,6 +10,7 @@ Constants for various functions.
 
 ## dht.read()
 Read all kinds of DHT sensors, including DHT11, 21, 22, 33, 44 humidity temperature combo sensor.
+for DHT12 please use dht.read11().
 
 #### Syntax
 `dht.read(pin)`
@@ -75,7 +76,7 @@ Read DHT11 humidity temperature combo sensor.
 [dht.read()](#dhtread)
 
 ## dht.readxx()
-Read all kinds of DHT sensors, except DHT11.
+Read all kinds of DHT sensors, except DHT11 and DHT12.
 
 ####Syntax
 `dht.readxx(pin)`


### PR DESCRIPTION
Fixes #2050.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rationale behind this PR\>
Due to shorthand implementation of DHT11,  DHT12 will fail to DHTxx logic.
However, DHT12 use the same data representations, thru DHT12 will have the wrong reading when using dht_read().
and shorthand implementation of DHT11 of its checksum will make dht_read11() fail in DHT 12.
this fix allows DHT12 user to call dht_read11() to have the correct reading.
