### PR TITLE
Espressif SDK v2.2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,20 +3,20 @@
 .NOTPARALLEL:
 
 # SDK base version, as released by Espressif
-SDK_BASE_VER:=2.2.0
+SDK_BASE_VER:=2.2.1
 
 # no patch: SDK_VER equals SDK_BASE_VER and sdk dir depends on sdk_extracted
-#SDK_VER:=$(SDK_BASE_VER)
-#SDK_DIR_DEPENDS:=sdk_extracted
+SDK_VER:=$(SDK_BASE_VER)
+SDK_DIR_DEPENDS:=sdk_extracted
 
 # with patch: SDK_VER differs from SDK_BASE_VER and sdk dir depends on sdk_patched
-SDK_PATCH_VER:=f8f27ce
-SDK_VER:=$(SDK_BASE_VER)-$(SDK_PATCH_VER)
-SDK_DIR_DEPENDS:=sdk_patched
+#SDK_PATCH_VER:=f8f27ce
+#SDK_VER:=$(SDK_BASE_VER)-$(SDK_PATCH_VER)
+#SDK_DIR_DEPENDS:=sdk_patched
 
 SDK_FILE_VER:=$(SDK_BASE_VER)
-SDK_FILE_SHA1:=8b63f1066d3560ff77f119e8ba30a9c39e7baaad
-SDK_PATCH_SHA1:=0bc21ec77b08488f04d3e1c9d161b711d07201a8
+SDK_FILE_SHA1:=48f2242d5895823709f222bf0fffce9d525996c8
+# SDK_PATCH_SHA1:=0bc21ec77b08488f04d3e1c9d161b711d07201a8
 # Ensure we search "our" SDK before the tool-chain's SDK (if any)
 TOP_DIR:=$(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 SDK_REL_DIR=sdk/esp_iot_sdk_v$(SDK_VER)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# **NodeMCU 2.2.0** #
+# **NodeMCU 2.2.1** #
 
 [![Join the chat at https://gitter.im/nodemcu/nodemcu-firmware](https://img.shields.io/gitter/room/badges/shields.svg)](https://gitter.im/nodemcu/nodemcu-firmware?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/nodemcu/nodemcu-firmware.svg)](https://travis-ci.org/nodemcu/nodemcu-firmware)
@@ -7,7 +7,7 @@
 
 ### A Lua based firmware for ESP8266 WiFi SOC
 
-NodeMCU is an [eLua](http://www.eluaproject.net/) based firmware for the [ESP8266 WiFi SOC from Espressif](http://espressif.com/en/products/esp8266/). The firmware is based on the [Espressif NON-OS SDK 2.2.0](https://github.com/espressif/ESP8266_NONOS_SDK/releases/tag/v2.2.0) and uses a file system based on [spiffs](https://github.com/pellepl/spiffs). The code repository consists of 98.1% C-code that glues the thin Lua veneer to the SDK.
+NodeMCU is an [eLua](http://www.eluaproject.net/) based firmware for the [ESP8266 WiFi SOC from Espressif](http://espressif.com/en/products/esp8266/). The firmware is based on the [Espressif NON-OS SDK 2.2.1](https://github.com/espressif/ESP8266_NONOS_SDK/releases/tag/v2.2.1) and uses a file system based on [spiffs](https://github.com/pellepl/spiffs). The code repository consists of 98.1% C-code that glues the thin Lua veneer to the SDK.
 
 The NodeMCU *firmware* is a companion project to the popular [NodeMCU dev kits](https://github.com/nodemcu/nodemcu-devkit-v1.0), ready-made open source development boards with ESP8266-12E chips.
 

--- a/app/lwip/app/dhcpserver.c
+++ b/app/lwip/app/dhcpserver.c
@@ -689,6 +689,7 @@ static void ICACHE_FLASH_ATTR handle_dhcp(void *arg,
             	 os_printf("dhcps: handle_dhcp-> DHCPD_STATE_ACK\n");
 #endif			
 	             send_ack(pmsg_dhcps, malloc_len);
+		     wifi_softap_set_station_info(pmsg_dhcps->chaddr, &client_address.addr);
 	             break;
 	        case DHCPS_STATE_NAK://4
 #if DHCPS_DEBUG            
@@ -1199,7 +1200,6 @@ uint32 ICACHE_FLASH_ATTR wifi_softap_dhcps_client_update(u8 *bssid, struct ip_ad
             node_insert_to_list(&plist,pback_node);
         }
     }
-    wifi_softap_set_station_info(bssid, &pdhcps_pool->ip);
 
     return pdhcps_pool->ip.addr;
 }

--- a/app/lwip/app/espconn.c
+++ b/app/lwip/app/espconn.c
@@ -1105,6 +1105,8 @@ espconn_set_opt(struct espconn *espconn, uint8 opt)
 	if (value) {
 		pnode->pcommon.espconn_opt |= opt;
 		tpcb = pnode->pcommon.pcb;
+		if (NULL == tpcb)
+			return ESPCONN_OK;
 		if (espconn_delay_disabled(pnode))
 			tcp_nagle_disable(tpcb);
 
@@ -1143,7 +1145,8 @@ espconn_clear_opt(struct espconn *espconn, uint8 opt)
 		tpcb = pnode->pcommon.pcb;
 		if (espconn_keepalive_enabled(pnode))
 			espconn_keepalive_disable(tpcb);
-
+		if (NULL == tpcb)
+			return ESPCONN_OK;
 		if (espconn_delay_enabled(pnode))
 			tcp_nagle_enable(tpcb);
 
@@ -1176,6 +1179,8 @@ sint8 ICACHE_FLASH_ATTR espconn_set_keepalive(struct espconn *espconn, uint8 lev
 	value = espconn_find_connection(espconn, &pnode);
 	if (value && espconn_keepalive_disabled(pnode)) {
 		struct tcp_pcb *pcb = pnode->pcommon.pcb;
+		if (NULL == pcb)
+			return ESPCONN_OK;
 		switch (level){
 			case ESPCONN_KEEPIDLE:
 				pcb->keep_idle = 1000 * (u32_t)(*(int*)optarg);
@@ -1221,6 +1226,8 @@ sint8 ICACHE_FLASH_ATTR espconn_get_keepalive(struct espconn *espconn, uint8 lev
 	value = espconn_find_connection(espconn, &pnode);
 	if (value && espconn_keepalive_disabled(pnode)) {
 		struct tcp_pcb *pcb = pnode->pcommon.pcb;
+		if (NULL == pcb)
+			return ESPCONN_OK;
 		switch (level) {
 		case ESPCONN_KEEPIDLE:
 			*(int*)optarg = (int)(pcb->keep_idle/1000);


### PR DESCRIPTION
Minimally build and boot tested, but the changes look pretty boring.
Fixes https://github.com/nodemcu/nodemcu-firmware/issues/2395

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).