### PR TITLE
Unbreak Travis-CI build for dev-esp32 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ install:
   - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:$PATH
 script:
 - dpkg -l | grep serial
+- which python python2.7 python3
+- python --version
+- dkpg -L python-serial
 - python -c "import serial; print(serial.__file__)"
 - python3 -c "import serial; print(serial.__file__)"
 - export BUILD_DATE=$(date +%Y%m%d)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: required
 dist: trusty
 language: cpp
+# we need at least GNU Make 4.0, which isn't available in trusty, so grab it
+# manually from xenial
 before_install:
 - wget http://mirrors.kernel.org/ubuntu/pool/main/m/make-dfsg/make_4.1-6_amd64.deb
 - sudo dpkg -i make_4.1-6_amd64.deb
@@ -8,20 +10,19 @@ addons:
   apt:
     packages:
     - python-serial
-    - srecord
     - gperf
 cache:
   directories:
     - cache
+# note that we clobber $PATH completely, to get rid of /opt/python* stuff so
+# we can use the system python and python-serial, rather than messing around
+# with pip all over the place
 install:
   - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:/bin:/usr/bin:/sbin:/usr/sbin
 script:
-- which python python2.7
-- python --version
-- dpkg -L python-serial
-- python -c "import serial; print(serial.__file__)"
 - export BUILD_DATE=$(date +%Y%m%d)
 - env BUILD_DIR_BASE=`pwd`/build/float make MORE_CFLAGS="-DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all
 - env BUILD_DIR_BASE=`pwd`/build/integer make MORE_CFLAGS="-DLUA_NUMBER_INTEGRAL -DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all
+- ls -l cache/
 # http://docs.travis-ci.com/user/environment-variables/#Convenience-Variables
 #- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash "$TRAVIS_BUILD_DIR"/tools/pr-build.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ addons:
   apt:
     packages:
     - python-serial
+    - python3-serial
     - srecord
     - gperf
 cache:
@@ -17,6 +18,7 @@ install:
   - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:$PATH
 script:
 - python -c "import serial; print(serial.__file__)"
+- python3 -c "import serial; print(serial.__file__)"
 - export BUILD_DATE=$(date +%Y%m%d)
 - env BUILD_DIR_BASE=`pwd`/build/float make MORE_CFLAGS="-DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all
 - env BUILD_DIR_BASE=`pwd`/build/integer make MORE_CFLAGS="-DLUA_NUMBER_INTEGRAL -DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 language: cpp
 before_install:
 - wget http://mirrors.kernel.org/ubuntu/pool/main/m/make-dfsg/make_4.1-6_amd64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
-sudo: false
+sudo: required
 language: cpp
+before_install:
+- wget http://mirrors.kernel.org/ubuntu/pool/main/m/make-dfsg/make_4.1-6_amd64.deb
+- sudo dpkg -i make_4.1-6_amd64.deb
 addons:
   apt:
-#    sources:
-#    - debian-sid
     packages:
     - python-serial
-    - python3-serial
     - srecord
     - gperf
-    - make
 cache:
   directories:
     - cache
@@ -17,7 +16,6 @@ install:
   - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:$PATH
 script:
 - python -c "import serial; print(serial.__file__)"
-- python3 -c "import serial; print(serial.__file__)"
 - export BUILD_DATE=$(date +%Y%m%d)
 - env BUILD_DIR_BASE=`pwd`/build/float make MORE_CFLAGS="-DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all
 - env BUILD_DIR_BASE=`pwd`/build/integer make MORE_CFLAGS="-DLUA_NUMBER_INTEGRAL -DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ addons:
   apt:
     packages:
     - python-serial
-    - python3-serial
     - srecord
     - gperf
 cache:
@@ -18,11 +17,10 @@ install:
   - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:$PATH
 script:
 - dpkg -l | grep serial
-- which python python2.7 python3
+- which python python2.7
 - python --version
