### PR TITLE
Fixed missing wifi module name.

### DIFF
--- a/lua_examples/telnet/telnet.lua
+++ b/lua_examples/telnet/telnet.lua
@@ -144,7 +144,7 @@ return {
       wifi.sta.config { ssid = ssid, pwd  = pwd, save = false }
     end
     tmr.alarm(0, 500, tmr.ALARM_AUTO, function()
-      if (sta.status() == wifi.STA_GOTIP) then
+      if (wifi.sta.status() == wifi.STA_GOTIP) then
         tmr.unregister(0)
         print("Welcome to NodeMCU world", node.heap(), wifi.sta.getip())
         net.createServer(net.TCP, 180):listen(port or 2323, telnet_listener)


### PR DESCRIPTION
This PR fixes a missing "wifi" module name. Without this, NodeMCU panics with sta being null.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

