### PR TITLE
esp8266: WiFi method to adjust maximum TX power

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -303,9 +303,7 @@ static int wifi_setmaxtxpower( lua_State* L )
 {
   unsigned power;
   power = luaL_checkinteger( L, 1 );
-
-  if ( power > 82 )
-    return luaL_error( L, "tx power out of range (0->82)");
+  luaL_argcheck(L, (power > 0 && power < 83), 1, "tx power out of range (0->82)");
 
   system_phy_set_max_tpw( (uint8_t) power);
   return 1;

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -298,6 +298,19 @@ static int wifi_getphymode( lua_State* L )
   return 1;
 }
 
+// Lua: wifi.setmaxtxpower()
+static int wifi_setmaxtxpower( lua_State* L )
+{
+  unsigned power;
+  power = luaL_checkinteger( L, 1 );
+
+  if ( power > 82 )
+    return luaL_error( L, "tx power out of range (0->82)");
+
+  system_phy_set_max_tpw( (uint8_t) power);
+  return 1;
+}
+
 #ifdef PMSLEEP_ENABLE
 /* Begin WiFi suspend functions*/
 #include "pmSleep.h"
@@ -1796,6 +1809,7 @@ static const LUA_REG_TYPE wifi_map[] =  {
   { LSTRKEY( "getchannel" ),     LFUNCVAL( wifi_getchannel ) },
   { LSTRKEY( "setphymode" ),     LFUNCVAL( wifi_setphymode ) },
   { LSTRKEY( "getphymode" ),     LFUNCVAL( wifi_getphymode ) },
+  { LSTRKEY( "setmaxtxpower" ),  LFUNCVAL( wifi_setmaxtxpower ) },
 #ifdef PMSLEEP_ENABLE
   { LSTRKEY( "suspend" ),        LFUNCVAL( wifi_suspend ) },
   { LSTRKEY( "resume" ),         LFUNCVAL( wifi_resume ) },

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -213,7 +213,7 @@ physical mode after setup
 
 ## wifi.setmaxtxpower()
 
-Sets WiFi maximum tx power
+Sets WiFi maximum tx power.  This setting is not persisted across power cycles, and the documentation does not specify if the setting persists after deep sleep.
 
 #### Syntax
 `wifi.setmaxtxpower(max_tpw)`

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -213,7 +213,7 @@ physical mode after setup
 
 ## wifi.setmaxtxpower()
 
-Sets WiFi maximum tx power.  This setting is not persisted across power cycles, and the documentation does not specify if the setting persists after deep sleep.
+Sets WiFi maximum tx power.  This setting is not persisted across power cycles, and the documentation does not specify if the setting persists after deep sleep.  The default value used is read from flash at boot time as part of the esp8266 init data, and its value is set by the Espressif SDK.
 
 #### Syntax
 `wifi.setmaxtxpower(max_tpw)`

--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -211,6 +211,20 @@ physical mode after setup
 #### See also
 [`wifi.getphymode()`](#wifigetphymode)
 
+## wifi.setmaxtxpower()
+
+Sets WiFi maximum tx power
+
+#### Syntax
+`wifi.setmaxtxpower(max_tpw)`
+
+#### Parameters
+`max_tpw` maximum value of RF Tx Power, unit: 0.25 dBm, range [0, 82]. 
+
+#### Returns
+`nil`
+
+
 ## wifi.startsmart()
 
 Starts to auto configuration, if success set up SSID and password automatically.


### PR DESCRIPTION
Fixes #2164 

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

I added the requested method to set maximum TX power.  I wasn't sure if the API should be expressed in dBm or these quarter-dBm units that the espressif SDK uses, so I went with quarter-dBm.  There is no SDK method to obtain the current setting, so I did not add this to the Lua binding.


