### PR TITLE
Single source for SSL / mbedtls buffer size setting

### DIFF
--- a/app/include/user_mbedtls.h
+++ b/app/include/user_mbedtls.h
@@ -1,5 +1,7 @@
 #include "c_types.h"
 
+#include "user_config.h"
+
 #undef MBEDTLS_HAVE_ASM
 #undef MBEDTLS_HAVE_SSE2
 
@@ -288,7 +290,19 @@
 //#define MBEDTLS_PLATFORM_NV_SEED_WRITE_MACRO  mbedtls_platform_std_nv_seed_write /**< Default nv_seed_write function to use, can be undefined */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_TIMEOUT       86400 /**< 1 day  */
 //#define MBEDTLS_SSL_CACHE_DEFAULT_MAX_ENTRIES      50 /**< Maximum entries in cache */
-#define MBEDTLS_SSL_MAX_CONTENT_LEN             4096 /**< Maxium fragment length in bytes, determines the size of each of the two internal I/O buffers */
+
+#if 0
+// dynamic buffer sizing with espconn_secure_set_size()
+extern unsigned int max_content_len;
+#define MBEDTLS_SSL_MAX_CONTENT_LEN             max_content_len;
+#else
+// the current mbedtls integration doesn't allow to set the buffer size dynamically:
+//   MBEDTLS_SSL_MAX_FRAGMENT_LENGTH feature and dynamic sizing are mutually exclusive
+//   due to non-constant initializer element in app/mbedtls/library/ssl_tls.c:150 
+// the buffer size is hardcoded here and value is taken from SSL_BUFFER_SIZE (user_config.h)
+#define MBEDTLS_SSL_MAX_CONTENT_LEN             SSL_BUFFER_SIZE /**< Maxium fragment length in bytes, determines the size of each of the two internal I/O buffers */
+#endif
+
 //#define MBEDTLS_SSL_DEFAULT_TICKET_LIFETIME     86400 /**< Lifetime of session tickets (if enabled) */
 //#define MBEDTLS_PSK_MAX_LEN               32 /**< Max size of TLS pre-shared keys, in bytes (default 256 bits) */
 //#define MBEDTLS_SSL_COOKIE_TIMEOUT        60 /**< Default expiration delay of DTLS cookies, in seconds if HAVE_TIME, or in number of cookies issued */

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -150,8 +150,12 @@ void nodemcu_init(void)
         return;
     }
 
+#if 0
+// espconn_secure_set_size() is not effective
+// see comments for MBEDTLS_SSL_MAX_CONTENT_LEN in user_mbedtls.h
 #if defined ( CLIENT_SSL_ENABLE ) && defined ( SSL_BUFFER_SIZE )
     espconn_secure_set_size(ESPCONN_CLIENT, SSL_BUFFER_SIZE);
+#endif
 #endif
 
 #ifdef BUILD_SPIFFS


### PR DESCRIPTION
Addresses #1707.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

## ~Commit "update espconn apps for lwip and mbedtls from non-os sdk master branch"~
~Recent bug fixes for espconn layer in Espressif's NON-OS SDK appear to fix the `HTTP client: Disconnected with error: 8` error with our http client (ref. https://github.com/nodemcu/nodemcu-firmware/issues/1707#issuecomment-362351302).~
~`espconn*` files are copied from third_party/mbedtls and third_party/lwip in https://github.com/espressif/ESP8266_NONOS_SDK/tree/cab958da920a9c29b09b8c8f906780a5d3d0427b/~

## Commit "enforce single source for SSL buffer size"
We had some inconsistency in the code base related to SSL buffer size configuration.

### Situation up to now
* `user_config.h` defines `SSL_BUFFER_SIZE` to 5120
* [`app/user/user_main.c`](https://github.com/nodemcu/nodemcu-firmware/blob/f87d68ff8f14128e18be4061123b644120ed9387/app/user/user_main.c#L154) uses this to configure the espconn/mbedtls layer
* But `espconn_secure_set_size()` is not effective due to our own integration of mbedtls. Espressif applied [some tweaks](https://github.com/espressif/ESP8266_NONOS_SDK/blob/cab958da920a9c29b09b8c8f906780a5d3d0427b/third_party/include/mbedtls/config_esp.h#L2471) to enable dynamic buffer sizing.
* In parallel, the real buffer size is defined by `MBEDTLS_SSL_MAX_CONTENT_LEN` in [`user_mbedtls.h`](https://github.com/nodemcu/nodemcu-firmware/blob/f87d68ff8f14128e18be4061123b644120ed9387/app/include/user_mbedtls.h#L291).

### Change
SSL buffer sizing mechanism is (almost) back to pre-mbedtls status:
Single source for SSL/TLS buffer size definition with `SSL_BUFFER_SIZE` in `user_config.h`. No need anymore to set the same value in `user_mbedtls.h`.

### Summary
We lost dynamic buffer sizing when we moved to our local mbedtls. It's not possible with the current configuration of `mbedtls` since the feature `MBEDTLS_SSL_MAX_FRAGMENT_LENGTH` and dynamic buffers are mutually exclusive due to non-constant initializer element error from app/mbedtls/library/ssl_tls.c:150.
If we decide to disable `MBEDTLS_SSL_MAX_FRAGMENT_LENGTH` then we could apply the same tweak like Espressif did and add a function to the `tls` module API to set buffer size during runtime.
