### PR TITLE
Put each ICACHE_RAM_ATTR function in its own section.

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -52,9 +52,9 @@ extern void luaL_assertfail(const char *file, int line, const char *message);
 
 #define ICACHE_STORE_TYPEDEF_ATTR __attribute__((aligned(4),packed))
 #define ICACHE_STORE_ATTR __attribute__((aligned(4)))
-#define STRINGIZE(x) STRINGIZE2(x)
-#define STRINGIZE2(x) #x
-#define ICACHE_RAM_ATTR     __attribute__((section(".iram0.text." __FILE__ "." STRINGIZE(__LINE__))))
+#define ICACHE_RAM_STRING(x) ICACHE_RAM_STRING2(x)
+#define ICACHE_RAM_STRING2(x) #x
+#define ICACHE_RAM_ATTR     __attribute__((section(".iram0.text." __FILE__ "." ICACHE_RAM_STRING(__LINE__))))
 #ifdef  GPIO_SAFE_NO_INTR_ENABLE
 #define NO_INTR_CODE ICACHE_RAM_ATTR __attribute__ ((noinline))
 #else

--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -52,7 +52,9 @@ extern void luaL_assertfail(const char *file, int line, const char *message);
 
 #define ICACHE_STORE_TYPEDEF_ATTR __attribute__((aligned(4),packed))
 #define ICACHE_STORE_ATTR __attribute__((aligned(4)))
-#define ICACHE_RAM_ATTR __attribute__((section(".iram0.text")))
+#define STRINGIZE(x) STRINGIZE2(x)
+#define STRINGIZE2(x) #x
+#define ICACHE_RAM_ATTR     __attribute__((section(".iram0.text." __FILE__ "." STRINGIZE(__LINE__))))
 #ifdef  GPIO_SAFE_NO_INTR_ENABLE
 #define NO_INTR_CODE ICACHE_RAM_ATTR __attribute__ ((noinline))
 #else

--- a/ld/nodemcu.ld
+++ b/ld/nodemcu.ld
@@ -121,7 +121,7 @@ SECTIONS
     /* *libwpa.a:*(.literal .text) - tested that safe to keep in iROM */
     /* *libwps.a:*(.literal .text) - tested that safe to keep in iROM */
 
-    *(.iram.text .iram0.text)
+    *(.iram.text .iram0.text .iram0.text.*)
 
     *(.stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
     


### PR DESCRIPTION
Fixes #2304.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This implements putting each ICACHE_RAM_ATTR function in its own section. This allows the linker to throw away more functions and hence use less ram.

I checked the map and it looks good. The image boots and seems to work.