### PR TITLE
Fixes problems with time not preserved through dsleep

### DIFF
--- a/app/include/rtc/rtctime_internal.h
+++ b/app/include/rtc/rtctime_internal.h
@@ -506,11 +506,6 @@ extern void rtc_time_enter_deep_sleep_final(void);
 
 static void rtc_time_enter_deep_sleep_us(uint32_t us)
 {
-  if (rtc_time_check_wake_magic())
-    rtc_time_set_sleep_magic();
-  else 
-    bbram_save();
-
   rtc_reg_write(0,0);
   rtc_reg_write(0,rtc_reg_read(0)&0xffffbfff);
   rtc_reg_write(0,rtc_reg_read(0)|0x30);
@@ -535,6 +530,11 @@ static void rtc_time_enter_deep_sleep_us(uint32_t us)
 
   uint32_t cycles=rtc_time_us_to_ticks(us);
   rtc_time_add_sleep_tracking(us,cycles);
+
+  if (rtc_time_check_wake_magic())
+    rtc_time_set_sleep_magic();
+  else 
+    bbram_save();
 
   rtc_reg_write(RTC_TARGET_ADDR,rtc_time_read_raw()+cycles);
   rtc_reg_write(0x9c,17);

--- a/app/include/rtc/rtctime_internal.h
+++ b/app/include/rtc/rtctime_internal.h
@@ -187,8 +187,9 @@
 #define CPU_BOOTUP_MHZ    52
 
 #ifdef RTC_DEBUG_ENABLED
+#warn this does not really work....
 #define RTC_DBG(...)         do { if (rtc_dbg_enabled == 'R') { dbg_printf(__VA_ARGS__); } } while (0)
-static bool rtc_dbg_enabled;
+static char rtc_dbg_enabled;
 #define RTC_DBG_ENABLED()   rtc_dbg_enabled = 'R'
 #define RTC_DBG_NOT_ENABLED()   rtc_dbg_enabled = 0
 #else
@@ -196,6 +197,8 @@ static bool rtc_dbg_enabled;
 #define RTC_DBG_ENABLED()
 #define RTC_DBG_NOT_ENABLED()
 #endif
+
+#define NOINIT_ATTR __attribute__((section(".noinit")))
 
 // RTCTIME storage
 #define RTC_TIME_MAGIC_POS       (RTC_TIME_BASE+0)
@@ -210,18 +213,18 @@ static bool rtc_dbg_enabled;
 //#define RTC_LASTTODUS_POS        (RTC_TIME_BASE+9)
 #define RTC_USRATE_POS		 (RTC_TIME_BASE+8)
 
-static uint32_t rtc_time_magic;
-static uint64_t rtc_cycleoffset;
-static uint32_t rtc_lastsourceval;
-static uint32_t rtc_sourcecycleunits;
-static uint32_t rtc_calibration;
-static uint32_t rtc_sleeptotalus;
-static uint32_t rtc_sleeptotalcycles;
-static uint64_t rtc_usatlastrate;
-static uint64_t rtc_rateadjustedus;
-static uint32_t rtc_todoffsetus;
-static uint32_t rtc_lasttodus;
-static uint32_t rtc_usrate;
+NOINIT_ATTR uint32_t rtc_time_magic;
+NOINIT_ATTR uint64_t rtc_cycleoffset;
+NOINIT_ATTR uint32_t rtc_lastsourceval;
+NOINIT_ATTR uint32_t rtc_sourcecycleunits;
+NOINIT_ATTR uint32_t rtc_calibration;
+NOINIT_ATTR uint32_t rtc_sleeptotalus;
+NOINIT_ATTR uint32_t rtc_sleeptotalcycles;
+NOINIT_ATTR uint64_t rtc_usatlastrate;
+NOINIT_ATTR uint64_t rtc_rateadjustedus;
+NOINIT_ATTR uint32_t rtc_todoffsetus;
+NOINIT_ATTR uint32_t rtc_lasttodus;
+NOINIT_ATTR uint32_t rtc_usrate;
 
 
 struct rtc_timeval
@@ -744,8 +747,8 @@ static void rtc_time_register_bootup(void)
     if (reset_reason!=2)  // This was *not* a proper wakeup from a deep sleep. All our time keeping is f*cked!
       rtc_time_reset(erase_calibration); // Possibly keep the calibration, it should still be good
     rtc_time_select_ccount_source(CPU_BOOTUP_MHZ,true);
-    rtc_rateadjustedus = rtc_usatlastrate = rtc_time_get_now_us_adjusted();
     rtc_todoffsetus = 0;
+    rtc_rateadjustedus = rtc_usatlastrate = rtc_time_get_now_us_adjusted();
     RTC_DBG_ENABLED();
     return;
   }

--- a/ld/nodemcu.ld
+++ b/ld/nodemcu.ld
@@ -207,6 +207,7 @@ SECTIONS
     *(COMMON)
     . = ALIGN (8);
     _bss_end = ABSOLUTE(.);
+    *(.noinit)
     _heap_start = ABSOLUTE(.);
 /*    _stack_sentry = ALIGN(0x8); */
   } >dram0_0_seg :dram0_0_bss_phdr


### PR DESCRIPTION
Fixes #2144.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

When I moved the rtc variables into memory (from the very slow rtc memory), the .bss initialization would clear them out after they were initialized. This caused no end of problems. Also, the sleep tracking values were updated *after* the last save to the rtc memory.

I'm currently running a long term test. The long term sleep (of 100 seconds) seems to cause a drift of under 1000ppm. 