### PR TITLE
Revert os_delay_us() usage to uint32

### DIFF
--- a/app/modules/tmr.c
+++ b/app/modules/tmr.c
@@ -128,9 +128,9 @@ static int tmr_delay( lua_State* L ){
 	sint32_t us = luaL_checkinteger(L, 1);
 	if(us <= 0)
 		return luaL_error(L, "wrong arg range");
-	while(us >= 10000){
-		us -= 10000;
-		os_delay_us(10000);
+	while(us >= 1000000){
+		us -= 1000000;
+		os_delay_us(1000000);
 		system_soft_wdt_feed ();
 	}
 	if(us>0){

--- a/app/tsl2561/tsl2561.c
+++ b/app/tsl2561/tsl2561.c
@@ -76,12 +76,6 @@ static tsl2561Gain_t _tsl2561Gain = TSL2561_GAIN_1X;
 static tsl2561Address_t tsl2561Address = TSL2561_ADDRESS_FLOAT;
 static tsl2561Package_t tsl2561Package = TSL2561_PACKAGE_T_FN_CL;
 
-static void delay_ms(uint16_t ms)
-{
-  while (ms--)
-    os_delay_us(1000);
-}
-
 /**************************************************************************/
 /*! 
  @brief  Writes an 8 bit values over I2C
@@ -236,13 +230,13 @@ tsl2561Error_t tsl2561GetLuminosity(uint16_t *broadband, uint16_t *ir) {
 	// Wait x ms for ADC to complete
 	switch (_tsl2561IntegrationTime) {
 	case TSL2561_INTEGRATIONTIME_13MS:
-		delay_ms(14); //systickDelay(14);
+		os_delay_us(14000); //systickDelay(14);
 		break;
 	case TSL2561_INTEGRATIONTIME_101MS:
-		delay_ms(102); //systickDelay(102);
+		os_delay_us(102000); //systickDelay(102);
 		break;
 	default:
-		delay_ms(404); //systickDelay(404);
+		os_delay_us(404000); //systickDelay(404);
 		break;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/nodemcu/nodemcu-firmware/issues/2225#issuecomment-356739818.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

SDK 2.2.0 reverted to `uint32_t` parameter size for `ets_delay_us()`. This PR reverts the workarounds which were introduced with #1962.
