### PR TITLE
Missed setting the ID into the data block

### DIFF
--- a/app/modules/rotary.c
+++ b/app/modules/rotary.c
@@ -152,6 +152,8 @@ static int lrotary_setup( lua_State* L )
   DATA *d = data[id];
   memset(d, 0, sizeof(*d));
 
+  d->id = id;
+
   os_timer_setfn(&d->timer, lrotary_timer_done, (void *) d);
   
   int i;


### PR DESCRIPTION
Fixes #2348.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

It turned out that there was an uninitialized filed in one of the data structures that was supposed to hold the channel number. It was always being set to zero and so channel zero would only ever work. Setting the field correctly, makes channels 1 and 2 also work.
