### PR TITLE
host field in HTTP header is no longer limited to 31 charcters

### DIFF
--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -215,20 +215,23 @@ static void ICACHE_FLASH_ATTR http_connect_callback( void * arg )
         ua_len = strlen(ua_header);
     }
 
-	char host_header[32] = "";
+	char * host_header = "";
     int host_len = 0;
     if ( os_strstr( req->headers, "Host:" ) == NULL && os_strstr( req->headers, "host:" ) == NULL)
     {
+        int max_header_len = 9 + strlen(req->hostname); // 9 is fixed size of "Host:[space][cr][lf]\0"
         if ((req->port == 80)
 #ifdef CLIENT_SSL_ENABLE
             || ((req->port == 443) && ( req->secure ))
 #endif
             )
         {
+            host_header = alloca(max_header_len);
             os_sprintf( host_header, "Host: %s\r\n", req->hostname );
         }
         else
         {
+            host_header = alloca(max_header_len + 6); // 6 is worst case of ":port" where port is maximum 5 digits
             os_sprintf( host_header, "Host: %s:%d\r\n", req->hostname, req->port );
         }
         host_len = strlen(host_header);


### PR DESCRIPTION
Fixed #2205, resubmit of #2202 on the dev branch