### PR TITLE
Fix problem with gpio.input

### DIFF
--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -106,7 +106,6 @@ static void NO_INTR_CODE set_gpio_no_interrupt(uint8 pin, uint8_t push_pull) {
                    GPIO_PIN_PAD_DRIVER_SET(GPIO_PAD_DRIVER_ENABLE));      //enable open drain;
   }
 
-  GPIO_REG_WRITE(GPIO_ENABLE_W1TS_ADDRESS, BIT(pnum));
   ETS_GPIO_INTR_ENABLE();
 }
 
@@ -155,12 +154,15 @@ int platform_gpio_mode( unsigned pin, unsigned mode, unsigned pull )
 
     case PLATFORM_GPIO_INPUT:
       GPIO_DIS_OUTPUT(pin_num[pin]);
-      /* run on */
+      set_gpio_no_interrupt(pin, TRUE);
+      break;
     case PLATFORM_GPIO_OUTPUT:
       set_gpio_no_interrupt(pin, TRUE);
+      GPIO_REG_WRITE(GPIO_ENABLE_W1TS_ADDRESS, BIT(pin_num[pin]));
       break;
     case PLATFORM_GPIO_OPENDRAIN:
       set_gpio_no_interrupt(pin, FALSE);
+      GPIO_REG_WRITE(GPIO_ENABLE_W1TS_ADDRESS, BIT(pin_num[pin]));
       break;
 
 #ifdef GPIO_INTERRUPT_ENABLE


### PR DESCRIPTION
Fixes #2280

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

When I fixed the problem with gpio.mode not actually setting the output status, I (inadvertently) changed the behavior of gpio.input. This was due to a fall-through switch statement. My testing didn't catch it as interrupt inputs still worked.

This fix is somewhat uglier than the previous code (but it has the big advantage that it actually works).
