### PR TITLE
DHT12 Fix

### DIFF
--- a/app/dhtlib/dht.c
+++ b/app/dhtlib/dht.c
@@ -41,6 +41,7 @@
 #endif /* ifndef HIGH */
 
 #define COMBINE_HIGH_AND_LOW_BYTE(byte_high, byte_low)  (((byte_high) << 8) | (byte_low))
+#define COMBINE_INT_AND_FRACTION(integer,  fraction)  ((integer * 10) + (fraction))
 
 static double dht_humidity;
 static double dht_temperature;
@@ -141,25 +142,30 @@ int dht_read_universal(uint8_t pin)
 // DHTLIB_ERROR_TIMEOUT
 int dht_read11(uint8_t pin)
 {
-    // READ VALUES
-    int rv = dht_readSensor(pin, DHTLIB_DHT11_WAKEUP);
-    if (rv != DHTLIB_OK)
-    {
-        dht_humidity    = DHTLIB_INVALID_VALUE; // invalid value, or is NaN prefered?
-        dht_temperature = DHTLIB_INVALID_VALUE; // invalid value
-        return rv;
-    }
+  // READ VALUES
+  int rv = dht_readSensor(pin, DHTLIB_DHT_WAKEUP);
+  if (rv != DHTLIB_OK)
+  {
+      dht_humidity    = DHTLIB_INVALID_VALUE;  // invalid value, or is NaN prefered?
+      dht_temperature = DHTLIB_INVALID_VALUE;  // invalid value
+      return rv; // propagate error value
+  }
 
-    // CONVERT AND STORE
-    dht_humidity    = dht_bytes[0];  // dht_bytes[1] == 0;
-    dht_temperature = dht_bytes[2];  // dht_bytes[3] == 0;
+  // CONVERT AND STORE
+  dht_humidity = (double)COMBINE_INT_AND_FRACTION(dht_bytes[0], dht_bytes[1]) * 0.1;
+  dht_temperature = (double)COMBINE_INT_AND_FRACTION(dht_bytes[2] & 0x7F, dht_bytes[3]) * 0.1;
+  if (dht_bytes[2] & 0x80)  // negative dht_temperature
+  {
+      dht_temperature = -dht_temperature;
+  }
 
-    // TEST CHECKSUM
-    // dht_bytes[1] && dht_bytes[3] both 0
-    uint8_t sum = dht_bytes[0] + dht_bytes[2];
-    if (dht_bytes[4] != sum) return DHTLIB_ERROR_CHECKSUM;
-
-    return DHTLIB_OK;
+  // TEST CHECKSUM
+  uint8_t sum = dht_bytes[0] + dht_bytes[1] + dht_bytes[2] + dht_bytes[3];
+  if (dht_bytes[4] != sum)
+  {
+      return DHTLIB_ERROR_CHECKSUM;
+  }
+  return DHTLIB_OK;
 }
 
 

--- a/app/dhtlib/dht.c
+++ b/app/dhtlib/dht.c
@@ -140,7 +140,7 @@ int dht_read_universal(uint8_t pin)
 // DHTLIB_OK
 // DHTLIB_ERROR_CHECKSUM
 // DHTLIB_ERROR_TIMEOUT
-int dht_read11(uint8_t pin)
+int dht_read11_12(uint8_t pin)
 {
   // READ VALUES
   int rv = dht_readSensor(pin, DHTLIB_DHT_WAKEUP);
@@ -167,6 +167,16 @@ int dht_read11(uint8_t pin)
   }
   return DHTLIB_OK;
 }
+// return values:
+// DHTLIB_OK
+// DHTLIB_ERROR_CHECKSUM
+// DHTLIB_ERROR_TIMEOUT
+int dht_read11(uint8_t pin)  __attribute__((alias("dht_read11_12")));
+// return values:
+// DHTLIB_OK
+// DHTLIB_ERROR_CHECKSUM
+// DHTLIB_ERROR_TIMEOUT
+int dht_read12(uint8_t pin)  __attribute__((alias("dht_read11_12")));
 
 
 // return values:

--- a/app/dhtlib/dht.h
+++ b/app/dhtlib/dht.h
@@ -53,7 +53,7 @@
 // DHTLIB_ERROR_CHECKSUM
 // DHTLIB_ERROR_TIMEOUT
 int dht_read_universal(uint8_t pin);
-int dht_read11(uint8_t pin);
+int dht_read11_12(uint8_t pin);
 int dht_read(uint8_t pin);
 
 int dht_read21(uint8_t pin);

--- a/app/modules/dht.c
+++ b/app/modules/dht.c
@@ -33,11 +33,11 @@ static int dht_lapi_read( lua_State *L )
 }
 
 // Lua: status, temp, humi, tempdec, humidec = dht.read11( id ))
-static int dht_lapi_read11( lua_State *L )
+static int dht_lapi_read11_12( lua_State *L )
 {
   unsigned id = luaL_checkinteger( L, 1 );
   MOD_CHECK_ID( dht, id );
-  lua_pushinteger( L, dht_read11(id) );
+  lua_pushinteger( L, dht_read11_12(id) );
   double temp = dht_getTemperature();
   double humi = dht_getHumidity();
   int tempdec = (int)((temp - (int)temp) * 1000);
@@ -101,7 +101,8 @@ static int dht_lapi_readxx( lua_State *L )
 // Module function map
 static const LUA_REG_TYPE dht_map[] = {
   { LSTRKEY( "read" ),           LFUNCVAL( dht_lapi_read ) },
-  { LSTRKEY( "read11" ),         LFUNCVAL( dht_lapi_read11 ) },
+  { LSTRKEY( "read11" ),         LFUNCVAL( dht_lapi_read11_12 ) },
+  { LSTRKEY( "read12" ),         LFUNCVAL( dht_lapi_read11_12 ) },
   { LSTRKEY( "readxx" ),         LFUNCVAL( dht_lapi_readxx ) },
   { LSTRKEY( "OK" ),             LNUMVAL( DHTLIB_OK ) },
   { LSTRKEY( "ERROR_CHECKSUM" ), LNUMVAL( DHTLIB_ERROR_CHECKSUM ) },


### PR DESCRIPTION
Fixes #2050.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [] I have thoroughly tested my contribution.
- [] The code changes are reflected in the documentation at `docs/en/*`.

Due to shorthand implementation of DHT11,  DHT12 will fail to DHTxx logic.
However, DHT12 use the same data representations, thru DHT12 will have the wrong reading when using dht_read().
and shorthand implementation of DHT11 of its checksum will make dht_read11() fail in DHT 12.
this fix allows DHT12 user to call dht_read11() to have the correct reading.
