### PR TITLE
Add option to strip debug symbols (false by default)

### DIFF
--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -175,6 +175,7 @@ static int node_compile( lua_State* L )
   int file_fd = 0;
   size_t len;
   const char *fname = luaL_checklstring( L, 1, &len );
+  int stripping = lua_toboolean( L, 2 );
   const char *basename = vfs_basename( fname );
   luaL_argcheck(L, strlen(basename) <= CONFIG_FS_OBJ_NAME_LEN && strlen(fname) == len, 1, "filename invalid");
 
@@ -196,8 +197,6 @@ static int node_compile( lua_State* L )
   }
 
   f = toproto(L, -1);
-
-  int stripping = 1;      /* strip debug information? */
 
   file_fd = vfs_open(output, "w+");
   if (!file_fd)

--- a/docs/en/modules/node.md
+++ b/docs/en/modules/node.md
@@ -66,10 +66,13 @@ reported as a string now. E.g. `"0x1818fe346a88"`.
 Compiles a Lua text file into Lua bytecode, and saves it as .lc file.
 
 #### Syntax
-`node.compile("file.lua")`
+`node.compile("file.lua", false)`
 
 #### Parameters
-`filename` name of Lua text file
+- `filename` name of Lua text file
+- `strip` whether or not to strip debug symbols
+  - `true` debug symbols **will** be stripped
+  - `false` debug symbols **will not** be stripped (Default)
 
 #### Returns
 `nil`


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This makes stripping debug symbols during compilation optional. By default, it does not enable stripping (to match behavior for ESP8266). This makes Lua stack traces usable.