### PR TITLE
Add %p to libc's debug printf

### DIFF
--- a/app/libc/dbg_printf.c
+++ b/app/libc/dbg_printf.c
@@ -120,6 +120,10 @@ reswitch:	switch (ch = *fmt++) {
 			    va_arg(ap, uint32_t) : va_arg(ap, uint32_t);
 			kprintn(put, ul, 10, width, zwidth);
 			break;
+		case 'p':
+			ul = va_arg(ap, ptrdiff_t);
+			kprintn(put, ul, 16, width, zwidth);
+			break;
 		case 'x':
 			ul = lflag ?
 			    va_arg(ap, uint32_t) : va_arg(ap, uint32_t);


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Absent this, many of the debugging printfs in the code just emit '%p', which is less than useful!
