### PR TITLE
Fix mqtt connect leak

### DIFF
--- a/app/lwip/app/espconn_tcp.c
+++ b/app/lwip/app/espconn_tcp.c
@@ -434,9 +434,9 @@ espconn_Task(os_event_t *events)
 				break;
 			case SIG_ESPCONN_ERRER:
 				/*remove the node from the client's active connection list*/
-				espconn_list_delete(&plink_active, task_msg);
 			    if (espconn_manual_recv_enabled(task_msg))
 			        espconn_list_delete(&plink_active, task_msg);
+			        espconn_tcp_reconnect(task_msg);
 				break;
 			case SIG_ESPCONN_CLOSE:
 				/*remove the node from the client's active connection list*/

--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -615,6 +615,12 @@ void mqtt_socket_timer(void *arg)
   if(mud->connState == MQTT_INIT){ // socket connect time out.
     NODE_DBG("Can not connect to broker.\n");
     os_timer_disarm(&mud->mqttTimer);
+#if 0
+    // don't try to disconnect here when connecting times out
+    //   this will leak memory since espconn_disconnect() will refuse to
+    //   disconnect/free pesp_conn as it was never connected
+    // espconn & lwip housekeeping is done on the intended route:
+    //   tcp_err()->espconn_client_err()->espconn_Task()->espconn_tcp_reconnect()->mqtt_socket_reconnected()
     mqtt_connack_fail(mud, MQTT_CONN_FAIL_SERVER_NOT_FOUND);
 #ifdef CLIENT_SSL_ENABLE
     if(mud->secure)
@@ -626,6 +632,7 @@ void mqtt_socket_timer(void *arg)
     {
       espconn_disconnect(mud->pesp_conn);
     }
+#endif
   } else if(mud->connState == MQTT_CONNECT_SENDING){ // MQTT_CONNECT send time out.
     NODE_DBG("sSend MQTT_CONNECT failed.\n");
     mud->connState = MQTT_INIT;


### PR DESCRIPTION
Fixes #2364.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

The memory leak I found was related to a time out when the socket connection to the server couldn't be established.

The approach in `mqtt` module to abort the connection attempt based on the mqtt-internal timer is problematic IMO. Calling `espconn_disconnect()` for a socket that actually isn't connected seems to skip memory cleanup. I disabled the respective code in `mqtt` and rely on the "reconnect" error callback to `mqtt_socket_reconnected()` instead.

This revealed a more subtle bug in espconn layer. For some reason the item "0018-feat-espconn-Modification-for-espconn.patch" wasn't applied correctly with #2269. It removed the invocation of the reconnect callback.

Both issues are addressed in this PR and connection errors for an unreachable server don't leak memory for me anymore.

@bondrogeen and @xfoldvar please check whether the changes fix your scenarios as well.
