### PR TITLE
Handle doublequotes in strings.

### DIFF
--- a/app/modules/sjson.c
+++ b/app/modules/sjson.c
@@ -765,6 +765,8 @@ static void encode_lua_object(lua_State *L, ENC_DATA *data, int argno, const cha
           }
           *d = '\0';
           luaL_addstring(&b, value);
+        } else if (*str == '"') {
+          luaL_addstring(&b, "\\\"");
         } else {
           luaL_addchar(&b, *str);
         }


### PR DESCRIPTION
Fixes #2099.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This has been tested in a test harness which runs the sjson modules as a loadable module for a linux based lua client. It now gives the correct output:

```
print(sjson.encode({a="printf(\"hello\")"}))
```
results in:
```
{"a":"printf(\"hello\")"}
```
