### PR TITLE
Small typo in ftp server fails compilation

### DIFF
--- a/lua_modules/ftp/ftpserver.lua
+++ b/lua_modules/ftp/ftpserver.lua
@@ -1,4 +1,4 @@
-o--[[ A simple ftp server
+--[[ A simple ftp server
 
  This is my implementation of a FTP server using Github user Neronix's
  example as inspriration, but as a cleaner Lua implementation that has been


### PR DESCRIPTION
There sneaked in an 'o' at the beginning of the file

Fixes #no issue as the change is minimal.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`. (Not applicable)

Maybe this could be prevented by assing lua compiles to the travis build?