### PR TITLE
fix example which is not intended to write to flash, but actually was

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -453,6 +453,7 @@ Sets the WiFi station configuration.
 station_cfg={}
 station_cfg.ssid="NODE-AABBCC"
 station_cfg.pwd="password"
+station_cfg.save=false
 wifi.sta.config(station_cfg)
 
 --connect to Access Point (DO save config to flash)
@@ -462,14 +463,14 @@ station_cfg.pwd="password"
 station_cfg.save=true
 wifi.sta.config(station_cfg)
 
---connect to Access Point with specific MAC address  
+--connect to Access Point with specific MAC address (DO save config to flash)
 station_cfg={}
 station_cfg.ssid="NODE-AABBCC"
 station_cfg.pwd="password"
 station_cfg.bssid="AA:BB:CC:DD:EE:FF"
 wifi.sta.config(station_cfg)
 
---configure station but don't connect to Access point
+--configure station but don't connect to Access point (DO save config to flash)
 station_cfg={}
 station_cfg.ssid="NODE-AABBCC"
 station_cfg.pwd="password"


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

The examples for wifi.sta.config() show different scenarios, including one which states that the config will not be written to flash. The provided example actually writes to flash. This could lead to unintentional excessive flash wear.