-- dkpg -L python-serial
+- dpkg -L python-serial
 - python -c "import serial; print(serial.__file__)"
-- python3 -c "import serial; print(serial.__file__)"
 - export BUILD_DATE=$(date +%Y%m%d)
 - env BUILD_DIR_BASE=`pwd`/build/float make MORE_CFLAGS="-DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all
 - env BUILD_DIR_BASE=`pwd`/build/integer make MORE_CFLAGS="-DLUA_NUMBER_INTEGRAL -DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,8 @@ cache:
   directories:
     - cache
 install:
-  - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:$PATH
+  - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:/bin:/usr/bin:/sbin:/usr/sbin
 script:
-- dpkg -l | grep python
 - which python python2.7
 - python --version
 - dpkg -L python-serial

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 install:
   - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:$PATH
 script:
-- dpkg -l | grep serial
+- dpkg -l | grep python
 - which python python2.7
 - python --version
 - dpkg -L python-serial

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: cpp
 addons:
   apt:
-    sources:
-    - debian-sid
+#    sources:
+#    - debian-sid
     packages:
     - python-serial
     - python3-serial

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 addons:
   apt:
     packages:
-    - python-serial
+    - python3-serial
     - srecord
     - gperf
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: required
-#dist: trusty
+sudo: required # due to manual install of make 4.1
+dist: trusty # due to the make 4.1 not installable on precise
 language: cpp
 # we need at least GNU Make 4.0, which isn't available in trusty, so grab it
 # manually from xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,22 @@ sudo: false
 language: cpp
 addons:
   apt:
+    sources:
+    - debian-sid
     packages:
+    - python-serial
     - python3-serial
     - srecord
     - gperf
+    - make
 cache:
   directories:
     - cache
 install:
   - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:$PATH
 script:
+- python -c "import serial; print(serial.__file__)"
+- python3 -c "import serial; print(serial.__file__)"
 - export BUILD_DATE=$(date +%Y%m%d)
 - env BUILD_DIR_BASE=`pwd`/build/float make MORE_CFLAGS="-DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all
 - env BUILD_DIR_BASE=`pwd`/build/integer make MORE_CFLAGS="-DLUA_NUMBER_INTEGRAL -DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ cache:
 install:
   - export PATH=$PWD/tools/toolchains/esp8266/bin:$PWD/tools/toolchains/esp32/bin:$PATH
 script:
+- dpkg -l | grep serial
 - python -c "import serial; print(serial.__file__)"
 - python3 -c "import serial; print(serial.__file__)"
 - export BUILD_DATE=$(date +%Y%m%d)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+#dist: trusty
 language: cpp
 # we need at least GNU Make 4.0, which isn't available in trusty, so grab it
 # manually from xenial
@@ -11,9 +11,6 @@ addons:
     packages:
     - python-serial
     - gperf
-cache:
-  directories:
-    - cache
 # note that we clobber $PATH completely, to get rid of /opt/python* stuff so
 # we can use the system python and python-serial, rather than messing around
 # with pip all over the place
@@ -23,6 +20,5 @@ script:
 - export BUILD_DATE=$(date +%Y%m%d)
 - env BUILD_DIR_BASE=`pwd`/build/float make MORE_CFLAGS="-DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all
 - env BUILD_DIR_BASE=`pwd`/build/integer make MORE_CFLAGS="-DLUA_NUMBER_INTEGRAL -DBUILD_DATE='\"'$BUILD_DATE'\"'" defconfig all
-- ls -l cache/
 # http://docs.travis-ci.com/user/environment-variables/#Convenience-Variables
 #- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash "$TRAVIS_BUILD_DIR"/tools/pr-build.sh; fi


### PR DESCRIPTION
After being handed a `trusty` container rather than the old `precise` container, things didn't work so well any more.

Changes:
- now forcing use of the OS python version, rather than new "magic" versions in /opt
- installing GNU make 4.1, since our build depends on that these days