### PR TITLE
Bugfix: wifi.suspend() disabled message causing crash

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -512,16 +512,16 @@ static int wifi_resume(lua_State* L)
 
 /* End WiFi suspend functions*/
 #else
-static char *susp_note_str = "\n The option \"pmsleep_enable\" in \"app/include/user_config.h\" was disabled during FW build!\n";
+static char *susp_note_str = "\n The option \"PMSLEEP_ENABLE\" in \"app/include/user_config.h\" was disabled during FW build!\n";
 static char *susp_unavailable_str = "wifi.suspend is unavailable";
 
 static int wifi_suspend(lua_State* L){
-  c_sprintf("%s", susp_note_str);
+  dbg_printf("%s", susp_note_str);
   return luaL_error(L, susp_unavailable_str);
 }
 
 static int wifi_resume(lua_State* L){
-  c_sprintf("%s", susp_note_str);
+  dbg_printf("%s", susp_note_str);
   return luaL_error(L, susp_unavailable_str);
 }
 #endif


### PR DESCRIPTION
Fixes #2361.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.

Issue #2361 brought to my attention a mistake I made when writing the code that tells the developer that `wifi.suspend()` is disabled when `PMSLEEP_ENABLE` is commented out in `app/include/user_config.h`.