### PR TITLE
Update node.dsleep() to support longer deep sleep duration.

### DIFF
--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -38,10 +38,15 @@ static int node_restart( lua_State* L )
   return 0;
 }
 
+static int dsleepMax( lua_State *L ) {
+  lua_pushnumber(L, (uint64_t)system_rtc_clock_cali_proc()*(0x80000000-1)/(0x1000));
+  return 1;
+}
+
 // Lua: dsleep( us, option )
 static int node_deepsleep( lua_State* L )
 {
-  uint32 us;
+  uint64 us;
   uint8 option;
   //us = luaL_checkinteger( L, 1 );
   // Set deleep option, skip if nil
@@ -592,8 +597,9 @@ static const LUA_REG_TYPE node_task_map[] = {
 
 static const LUA_REG_TYPE node_map[] =
 {
-  { LSTRKEY( "restart" ), LFUNCVAL( node_restart ) },
-  { LSTRKEY( "dsleep" ), LFUNCVAL( node_deepsleep ) },
+  { LSTRKEY( "restart" ),   LFUNCVAL( node_restart ) },
+  { LSTRKEY( "dsleep" ),    LFUNCVAL( node_deepsleep ) },
+  { LSTRKEY( "dsleepMax" ), LFUNCVAL( dsleepMax ) },
 #ifdef PMSLEEP_ENABLE
   { LSTRKEY( "sleep" ), LFUNCVAL( node_sleep ) },
   PMSLEEP_INT_MAP,

--- a/docs/en/modules/node.md
+++ b/docs/en/modules/node.md
@@ -87,9 +87,8 @@ dofile("hello.lc")
 
 Enters deep sleep mode, wakes up when timed out.
 
-The maximum sleep time is 4294967295us, ~71 minutes. This is an SDK limitation.
-Firmware from before 05 Jan 2016 have a maximum sleeptime of ~35 minutes.
-
+Theoretical maximum deep sleep duration can be found with [`node.dsleepMax()`](#nodedsleepmax)
+ 
 !!! caution
 
     This function can only be used in the condition that esp8266 PIN32(RST) and PIN8(XPD_DCDC aka GPIO16) are connected together. Using sleep(0) will set no wake up timer, connect a GPIO to pin RST, the chip will wake up by a falling-edge on pin RST.
@@ -107,10 +106,7 @@ Firmware from before 05 Jan 2016 have a maximum sleeptime of ~35 minutes.
 	- 1, RF_CAL after deep-sleep wake up, there will be large current
 	- 2, no RF_CAL after deep-sleep wake up, there will only be small current
 	- 4, disable RF after deep-sleep wake up, just like modem sleep, there will be the smallest current
- - `instant` number (integer) or `nil`. If present and non-zero, do not use
-    the normal grace time before entering deep sleep.  This is a largely
-    undocumented feature, and is only briefly mentioned in Espressif's
-    [low power solutions](https://espressif.com/sites/default/files/documentation/9b-esp8266_low_power_solutions_en.pdf#page=10) document (chapter 4.5).
+ - `instant` number (integer) or `nil`. If present and non-zero, the chip will enter Deep-sleep immediately and will not wait for the Wi-Fi core to be shutdown.
 
 #### Returns
 `nil`
@@ -131,6 +127,38 @@ node.dsleep(nil,4)
 - [`wifi.suspend()`](wifi.md#wifisuspend)
 - [`wifi.resume()`](wifi.md#wifiresume)
 - [`node.sleep()`](#nodesleep)
+- [`node.dsleepMax()`](#nodedsleepmax)
+
+## node.dsleepMax()
+
+Returns the current theoretical maximum deep sleep duration.
+
+!!! caution
+
+	While it is possible to sleep longer than the theoretical maximum sleep duration, which can be found with `node.dsleepMax()`, it is not recommended to exceed this theoretical maximum. 
+
+
+!!! note
+
+	This theoretical maximum is dependent on ambient temperature.   
+	(lower temp = shorter sleep duration, higher temp = longer sleep duration)
+
+#### Syntax
+`node.dsleepMax()`
+
+#### Parameters
+ none
+ 
+#### Returns
+`max_duration`
+
+#### Example
+```lua
+node.dsleep(node.dsleepMax())
+```
+
+#### See also
+- [`node.dsleep()`](#nodedsleep)
 
 ## node.flashid()
 

--- a/docs/en/modules/node.md
+++ b/docs/en/modules/node.md
@@ -135,7 +135,7 @@ Returns the current theoretical maximum deep sleep duration.
 
 !!! caution
 
-	While it is possible to sleep longer than the theoretical maximum sleep duration, which can be found with `node.dsleepMax()`, it is not recommended to exceed this theoretical maximum. 
+	While it is possible to specify a longer sleep time than the theoretical maximum sleep duration, it is not recommended to exceed this maximum.
 
 
 !!! note


### PR DESCRIPTION
Fixes #2351.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

Beginning with SDK 2.1, the functions `system_deep_sleep()` and `system_deep_sleep_instant()` were changed to accept `uint64` values, allowing for longer sleep duration.
This PR updates `node.dsleep()` to accept these larger sleep times.