### PR TITLE
Fix leak in pcm for subsequent object creation

### DIFF
--- a/app/pcm/drv_sigma_delta.c
+++ b/app/pcm/drv_sigma_delta.c
@@ -33,7 +33,7 @@ static void ICACHE_RAM_ATTR drv_sd_timer_isr( os_param_t arg )
     if (cfg->vu_samples_tmp >= cfg->vu_req_samples) {
       cfg->vu_peak = cfg->vu_peak_tmp;
 
-      task_post_low( cfg->data_vu_task, (os_param_t)cfg );
+      task_post_low( pcm_data_vu_task, (os_param_t)cfg );
 
       cfg->vu_samples_tmp = 0;
       cfg->vu_peak_tmp    = 0;
@@ -44,7 +44,7 @@ static void ICACHE_RAM_ATTR drv_sd_timer_isr( os_param_t arg )
       // buffer data consumed, request to re-fill it
       buf->empty = TRUE;
       cfg->fbuf_idx = cfg->rbuf_idx;
-      task_post_high( cfg->data_play_task, (os_param_t)cfg );
+      task_post_high( pcm_data_play_task, (os_param_t)cfg );
       // switch to next buffer
       cfg->rbuf_idx ^= 1;
       dbg_platform_gpio_write( PLATFORM_GPIO_LOW );
@@ -54,7 +54,7 @@ static void ICACHE_RAM_ATTR drv_sd_timer_isr( os_param_t arg )
     cfg->isr_throttled = 1;
     dbg_platform_gpio_write( PLATFORM_GPIO_LOW );
     cfg->fbuf_idx = cfg->rbuf_idx;
-    task_post_high( cfg->data_play_task, (os_param_t)cfg );
+    task_post_high( pcm_data_play_task, (os_param_t)cfg );
   }
 
 }

--- a/app/pcm/pcm.h
+++ b/app/pcm/pcm.h
@@ -4,6 +4,7 @@
 #define _PCM_H
 
 
+#include "task/task.h"
 #include "platform.h"
 
 
@@ -63,8 +64,6 @@ typedef struct {
   // buffer selectors
   uint8_t rbuf_idx;   // read by ISR
   uint8_t fbuf_idx;   // fill by data task
-  // task handles
-  task_handle_t data_vu_task, data_play_task, start_play_task;
   // callback fn refs
   int self_ref;
     int cb_data_ref, cb_drained_ref, cb_paused_ref, cb_stopped_ref, cb_vu_ref;
@@ -95,7 +94,10 @@ typedef struct {
 } pud_t;
 
 
-void pcm_data_vu_task( task_param_t param, uint8 prio );
-void pcm_data_play_task( task_param_t param, uint8 prio );
+void pcm_data_vu( task_param_t param, uint8 prio );
+void pcm_data_play( task_param_t param, uint8 prio );
+
+// task handles
+extern task_handle_t pcm_data_vu_task, pcm_data_play_task, pcm_start_play_task;
 
 #endif /* _PCM_H */

--- a/app/pcm/pcm_core.c
+++ b/app/pcm/pcm_core.c
@@ -27,7 +27,7 @@ static void dispatch_callback( lua_State *L, int self_ref, int cb_ref, int retur
   }
 }
 
-void pcm_data_vu_task( task_param_t param, uint8 prio )
+void pcm_data_vu( task_param_t param, uint8 prio )
 {
   cfg_t *cfg = (cfg_t *)param;
   lua_State *L = lua_getstate();
@@ -40,7 +40,7 @@ void pcm_data_vu_task( task_param_t param, uint8 prio )
   }
 }
 
-void pcm_data_play_task( task_param_t param, uint8 prio )
+void pcm_data_play( task_param_t param, uint8 prio )
 {
   cfg_t *cfg = (cfg_t *)param;
   pcm_buf_t *buf = &(cfg->bufs[cfg->fbuf_idx]);
@@ -85,7 +85,7 @@ void pcm_data_play_task( task_param_t param, uint8 prio )
         // rerun data callback to get next buffer chunk
         dbg_platform_gpio_write( PLATFORM_GPIO_LOW );
         cfg->fbuf_idx = other_buf;
-        pcm_data_play_task( param, 0 );
+        pcm_data_play( param, 0 );
       }
       // unthrottle ISR
       cfg->isr_throttled = 0;


### PR DESCRIPTION
Fixes #2227.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This fixes a memory leak when multiple pcm objects are created:
No need to assign task ids in `new()`, just initialize them once during module registration.