### PR TITLE
Make it build without INTERRUPT_ENABLE

### DIFF
--- a/app/modules/gpio.c
+++ b/app/modules/gpio.c
@@ -132,7 +132,13 @@ static int lgpio_mode( lua_State* L )
 
 NODE_DBG("pin,mode,pullup= %d %d %d\n",pin,mode,pullup);
 NODE_DBG("Pin data at mode: %d %08x, %d %d %d, %08x\n",
-          pin, pin_mux[pin], pin_num[pin], pin_func[pin], pin_int_type[pin], gpio_cb_ref[pin]);
+          pin, pin_mux[pin], pin_num[pin], pin_func[pin], 
+#ifdef GPIO_INTERRUPT_ENABLE
+          pin_int_type[pin], gpio_cb_ref[pin]
+#else
+          0, 0
+#endif
+          );
 
 #ifdef GPIO_INTERRUPT_ENABLE
   if (mode != INTERRUPT){     // disable interrupt


### PR DESCRIPTION
Fixes #2092 .


- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- x ] I have thoroughly tested my contribution.

Makes it build without having to have GPIO_INTERRUPT_ENABLE defined (the default is to have it defined).
