### PR TITLE
Update file.c

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -477,7 +477,7 @@ static int file_readline( lua_State* L )
 {
   GET_FILE_OBJ;
 
-  return file_g_read(L, LUAL_BUFFERSIZE, '\n', fd);
+  return file_g_read(L, FILE_READ_CHUNK, '\n', fd);
 }
 
 // Lua: write("string")


### PR DESCRIPTION
Buffer size of funtion readline is wrong  (Line 480)
Should be FILE_READ_CHUNK = 1024 bytes instead 256 bytes

Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rationale behind this PR\>
Buffer size wrong.