### PR TITLE
Fix for lack of nil return in file.read() when EOF is reached

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -432,7 +432,8 @@ static int file_g_read( lua_State* L, int n, int16_t end_char, int fd )
       luaM_free(L, heap_mem);
       heap_mem = NULL;
     }
-    return 0;
+    lua_pushnil(L);
+    return 1;
   }
 
   vfs_lseek(fd, -(n - i), VFS_SEEK_CUR);


### PR DESCRIPTION
Fixes #2376.
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.

This PR adds the missing `nil` return when a file is stepped through with `print(file.read())` and the end of file is reached.