### PR TITLE
Makefile: optionally wrap the C compiler invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,9 @@ else
 	endif
 	CCFLAGS += -ffunction-sections -fno-jump-tables -fdata-sections
 	AR = xtensa-lx106-elf-ar
-	CC = xtensa-lx106-elf-gcc
+	CC = $(WRAPCC) xtensa-lx106-elf-gcc
 	NM = xtensa-lx106-elf-nm
-	CPP = xtensa-lx106-elf-cpp
+	CPP = $(WRAPCC) xtensa-lx106-elf-gcc -E
 	OBJCOPY = xtensa-lx106-elf-objcopy
 	FIRMWAREDIR = ../bin/
     UNAME_S := $(shell uname -s)


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

If `ccache` is installed, use it when building the firmware.  This dramatically speeds up the build, at least on my system.  Using @marcelstoer's docker image modified to include `ccache` and an otherwise unmodified checkout, `time`-ing the first build took just over 90 seconds while the second, with a completely hot cache, took a just over 25.  In comparison, a completely stock build without `ccache` at all took 78 seconds.

I believe there are no documentation changes necessary since this is an opportunistic use of `ccache`.  To be sure, I built the docker builder without ccache installed and tested that things built even with this change in place.