### PR TITLE
Fixed broken wifi.sta.{dis,}connect() with event mon enabled.

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -979,6 +979,7 @@ static int wifi_station_connect4lua( lua_State* L )
   if(lua_isfunction(L, 1)){
     lua_pushnumber(L, EVENT_STAMODE_CONNECTED);
     lua_pushvalue(L, 1);
+    lua_remove(L, 1);
     wifi_event_monitor_register(L);
   }
 #endif
@@ -993,6 +994,7 @@ static int wifi_station_disconnect4lua( lua_State* L )
   if(lua_isfunction(L, 1)){
     lua_pushnumber(L, EVENT_STAMODE_DISCONNECTED);
     lua_pushvalue(L, 1);
+    lua_remove(L, 1);
     wifi_event_monitor_register(L);
   }
 #endif


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [n/a] The code changes are reflected in the documentation at `docs/en/*`.

I discovered the hard way that `wifi.sta.disconnect()` and `wifi.sta.connect()` are unusable if `WIFI_SDK_EVENT_MONITOR_ENABLE` is defined. This is because `wifi_event_monitor_register()`  expects the first argument on the stack to be the event code, whereas connect/disconnect have left the callback function as the first argument. Fix is to remove the (copied) callback.