### PR TITLE
cron: don't include rtctime_internal.h

### DIFF
--- a/app/modules/cron.c
+++ b/app/modules/cron.c
@@ -8,7 +8,6 @@
 #include "c_string.h"
 #include "ets_sys.h"
 #include "time.h"
-#include "rtc/rtctime_internal.h"
 #include "rtc/rtctime.h"
 #include "stdlib.h"
 #include "mem.h"
@@ -189,7 +188,7 @@ static void cron_handle_time(uint8_t mon, uint8_t dom, uint8_t dow, uint8_t hour
 
 static void cron_handle_tmr() {
   struct rtc_timeval tv;
-  rtc_time_gettimeofday(&tv);
+  rtctime_gettimeofday(&tv);
   if (tv.tv_sec == 0) { // Wait for RTC time
     ets_timer_arm_new(&cron_timer, 1000, 0, 1);
     return;


### PR DESCRIPTION
Fixes nodemcu/nodemcu-firmware#2080

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

That file is supposed to only be included once because it does things
like declare static globals.  As it stands, cron doesn't believe time is
ticking.  With this patch applied, cron gets itself going again.

Requesting review from @pjsg and @djphoenix .