### PR TITLE
Fix batch multi-line UART input discarding all but first line

### DIFF
--- a/app/lua/lua.c
+++ b/app/lua/lua.c
@@ -599,11 +599,12 @@ static bool readline(lua_Load *load){
         {
           /* Get a empty line, then go to get a new line */
           c_puts(load->prmt);
+          continue;
         } else {
           load->done = 1;
           need_dojob = true;
+          break;
         }
-        continue;
       }
 
       /* other control character or not an acsii character */

--- a/app/lua/lua.c
+++ b/app/lua/lua.c
@@ -468,8 +468,11 @@ int lua_main (int argc, char **argv) {
 
 void lua_handle_input (bool force)
 {
-  if (gLoad.L && (force || readline (&gLoad)))
+  while (gLoad.L && (force || readline (&gLoad)))
+  {
     dojob (&gLoad);
+    force = false;
+  }
 }
 
 void donejob(lua_Load *load){


### PR DESCRIPTION
- [X] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [n/a] The code changes are reflected in the documentation at `docs/en/*`.

Currently, if sending Lua commands to the ESP over UART one needs to have a bit of a break between each command. This is most noticeable if you're feeding commands from another micro controller to the ESP.

I finally tracked down the cause of this. It turns out that we're at most ever handing one line over to the LVM for each input-has-arrived notification. If that input consisted of multiple lines, we end up silently gobbling them up. This PR now splits up such input and gets each line through to the LVM. You'll still want to avoid filling up the UART input buffer so the LVM gets a chance to process it, but sending a few short lines in a batch is no longer a problem.
