### PR TITLE
webap_toggle_pin.lua HTML warnings and typos fixed

### DIFF
--- a/lua_examples/webap_toggle_pin.lua
+++ b/lua_examples/webap_toggle_pin.lua
@@ -15,7 +15,7 @@ srv:listen(80,function(conn)
                 _GET[k] = v
             end
         end
-        buf = buf.."<h1> Hello, NodeMcu.</h1><form src=\"/\">Turn PIN1 <select name=\"pin\" onchange=\"form.submit()\">"
+        buf = buf.."<!DOCTYPE html><html><body><h1>Hello, NodeMcu.</h1><form src=\"/\">Turn PIN1 <select name=\"pin\" onchange=\"form.submit()\">"
         local _on,_off = "",""
         if(_GET.pin == "ON")then
               _on = " selected=true"
@@ -24,7 +24,7 @@ srv:listen(80,function(conn)
               _off = " selected=\"true\""
               gpio.write(1, gpio.LOW)
         end
-        buf = buf.."<option".._on..">ON</opton><option".._off..">OFF</option></select></form>"
+        buf = buf.."<option".._on..">ON</option><option".._off..">OFF</option></select></form></body></html>"
         client:send(buf)
     end)
     conn:on("sent", function (c) c:close() end)


### PR DESCRIPTION
- [ ] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

I tried out some of the examples and noticed that there are several typos and missing HTML tags in this one. I fixed them so the web browser does not complain anymore.