### PR TITLE
Fix SNTP so that it retries DNS lookups if it needs to

### DIFF
--- a/app/modules/sntp.c
+++ b/app/modules/sntp.c
@@ -132,6 +132,7 @@ typedef struct
 typedef struct {
   int32_t sync_cb_ref;
   int32_t err_cb_ref;
+  int32_t list_ref;
   os_timer_t timer;
 } sntp_repeat_t;
 
@@ -227,7 +228,6 @@ static void sntp_handle_result(lua_State *L) {
   if (state->best.stratum == 0) {
     // This could be because none of the servers are reachable, or maybe we haven't been able to look 
     // them up.
-    state->lookup_pos = 0; // Reset for next time.
     server_count = 0;      // Reset for next time.
     handle_error(L, NTP_TIMEOUT_ERR, NULL);
     return;
@@ -697,6 +697,8 @@ static char *set_repeat_mode(lua_State *L, bool enable)
     repeat->sync_cb_ref = luaL_ref(L, LUA_REGISTRYINDEX);
     lua_rawgeti(L, LUA_REGISTRYINDEX, state->err_cb_ref);
     repeat->err_cb_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    lua_rawgeti(L, LUA_REGISTRYINDEX, state->list_ref);
+    repeat->list_ref = luaL_ref(L, LUA_REGISTRYINDEX);
     os_timer_setfn(&repeat->timer, on_long_timeout, NULL);
     os_timer_arm(&repeat->timer, 1000 * 1000, 1);
   } else {
@@ -704,6 +706,7 @@ static char *set_repeat_mode(lua_State *L, bool enable)
       os_timer_disarm (&repeat->timer);
       luaL_unref (L, LUA_REGISTRYINDEX, repeat->sync_cb_ref);
       luaL_unref (L, LUA_REGISTRYINDEX, repeat->err_cb_ref);
+      luaL_unref (L, LUA_REGISTRYINDEX, repeat->list_ref);
       c_free(repeat);
       repeat = NULL;
     }
@@ -723,6 +726,10 @@ static void on_long_timeout (void *arg)
       state->sync_cb_ref = luaL_ref(L, LUA_REGISTRYINDEX);
       lua_rawgeti(L, LUA_REGISTRYINDEX, repeat->err_cb_ref);
       state->err_cb_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+      if (server_count == 0) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, repeat->list_ref);
+        state->list_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+      }
       state->is_on_timeout = 1;
       sntp_dolookups(L);
     }


### PR DESCRIPTION
Fixes #2277

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.


This retries the DNS lookups on each sync operation if the last sync operation ended in a timeout with no good responses, or if the dns lookups failed on the previous attempt. THis deals with the case when you start without a connection to the internet and the dns lookups fail. Then you get connected, and the next sync will do the lookups and then sync the time. Those IPs will continue to be used until they stop working (maybe because the connection goes away). Then the DNS lookups are retried until good answers are received.
