### PR TITLE
changes regarding x, y, and z values in hmc5883l.c

### DIFF
--- a/app/modules/hmc5883l.c
+++ b/app/modules/hmc5883l.c
@@ -44,7 +44,6 @@ static int hmc5883_setup(lua_State* L) {
     if ((devid_a != 0x48) || (devid_b != 0x34) || (devid_c != 0x33)) {
         return luaL_error(L, "device not found");
     }
-
     // 8 sample average, 15 Hz update rate, normal measurement
     w8u(hmc5883_i2c_id, 0x00, 0x70);
 
@@ -58,7 +57,6 @@ static int hmc5883_setup(lua_State* L) {
 }
 
 static int hmc5883_init(lua_State* L) {
-
     uint32_t sda;
     uint32_t scl;
 
@@ -96,8 +94,8 @@ static int hmc5883_read(lua_State* L) {
     platform_i2c_send_stop(hmc5883_i2c_id);
 
     x = (int16_t) ((data[0] << 8) | data[1]);
-    y = (int16_t) ((data[2] << 8) | data[3]);
-    z = (int16_t) ((data[4] << 8) | data[5]);
+    z = (int16_t) ((data[2] << 8) | data[3]);
+    y = (int16_t) ((data[4] << 8) | data[5]);
 
     lua_pushinteger(L, x);
     lua_pushinteger(L, y);


### PR DESCRIPTION
in current code of hmc5883l.c it uses
`x = (int16_t) ((data[0] << 8) | data[1]);`
`y = (int16_t) ((data[2] << 8) | data[3]);`
`z = (int16_t) ((data[4] << 8) | data[5]);`

but as per hmc5883l datasheet 

0th and 1st bytes are of x axis 
2nd and 3rd bytes are of z axis
4th and 5th bytes are of y axis
![image](https://user-images.githubusercontent.com/32166791/31483673-f81a48ee-af4a-11e7-8d81-8db826e1893a.png)

i.e. it should be

`x = (int16_t) ((data[0] << 8) | data[1]);`
`z = (int16_t) ((data[2] << 8) | data[3]);`
`y = (int16_t) ((data[4] << 8) | data[5]);`

Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rationale behind this PR\>
