### PR TITLE
Add ws2812 open-drain mode

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -10,7 +10,8 @@
 
 #define CANARY_VALUE 0x32383132
 #define MODE_SINGLE  0
-#define MODE_DUAL    1
+#define MODE_SINGLE_OPEN 1
+#define MODE_DUAL    2
 
 #define FADE_IN  1
 #define FADE_OUT 0
@@ -29,7 +30,7 @@ typedef struct {
 // You HAVE to redirect LUA's output somewhere else
 static int ws2812_init(lua_State* L) {
   const int mode = luaL_optinteger(L, 1, MODE_SINGLE);
-  luaL_argcheck(L, mode == MODE_SINGLE || mode == MODE_DUAL, 1, "ws2812.SINGLE or ws2812.DUAL expected");
+  luaL_argcheck(L, mode >= MODE_SINGLE && mode <= MODE_DUAL, 1, "ws2812 mode expected");
 
   // Configure UART1
   // Set baudrate of UART1 to 3200000
@@ -46,7 +47,11 @@ static int ws2812_init(lua_State* L) {
   }
 
   // Pull GPIO2 down
-  platform_gpio_mode(4, PLATFORM_GPIO_OUTPUT, PLATFORM_GPIO_FLOAT);
+  if (mode == MODE_SINGLE_OPEN) {
+    platform_gpio_mode(4, PLATFORM_GPIO_OPENDRAIN, PLATFORM_GPIO_FLOAT);
+  } else {
+    platform_gpio_mode(4, PLATFORM_GPIO_OUTPUT, PLATFORM_GPIO_FLOAT);
+  }
   platform_gpio_write(4, 0);
 
   // Waits 10us to simulate a reset
@@ -594,6 +599,7 @@ static const LUA_REG_TYPE ws2812_map[] =
   { LSTRKEY( "FADE_IN" ),        LNUMVAL( FADE_IN ) },
   { LSTRKEY( "FADE_OUT" ),       LNUMVAL( FADE_OUT ) },
   { LSTRKEY( "MODE_SINGLE" ),    LNUMVAL( MODE_SINGLE ) },
+  { LSTRKEY( "MODE_SINGLE_OPEN" ),    LNUMVAL( MODE_SINGLE_OPEN ) },
   { LSTRKEY( "MODE_DUAL" ),      LNUMVAL( MODE_DUAL ) },
   { LSTRKEY( "SHIFT_LOGICAL" ),  LNUMVAL( SHIFT_LOGICAL ) },
   { LSTRKEY( "SHIFT_CIRCULAR" ), LNUMVAL( SHIFT_CIRCULAR ) },

--- a/docs/en/modules/ws2812.md
+++ b/docs/en/modules/ws2812.md
@@ -23,7 +23,21 @@ Initialize UART0 (TXD0) too if `ws2812.MODE_DUAL` is set.
 `ws2812.init([mode])`
 
 #### Parameters
-- `mode` (optional) either `ws2812.MODE_SINGLE` (default if omitted) or `ws2812.MODE_DUAL`
+- `mode` (optional) either `ws2812.MODE_SINGLE` (default if omitted), `ws2812.MODE_SINGLE_OPEN`, or `ws2812.MODE_DUAL`
+
+WS2812-alikes generally expect 5V supply rails and when so powered may not
+consider the 3.3V logic high of the ESP8266 to be logic high. As such, one
+should consider using a level shifter.  However, the ESP8266 has 5V tolerant
+I/O when running at 3.3V and supports open-drain GPIO, so a lower
+component-count option is to externally pull the WS2812 data line high with
+a resistor to 5V and have the ESP float, rather than drive, the line during
+logic high pulses.  That is, wire the system as follows:
+```
+5V >----[10K]---+
+                |
+GPIO4 >---------+------> WS2812 Data In
+```
+and pass `ws2812.MODE_SINGLE_OPEN`.
 
 In `ws2812.MODE_DUAL` mode you will be able to handle two strips in parallel but will lose access to Lua's serial console as it shares the same UART and PIN.
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

WS2812-alikes generally expect 5V supply rails and so may not consider the 3.3V logic high of the ESP8266 to be logic high.  As such, one should consider using a level shifter.  However, the ESP8266 is 5V tolerant and supports open-drain GPIO, so a lower component-count option is to externally pull the WS2812 data line high with a resistor to 5V and have the ESP float, rather than drive, the line during logic high pulses.  In testing, this works great with the APA106 I have handy.