### PR TITLE
Fix data loss in TCP streams.

### DIFF
--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -203,19 +203,22 @@ static void net_recv_cb(lnet_userdata *ud, struct pbuf *p, ip_addr_t *addr, u16_
     return;
   }
 
+  int num_args = 2;
+  char iptmp[16] = { 0, };
+  if (ud->type == TYPE_UDP_SOCKET)
+  {
+    num_args += 2;
+    ets_sprintf(iptmp, IPSTR, IP2STR(&addr->addr));
+  }
+
   lua_State *L = lua_getstate();
   struct pbuf *pp = p;
   while (pp)
   {
-    int num_args = 2;
     lua_rawgeti(L, LUA_REGISTRYINDEX, ud->client.cb_receive_ref);
     lua_rawgeti(L, LUA_REGISTRYINDEX, ud->self_ref);
     lua_pushlstring(L, pp->payload, pp->len);
     if (ud->type == TYPE_UDP_SOCKET) {
-      num_args += 2;
-      char iptmp[16];
-      bzero(iptmp, 16);
-      ets_sprintf(iptmp, IPSTR, IP2STR(&addr->addr));
       lua_pushinteger(L, port);
       lua_pushstring(L, iptmp);
     }

--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -202,20 +202,26 @@ static void net_recv_cb(lnet_userdata *ud, struct pbuf *p, ip_addr_t *addr, u16_
     pbuf_free(p);
     return;
   }
+
   lua_State *L = lua_getstate();
-  int num_args = 2;
-  lua_rawgeti(L, LUA_REGISTRYINDEX, ud->client.cb_receive_ref);
-  lua_rawgeti(L, LUA_REGISTRYINDEX, ud->self_ref);
-  lua_pushlstring(L, p->payload, p->len);
-  if (ud->type == TYPE_UDP_SOCKET) {
-    num_args += 2;
-    char iptmp[16];
-    bzero(iptmp, 16);
-    ets_sprintf(iptmp, IPSTR, IP2STR(&addr->addr));
-    lua_pushinteger(L, port);
-    lua_pushstring(L, iptmp);
+  struct pbuf *pp = p;
+  while (pp)
+  {
+    int num_args = 2;
+    lua_rawgeti(L, LUA_REGISTRYINDEX, ud->client.cb_receive_ref);
+    lua_rawgeti(L, LUA_REGISTRYINDEX, ud->self_ref);
+    lua_pushlstring(L, pp->payload, pp->len);
+    if (ud->type == TYPE_UDP_SOCKET) {
+      num_args += 2;
+      char iptmp[16];
+      bzero(iptmp, 16);
+      ets_sprintf(iptmp, IPSTR, IP2STR(&addr->addr));
+      lua_pushinteger(L, port);
+      lua_pushstring(L, iptmp);
+    }
+    lua_call(L, num_args, 0);
+    pp = pp->next;
   }
-  lua_call(L, num_args, 0);
   pbuf_free(p);
 }
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [n/a] The code changes are reflected in the documentation at `docs/en/*`.

So it turns out that very occasionally^ the lwip stack hands over chained `pbuf`s to the `tcp_recv()` callback. As only the first `pbuf` in the chain was passed into Lua, this meant that data went missing from the middle of the TCP stream (which one would certainly *not* expect). The fix here is to simply do multiple callbacks into Lua until the end of the chain is reached (though I've never seen more than two `pbuf`s in the chain so far).

With this patch I'm now always successfully getting the full TCP stream, whereas before I never did.

^) During each 1meg transfer, I saw it happen 1-4 times.