### PR TITLE
Ignore lookup errors on sync request unless all lookups fail

### DIFF
--- a/docs/en/modules/sntp.md
+++ b/docs/en/modules/sntp.md
@@ -16,6 +16,11 @@ Attempts to obtain time synchronization.
 For best results you may want to to call this periodically in order to compensate for internal clock drift. As stated in the [rtctime](rtctime.md) module documentation it's advisable to sync time after deep sleep and it's necessary to sync after module reset (add it to [`init.lua`](../upload.md#initlua) after WiFi initialization).
 Note that either a single server can be provided as an argument (name or address), or a list (table) of servers can be provided. 
 
+If *all* of the supplied host names/addresses are invalid, then the error callback will be called with argument type 1. Otherwise, if
+there is at least one valid name/address, then then sync will be performed.
+
+If any sync operation fails (maybe the device is disconnected from the internet), then all the names will be looked up again. 
+
 #### Syntax
 `sntp.sync([server_ip], [callback], [errcallback], [autorepeat])`
 `sntp.sync({ server1, server2, .. }, [callback], [errcallback], [autorepeat])`


### PR DESCRIPTION
Fixes #2296.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This was largely driven by my experience of being disconnected from the internet as a result of a severe winter storm. I was unable to sync even though some of the targets were valid and would respond. This change also protects against someone prespecifying some named hosts and then not renewing the domain name. While there is at least one valid address, the sync will happen.
