### PR TITLE
Set safe defaults for scan config

### DIFF
--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1158,8 +1158,8 @@ static int wifi_station_listap( lua_State* L )
   {
     return luaL_error( L, "Can't list ap in SOFTAP mode" );
   }
-  struct scan_config scan_cfg;
-  memset(&scan_cfg, 0, sizeof(scan_cfg));
+  // set safe defaults for scan time, all others members are initialized with 0
+  struct scan_config scan_cfg = {.scan_time = {.passive=120, .active = {.max=120, .min=60}}};
 
   getap_output_format=0;
 

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1158,7 +1158,8 @@ static int wifi_station_listap( lua_State* L )
   {
     return luaL_error( L, "Can't list ap in SOFTAP mode" );
   }
-  // set safe defaults for scan time, all others members are initialized with 0
+  // set safe defaults for scan time, all other members are initialized with 0
+  // source: https://github.com/espressif/ESP8266_NONOS_SDK/issues/103
   struct scan_config scan_cfg = {.scan_time = {.passive=120, .active = {.max=120, .min=60}}};
 
   getap_output_format=0;


### PR DESCRIPTION
Follow-up to #2269.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This is a follow-up to the SDK 2.2 update where Espressif introduced the scan threshold and dwell time API. Up to now these were initialized with all-0, and this PR sets the default values which were used in earlier SDKs according to espressif/ESP8266_NONOS_SDK#103.
I don't observe any change in behavior with my test setup.
