### PR TITLE
MQTT re-connect issue

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -337,6 +337,7 @@ READPACKET:
       } else {
         mud->connState = MQTT_DATA;
         NODE_DBG("MQTT: Connected\r\n");
+        mud->keepalive_sent = 0;
         if (mud->mqtt_state.auto_reconnect == RECONNECT_POSSIBLE) {
           mud->mqtt_state.auto_reconnect = RECONNECT_ON;
         }


### PR DESCRIPTION
Fixes #2197 .

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Connection with the broker could not be reestablished after a disconnect. This was caused by the node not sending a PINGREQ after the keep-alive period. This has been resolved by clearing the keep_alive flag after (re-)connecting.
