### PR TITLE
Comment out pmsleep and timer_suspend options in user_config.h

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -114,8 +114,8 @@ extern void luaL_assertfail(const char *file, int line, const char *message);
 #define WIFI_SDK_EVENT_MONITOR_ENABLE
 #define WIFI_EVENT_MONITOR_DISCONNECT_REASON_LIST_ENABLE
 
-#define ENABLE_TIMER_SUSPEND
-#define PMSLEEP_ENABLE
+////#define ENABLE_TIMER_SUSPEND
+//#define PMSLEEP_ENABLE
 
 
 #define STRBUF_DEFAULT_INCREMENT 32

--- a/app/modules/tmr.c
+++ b/app/modules/tmr.c
@@ -428,7 +428,7 @@ static int tmr_create( lua_State *L ) {
 }
 
 
-#if defined(SWTMR_DEBUG)
+#if defined(ENABLE_TIMER_SUSPEND) && defined(SWTMR_DEBUG)
 static void tmr_printRegistry(lua_State* L){
   swtmr_print_registry();
 }
@@ -463,7 +463,7 @@ static const LUA_REG_TYPE tmr_dyn_map[] = {
 	{ LNILKEY, LNILVAL }
 };
 
-#if defined(SWTMR_DEBUG)
+#if defined(ENABLE_TIMER_SUSPEND) && defined(SWTMR_DEBUG)
 static const LUA_REG_TYPE tmr_dbg_map[] = {
     { LSTRKEY( "printRegistry" ),        LFUNCVAL( tmr_printRegistry ) },
     { LSTRKEY( "printSuspended" ),        LFUNCVAL( tmr_printSuspended ) },
@@ -492,7 +492,7 @@ static const LUA_REG_TYPE tmr_map[] = {
 	{ LSTRKEY( "state" ),        LFUNCVAL( tmr_state ) },
 	{ LSTRKEY( "interval" ),     LFUNCVAL( tmr_interval ) },
 	{ LSTRKEY( "create" ),       LFUNCVAL( tmr_create ) },
-#if defined(SWTMR_DEBUG)
+#if defined(ENABLE_TIMER_SUSPEND) && defined(SWTMR_DEBUG)
   { LSTRKEY( "debug" ),       LROVAL( tmr_dbg_map ) },
 #endif
 	{ LSTRKEY( "ALARM_SINGLE" ), LNUMVAL( TIMER_MODE_SINGLE ) },


### PR DESCRIPTION
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.

This PR comments out `ENABLE_TIMER_SUSPEND` and `PMSLEEP_ENABLE` in `user_config.h`.
These features currently have some issues that will take some time to resolve and to prevent further delay of the master drop, the features have been disabled in `user_config.h`