### PR TITLE
Disable (and clear) unexpected interrupts

### DIFF
--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -247,6 +247,10 @@ static void ICACHE_RAM_ATTR platform_gpio_intr_dispatcher (void *dummy){
           }
           // We re-enable the interrupt when we execute the callback (if level)
         }
+      } else {
+        // this is an unexpected interrupt so shut it off for now
+        gpio_pin_intr_state_set(GPIO_ID_PIN(j), GPIO_PIN_INTR_DISABLE);
+        GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, BIT(j));
       }
     }
   }


### PR DESCRIPTION
Fixes #2229.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.

As @pjsg suggested: When the GPIO ISR is triggered for an unexpected interrupt it's shut off and has its status cleared. This fixes the issue of pending interrupts after `node.restart()` and is supposed to mitigate races when a level-triggered interrupt fires between `gpio.mode()` and `gpio.trig()`.

It would be great if someone with a HW setup for `gpio.trig()` could verify the change for regressions. @crasu can you maybe support here and check whether your application is still working?
