### PR TITLE
Align wifi.sta.config table elements connected_cb and disconnected_cb with doc

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -849,7 +849,7 @@ static int wifi_station_config( lua_State* L )
 
     lua_State* L_temp = NULL;
 
-    lua_getfield(L, 1, "connect_cb");
+    lua_getfield(L, 1, "connected_cb");
     if (!lua_isnil(L, -1))
     {
       if (lua_isfunction(L, -1))
@@ -862,12 +862,12 @@ static int wifi_station_config( lua_State* L )
       }
       else
       {
-        return luaL_argerror(L, 1, "connect_cb:not function");
+        return luaL_argerror(L, 1, "connected_cb:not function");
       }
     }
     lua_pop(L, 1);
 
-    lua_getfield(L, 1, "disconnect_cb");
+    lua_getfield(L, 1, "disconnected_cb");
     if (!lua_isnil(L, -1))
     {
       if (lua_isfunction(L, -1))
@@ -880,7 +880,7 @@ static int wifi_station_config( lua_State* L )
       }
       else
       {
-        return luaL_argerror(L, 1, "disconnect_cb:not function");
+        return luaL_argerror(L, 1, "disconnected_cb:not function");
       }
     }
     lua_pop(L, 1);


### PR DESCRIPTION
Fixes #2275.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

`wifi.sta.config()` expects table elements for the connect and disconnect callbacks as `connect_cb` and `disconnect_cb` while the API doc lists them as `connected_cb` and `disconnected_cb`.
I propose to align the implementation to the doc (and not vice versa) since the `*ed_cb` terminology fits better to the underlying SDK (e.g. `EVENT_STAMODE_CONNECTED`).
