### PR TITLE
ads1115 - introduced sign into read and startread

### DIFF
--- a/docs/en/modules/ads1115.md
+++ b/docs/en/modules/ads1115.md
@@ -92,19 +92,20 @@ ads1115.reset()
 Gets the result stored in the register of a previously issued conversion, e.g. in continuous mode or with a conversion ready interrupt.
 
 #### Syntax
-`volt, volt_dec, adc = device:read()`
+`volt, volt_dec, raw, sign = device:read()`
 
 #### Parameters
 none
 
 #### Returns
 - `volt` voltage in mV (see note below)
-- `volt_dec` voltage decimal (see note below)
-- `adc` raw adc value
+- `volt_dec` voltage decimal in uV (see note below)
+- `adc` raw adc register value
+- `sign` sign of the result (see note below)
 
 !!! note
 
-	If using float firmware then `volt` is a floating point number. On an integer firmware, the final value has to be concatenated from `volt` and `volt_dec`. Both values `volt` and `volt_dec` contains sign.
+	If using float firmware then `volt` is a floating point number, `volt_dec` and `sign` are nil. On an integer firmware, the final value has to be concatenated from `volt`, `volt_dec` and `sign`. On integer firmware `volt` and `volt_dec` are always positive, sign can be `-1`, `0`, `1`.
 
 #### Example
 ```lua
@@ -116,23 +117,32 @@ adc1 = ads1115.ads1115(id, ads1115.ADDR_GND)
 -- continuous mode
 adc1:setting(ads1115.GAIN_6_144V, ads1115.DR_128SPS, ads1115.SINGLE_0, ads1115.CONTINUOUS)
 -- read adc result with read()
-volt, volt_dec, adc = ads1:read()
-print(volt, volt_dec, adc)
+volt, volt_dec, adc, sign = ads1:read()
+print(volt, volt_dec, adc, sign)
 
 -- comparator
 adc1:setting(ads1115.GAIN_6_144V, ads1115.DR_128SPS, ads1115.SINGLE_0, ads1115.CONTINUOUS, ads1115.COMP_1CONV, 1000, 2000)
 local function comparator(level, when)
 	-- read adc result with read() when threshold reached
 	gpio.trig(alert_pin)
-	volt, volt_dec, adc = ads1:read()
-	print(volt, volt_dec, adc)
+	volt, volt_dec, adc, sign = ads1:read()
+	print(volt, volt_dec, adc, sign)
 end
 gpio.mode(alert_pin, gpio.INT)
 gpio.trig(alert_pin, "both", comparator)
 
 -- read adc result with read()
-volt, volt_dec, adc = ads1115:read()
-print(volt, volt_dec, adc)
+volt, volt_dec, adc, sign = ads1115:read()
+print(volt, volt_dec, adc, sing)
+
+-- format value in int build
+if sign then
+    -- int build
+    print(string.format("%s%d.%03d mV", sign >= 0 and "+" or "-", volt, volt_dec))
+else
+    -- float build
+    -- just use V as it is
+end
 ```
 
 
@@ -218,7 +228,7 @@ Starts the ADC reading for single-shot mode and after the conversion is done it 
 
 #### Parameters
 - `CALLBACK` callback function which will be invoked after the adc conversion is done
-	* `function(volt, volt_dec, adc) end`
+	* `function(volt, volt_dec, adc, sign) end`
 
 #### Returns
 - `nil`
@@ -233,14 +243,14 @@ adc1 = ads1115.ads1115(id, ads1115.ADDR_VDD)
 -- single shot
 adc1:setting(ads1115.GAIN_6_144V, ads1115.DR_128SPS, ads1115.SINGLE_0, ads1115.SINGLE_SHOT)
 -- start adc conversion and get result in callback after conversion is ready
-adc1:startread(function(volt, volt_dec, adc) print(volt, volt_dec, adc) end)
+adc1:startread(function(volt, volt_dec, adc, sign) print(volt, volt_dec, adc, sign) end)
 
 -- conversion ready
 adc1:setting(ads1115.GAIN_6_144V, ads1115.DR_128SPS, ads1115.SINGLE_0, ads1115.SINGLE_SHOT, ads1115.CONV_RDY_1)
 local function conversion_ready(level, when)
 	gpio.trig(alert_pin)
-	volt, volt_dec, adc = adc1:read()
-	print(volt, volt_dec, adc)
+	volt, volt_dec, adc, sign = adc1:read()
+	print(volt, volt_dec, adc, sign)
 end
 gpio.mode(alert_pin, gpio.INT)
 gpio.trig(alert_pin, "down", conversion_ready)


### PR DESCRIPTION
* in float build, uV and sign are included in mV
* in int build, uV and mV are absolute, sign is -1, 0, 1
* added rounding of uV values
* added optional test function

Fixes #2207

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution. Tests available under: https://github.com/paweljasinski/nodemcu-mispec/blob/master/nodemcu/mispec_ads1115_1.lua and https://github.com/paweljasinski/nodemcu-mispec/blob/master/nodemcu/mispec_ads1115_2.lua
- [x] The code changes are reflected in the documentation at `docs/en/*`.


