### PR TITLE
use ar from esp toolchain instead of host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,8 +227,8 @@ $(TOP_DIR)/sdk/.patched-$(SDK_VER): $(TOP_DIR)/cache/$(SDK_PATCH_VER).patch
 
 $(TOP_DIR)/sdk/.pruned-$(SDK_VER):
 	rm -f $(SDK_DIR)/lib/liblwip.a $(SDK_DIR)/lib/libssl.a $(SDK_DIR)/lib/libmbedtls.a
-	ar d $(SDK_DIR)/lib/libmain.a time.o
-	ar d $(SDK_DIR)/lib/libc.a lib_a-time.o
+	$(AR) d $(SDK_DIR)/lib/libmain.a time.o
+	$(AR) d $(SDK_DIR)/lib/libc.a lib_a-time.o
 	touch $@
 
 $(TOP_DIR)/cache/v$(SDK_FILE_VER).zip:


### PR DESCRIPTION
Fixes #2444.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

The steps for preparing the binary libraries use `ar` from the host's toolchain. This appears to fail sometimes as reported in the related issue.
Since we're operating on archives for the target esp system, I'd say it's safer to use `ar` from the target xtensa toochain.
