### PR TITLE
Disable MQTT connect error callback after successful connection

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -338,6 +338,8 @@ READPACKET:
         mud->connState = MQTT_DATA;
         NODE_DBG("MQTT: Connected\r\n");
         mud->keepalive_sent = 0;
+        luaL_unref(L, LUA_REGISTRYINDEX, mud->cb_connect_fail_ref);
+        mud->cb_connect_fail_ref = LUA_NOREF;
         if (mud->mqtt_state.auto_reconnect == RECONNECT_POSSIBLE) {
           mud->mqtt_state.auto_reconnect = RECONNECT_ON;
         }


### PR DESCRIPTION
Fixes #2257 

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Disable the error callback of mqtt.client:connect() after a successful connection.
This will prevent this function to be called after a future disconnection.
Instead the "offline" function is called.

**Note**
Not sure if this is a mis-use of the "offline"  function, but this implementation seems more clean and better to understand. And I hope I implemented clearing the error callback in a correct way.