### PR TITLE
remove deprecated init functions in adxl345, am2320, bme280, bmp085, hdc1080, hmc58831, l3g4200d, HDC1000, lm92

### DIFF
--- a/app/modules/adxl345.c
+++ b/app/modules/adxl345.c
@@ -45,23 +45,6 @@ static int adxl345_setup(lua_State* L) {
     return 0;
 }
 
-static int adxl345_init(lua_State* L) {
-
-    uint32_t sda;
-    uint32_t scl;
-
-    platform_print_deprecation_note("adxl345.init() is replaced by adxl345.setup()", "in the next version");
-
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
-
-    platform_i2c_setup(adxl345_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-    
-    return adxl345_setup(L);
-}
-
 static int adxl345_read(lua_State* L) {
 
     uint8_t data[6];
@@ -96,8 +79,6 @@ static int adxl345_read(lua_State* L) {
 static const LUA_REG_TYPE adxl345_map[] = {
     { LSTRKEY( "read" ),         LFUNCVAL( adxl345_read )},
     { LSTRKEY( "setup" ),        LFUNCVAL( adxl345_setup )},
-    /// init() is deprecated
-    { LSTRKEY( "init" ),         LFUNCVAL( adxl345_init )},
     { LNILKEY, LNILVAL}
 };
 

--- a/app/modules/am2320.c
+++ b/app/modules/am2320.c
@@ -106,29 +106,6 @@ static int am2320_setup(lua_State* L)
     return 3;
 }
 
-static int am2320_init(lua_State* L)
-{
-    uint32_t sda;
-    uint32_t scl;
-
-    platform_print_deprecation_note("am2320.init() is replaced by am2320.setup()", "in the next version");
-
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
-        return luaL_error(L, "wrong arg range");
-    }
-
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    if (scl == 0 || sda == 0) {
-        return luaL_error(L, "no i2c for D0");
-    }
-
-    platform_i2c_setup(am2320_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-
-    return am2320_setup(L);
-}
-
 static int am2320_read(lua_State* L)
 {
     int ret;
@@ -155,8 +132,6 @@ static int am2320_read(lua_State* L)
 static const LUA_REG_TYPE am2320_map[] = {
     { LSTRKEY( "read" ),  LFUNCVAL( am2320_read )},
     { LSTRKEY( "setup" ), LFUNCVAL( am2320_setup )},
-    // init() is deprecated
-    { LSTRKEY( "init" ),  LFUNCVAL( am2320_init )},
     { LNILKEY, LNILVAL}
 };
 

--- a/app/modules/bme280.c
+++ b/app/modules/bme280.c
@@ -314,30 +314,6 @@ static int bme280_lua_setup(lua_State* L) {
 	return 1;
 }
 
-static int bme280_lua_init(lua_State* L) {
-	uint8_t sda;
-	uint8_t scl;
-	uint8_t config;
-	uint8_t ack;
-	uint8_t full_init;
-	
-	platform_print_deprecation_note("bme280.init() is replaced by bme280.setup()", "in the next version");
-
-	if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
-		return luaL_error(L, "wrong arg range");
-	}
-	sda = luaL_checkinteger(L, 1);
-	scl = luaL_checkinteger(L, 2);
-	
-	platform_i2c_setup(bme280_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-
-	// remove sda and scl parameters from stack
-	lua_remove(L, 1);
-	lua_remove(L, 1);
-
-	return bme280_lua_setup(L);
-}
-
 static void bme280_readoutdone (void *arg)
 {
 	NODE_DBG("timer out\n");
@@ -495,8 +471,6 @@ static int bme280_lua_dewpoint(lua_State* L) {
 }
 
 static const LUA_REG_TYPE bme280_map[] = {
-        // init() is deprecated
-	{ LSTRKEY( "init" ), LFUNCVAL(bme280_lua_init)},
 	{ LSTRKEY( "setup" ), LFUNCVAL(bme280_lua_setup)},
 	{ LSTRKEY( "temp" ),  LFUNCVAL(bme280_lua_temp)},
 	{ LSTRKEY( "baro" ),  LFUNCVAL(bme280_lua_baro)},

--- a/app/modules/bmp085.c
+++ b/app/modules/bmp085.c
@@ -63,28 +63,6 @@ static int bmp085_setup(lua_State* L) {
     return 0;
 }
 
-static int bmp085_init(lua_State* L) {
-    uint32_t sda;
-    uint32_t scl;
-
-    platform_print_deprecation_note("bmp085.init() is replaced by bmp085.setup()", "in the next version");
-
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
-        return luaL_error(L, "wrong arg range");
-    }
-
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    if (scl == 0 || sda == 0) {
-        return luaL_error(L, "no i2c for D0");
-    }
-
-    platform_i2c_setup(bmp085_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-
-    return bmp085_setup(L);
-}
-
 static uint32_t bmp085_temperature_raw_b5(void) {
     int16_t t, X1, X2;
 
@@ -196,8 +174,6 @@ static const LUA_REG_TYPE bmp085_map[] = {
     { LSTRKEY( "pressure" ),     LFUNCVAL( bmp085_lua_pressure )},
     { LSTRKEY( "pressure_raw" ), LFUNCVAL( bmp085_lua_pressure_raw )},
     { LSTRKEY( "setup" ),        LFUNCVAL( bmp085_setup )},
-    // init() is deprecated
-    { LSTRKEY( "init" ),         LFUNCVAL( bmp085_init )},
     { LNILKEY, LNILVAL}
 };
 

--- a/app/modules/hdc1080.c
+++ b/app/modules/hdc1080.c
@@ -33,33 +33,6 @@ static int hdc1080_setup(lua_State* L) {
     return 0;
 }
 
-static int hdc1080_init(lua_State* L) {
-
-	uint32_t sda;
-    uint32_t scl;
-    
-    platform_print_deprecation_note("hdc1080.init() is replaced by hdc1080.setup()", "in the next version");
-    
-    if (!lua_isnumber(L, 1) || !lua_isnumber(L, 2)) {
-        return luaL_error(L, "wrong arg range");
-    }
-
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-    
-    if (scl == 0 || sda == 0) {
-        return luaL_error(L, "no i2c for D0");
-    }
-
-    platform_i2c_setup(hdc1080_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-    
-    // remove sda and scl parameters from stack
-    lua_remove(L, 1);
-    lua_remove(L, 1);
-    
-    return hdc1080_setup(L);
-}
-
 static int hdc1080_read(lua_State* L) {
 
     uint8_t data[2];
@@ -129,7 +102,6 @@ static int hdc1080_read(lua_State* L) {
 static const LUA_REG_TYPE hdc1080_map[] = {
     { LSTRKEY( "read"  ),        LFUNCVAL( hdc1080_read )},
     { LSTRKEY( "setup" ),        LFUNCVAL( hdc1080_setup )},
-    { LSTRKEY( "init" ),         LFUNCVAL( hdc1080_init )},
     { LNILKEY, LNILVAL}
 };
 

--- a/app/modules/hmc5883l.c
+++ b/app/modules/hmc5883l.c
@@ -57,23 +57,6 @@ static int hmc5883_setup(lua_State* L) {
     return 0;
 }
 
-static int hmc5883_init(lua_State* L) {
-
-    uint32_t sda;
-    uint32_t scl;
-
-    platform_print_deprecation_note("hmc5883l.init() is replaced by hmc5883l.setup()", "in the next version");
-
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
-
-    platform_i2c_setup(hmc5883_i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-
-    return hmc5883_setup(L);
-}
-
 static int hmc5883_read(lua_State* L) {
 
     uint8_t data[6];
@@ -109,8 +92,6 @@ static int hmc5883_read(lua_State* L) {
 static const LUA_REG_TYPE hmc5883_map[] = {
     { LSTRKEY( "read" ),         LFUNCVAL( hmc5883_read )},
     { LSTRKEY( "setup" ),        LFUNCVAL( hmc5883_setup )},
-    // init() is deprecated
-    { LSTRKEY( "init" ),         LFUNCVAL( hmc5883_init )},
     { LNILKEY, LNILVAL}
 };
 

--- a/app/modules/l3g4200d.c
+++ b/app/modules/l3g4200d.c
@@ -48,23 +48,6 @@ static int l3g4200d_setup(lua_State* L) {
     return 0;
 }
 
-static int l3g4200d_init(lua_State* L) {
-
-    uint32_t sda;
-    uint32_t scl;
-
-    platform_print_deprecation_note("l3g4200d.init() is replaced by l3g4200d.setup()", "in the next version");
-
-    sda = luaL_checkinteger(L, 1);
-    scl = luaL_checkinteger(L, 2);
-
-    luaL_argcheck(L, sda > 0 && scl > 0, 1, "no i2c for D0");
-
-    platform_i2c_setup(i2c_id, sda, scl, PLATFORM_I2C_SPEED_SLOW);
-
-    return l3g4200d_setup(L);
-}
-
 static int l3g4200d_read(lua_State* L) {
 
     uint8_t data[6];
@@ -99,8 +82,6 @@ static int l3g4200d_read(lua_State* L) {
 static const LUA_REG_TYPE l3g4200d_map[] = {
     { LSTRKEY( "read" ),         LFUNCVAL( l3g4200d_read )},
     { LSTRKEY( "setup" ),        LFUNCVAL( l3g4200d_setup )},
-    // init() is deprecated
-    { LSTRKEY( "init" ),         LFUNCVAL( l3g4200d_init )},
     { LNILKEY, LNILVAL}
 };
 

--- a/docs/en/modules/adxl345.md
+++ b/docs/en/modules/adxl345.md
@@ -24,23 +24,6 @@ local x,y,z = adxl345.read()
 print(string.format("X = %d, Y = %d, Z = %d", x, y, z))
 ```
 
-## adxl345.init()
-Initializes the module and sets the pin configuration.
-
-!!! attention
-
-    This function is deprecated and will be removed in upcoming releases. Use `adxl345.setup()` instead.
-
-#### Syntax
-`adxl345.init(sda, scl)`
-
-#### Parameters
-- `sda` data pin
-- `scl` clock pin
-
-#### Returns
-`nil`
-
 ## adxl345.setup()
 Initializes the module.
 

--- a/docs/en/modules/am2320.md
+++ b/docs/en/modules/am2320.md
@@ -6,27 +6,6 @@
 
 This module provides access to the [AM2320](https://akizukidenshi.com/download/ds/aosong/AM2320.pdf) humidity and temperature sensor, using the i2c interface.
 
-## am2320.init()
-Initializes the module and sets the pin configuration. Returns model, version, serial but is seams these where all zero on my model.
-
-!!! attention
-
-    This function is deprecated and will be removed in upcoming releases. Use `am2320.setup()` instead.
-
-#### Syntax
-`model, version, serial = am2320.init(sda, scl)`
-
-#### Parameters
-- `sda` data pin
-- `scl` clock pin
-
-#### Returns
-- `model`  16 bits number of model
-- `version`  8 bits version number
-- `serial`  32 bits serial number
-
-   Note: I have only observed values of 0 for all of these, maybe other sensors return more sensible readings.
-
 ## am2320.read()
 Samples the sensor and returns the relative humidity in % and temperature in celsius, as an integer multiplied with 10.
 

--- a/docs/en/modules/bme280.md
+++ b/docs/en/modules/bme280.md
@@ -68,21 +68,6 @@ none
 - `H` last relative humidity reading in % times 1000
 - `T` temperature in celsius as an integer multiplied with 100
 
-## bme280.init()
-
-Initializes module. Initialization is mandatory before read values.
-
-!!! attention
-
-    This function is deprecated and will be removed in upcoming releases. Use `bme280.setup()` instead.
-
-#### Syntax
-
-`bme280.init(sda, scl, [temp_oss, press_oss, humi_oss, power_mode, inactive_duration, IIR_filter])`
-
-#### Parameters
-See [`setup()`](#bme280setup).
-
 ## bme280.qfe2qnh()
 
 For given altitude converts the air pressure to sea level air pressure.

--- a/docs/en/modules/bmp085.md
+++ b/docs/en/modules/bmp085.md
@@ -6,23 +6,6 @@
 
 This module provides access to the [BMP085](https://www.sparkfun.com/tutorials/253) temperature and pressure sensor. The module also works with BMP180.
 
-## bmp085.init()
-Initializes the module and sets the pin configuration.
-
-!!! attention
-
-    This function is deprecated and will be removed in upcoming releases. Use `bmp085.setup()` instead.
-
-#### Syntax
-`bmp085.init(sda, scl)`
-
-#### Parameters
-- `sda` data pin
-- `scl` clock pin
-
-#### Returns
-`nil`
-
 ## bmp085.setup()
 Initializes the module.
 

--- a/docs/en/modules/hdc1080.md
+++ b/docs/en/modules/hdc1080.md
@@ -36,21 +36,3 @@ Initializes the module.
 
 #### Returns
 `nil`
-
-
-## hdc1080.init(sda,scl)
-Initializes the module and sets the pin configuration.
-
-!!! attention
-
-	 This function is deprecated and will be removed in upcoming releases. Use `hdc1080.setup()` instead.
-
-#### Syntax
-`hdc1080.init(sda, scl)`
-
-#### Parameters
-- `sda` data pin
-- `scl` clock pin
-
-#### Returns
-`nil`

--- a/docs/en/modules/hmc5883l.md
+++ b/docs/en/modules/hmc5883l.md
@@ -25,23 +25,6 @@ local x,y,z = hmc5883l.read()
 print(string.format("x = %d, y = %d, z = %d", x, y, z))
 ```
 
-## hmc5883l.init()
-Initializes the module and sets the pin configuration.
-
-!!! attention
-
-    This function is deprecated and will be removed in upcoming releases. Use `hmc5883l.setup()` instead.
-
-#### Syntax
-`hmc5883l.init(sda, scl)`
-
-#### Parameters
-- `sda` data pin
-- `scl` clock pin
-
-#### Returns
-`nil`
-
 ## hmc5883l.setup()
 Initializes the module.
 

--- a/docs/en/modules/l3g4200d.md
+++ b/docs/en/modules/l3g4200d.md
@@ -24,23 +24,6 @@ local x,y,z = l3g4200d.read()
 print(string.format("X = %d, Y = %d, Z = %d", x, y, z)
 ```
 
-## l3g4200d.init()
-Initializes the module and sets the pin configuration.
-
-!!! attention
-
-    This function is deprecated and will be removed in upcoming releases. Use `l3g4200d.setup()` instead.
-
-#### Syntax
-`l3g4200d.init(sda, scl)`
-
-#### Parameters
-- `sda` data pin
-- `scl` clock pin
-
-#### Returns
-`nil`
-
 ## l3g4200d.setup()
 Initializes the module.
 

--- a/lua_modules/hdc1000/HDC1000-example.lua
+++ b/lua_modules/hdc1000/HDC1000-example.lua
@@ -4,7 +4,8 @@ sda = 1
 scl = 2
 drdyn = false
 
-HDC1000.init(sda, scl, drdyn)
+i2c.setup(0, sda, scl, i2c.SLOW)  -- call i2c.setup() only once
+HDC1000.setup(drdyn)
 HDC1000.config() -- default values are used if called with no arguments. prototype is config(address, resolution, heater)
 
 print(string.format("Temperature: %.2f °C\nHumidity: %.2f %%", HDC1000.getTemp(), HDC1000.getHumi()))

--- a/lua_modules/hdc1000/HDC1000.lua
+++ b/lua_modules/hdc1000/HDC1000.lua
@@ -69,10 +69,9 @@ function M.batteryDead()
 
 end
 
--- initalize i2c
-function M.init(sda, scl, drdyn_pin)
+-- setup i2c
+function M.setup(drdyn_pin)
 	_drdyn_pin = drdyn_pin
-	i2c.setup(id, sda, scl, i2c.SLOW)
 end
 
 function M.config(addr, resolution, heater)

--- a/lua_modules/hdc1000/README.md
+++ b/lua_modules/hdc1000/README.md
@@ -10,7 +10,10 @@ First, require it:
 
 Then, initialize it:
 
-`HDC1000.init(sda, scl, drdyn)`
+```lua
+i2c.setup(0, sda, scl, i2c.SLOW)  -- call i2c.setup() only once
+HDC1000.setup(drdyn)
+```
 
 If you don't want to use the DRDYn pin, set it to false: a 20ms delay will be automatically set after each read request.
 

--- a/lua_modules/lm92/README.md
+++ b/lua_modules/lm92/README.md
@@ -16,16 +16,14 @@ LM92 = nil
 package.loaded["lm92"]=nil
 ```
 
-##init()
+##setup()
 ####Description
-Setting the i2c pins and address for lm92.
+Setting the address for lm92.
 
 ####Syntax
-init(sda, scl, address)
+setup(sda, scl, address)
 
 ####Parameters
-sda: 1~12, IO index.<br />
-scl: 1~12, IO index.<br />
 address: 0x48~0x4b, i2c address (depends on tha A0~A1 pins)
 ####Returns
 nil
@@ -38,7 +36,8 @@ gpio2 = 4
 sda = gpio0
 scl = gpio2
 addr = 0x48
-LM92.init(sda, scl,addr)
+i2c.setup(0, sda, scl, i2c.SLOW)  -- call i2c.setup() only once
+LM92.setup(addr)
 ```
 ##getTemperature()
 ####Description
@@ -251,7 +250,8 @@ gpio2 = 4
 sda = gpio0
 scl = gpio2
 addr = 0x48
-LM92.init(sda, scl,addr)
+i2c.setup(0, sda, scl, i2c.SLOW)  -- call i2c.setup() only once
+LM92.setup(addr)
  
 t = LM92.getTemperature()
 print("Got temperature: "..t.." C")

--- a/lua_modules/lm92/lm92.lua
+++ b/lua_modules/lm92/lm92.lua
@@ -59,13 +59,9 @@ local function write_comp_reg(reg_addr, msb, lsb)
     i2c.stop(id)
 end 
 -- initialize i2c
--- d: sda
--- c: scl
 -- a: i2c addr 0x48|A1<<1|A0 (A0-A1: chip pins)
-function M.init(d,c,a)
-if (d ~= nil) and (c ~= nil) and (d >= 0) and (d <= 11) and (c >= 0) and ( c <= 11) and (d ~= l) and (a ~= nil) and (a >= 0x48) and (a <= 0x4b ) then
-		sda = d
-		scl = c 
+function M.setup(a)
+  if (a ~= nil) and (a >= 0x48) and (a <= 0x4b ) then
 		address = a
 		i2c.start(id)
 		res = i2c.address(id, address, i2c.TRANSMITTER) --verify that the address is valid
@@ -74,10 +70,9 @@ if (d ~= nil) and (c ~= nil) and (d >= 0) and (d <= 11) and (c >= 0) and ( c <= 
 			print("device not found")
 			return nil
 		end
-		else 
-        print("i2c configuration failed") return nil
-      end
-	i2c.setup(id,sda,scl,i2c.SLOW)
+  else 
+     print("wrong i2c address") return nil
+  end
 end
 
 -- Return the temperature data


### PR DESCRIPTION
Fixes #1888.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

As the title says, this is the last step for deprecating the `.init()` functions of certain modules.
It completes #1887.