### PR TITLE
file: list now takes optional pattern for filtering

### DIFF
--- a/docs/en/modules/file.md
+++ b/docs/en/modules/file.md
@@ -144,13 +144,17 @@ print("\nFile system info:\nTotal : "..total.." (k)Bytes\nUsed : "..used.." (k)B
 Lists all files in the file system.
 
 #### Syntax
-`file.list()`
+`file.list([pattern])`
 
 #### Parameters
 none
 
 #### Returns
-a Lua table which contains the {file name: file size} pairs
+a Lua table which contains all {file name: file size} pairs, if no pattern
+given.  If a pattern is given, only those file names matching the pattern
+(interpreted as a traditional [Lua pattern](https://www.lua.org/pil/20.2.html),
+not, say, a UNIX shell glob) will be included in the resulting table.
+`file.list` will throw any errors encountered during pattern matching.
 
 #### Example
 ```lua


### PR DESCRIPTION
See #2440.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This adds an optional pattern to `file.list()` to filter results before handing them to Lua.  This optimizes the relatively common pattern of
```lua
for f,s in pairs(file.list()) do
  if s:match(pattern) then
    -- process matching file name
  end
end
```
into the more concise, faster, and less-memory-consuming
```lua
for f,s in pairs (file.list(pattern)) do
  -- process each matching file name
end
```
(neglecting the possibility that pattern might raise an error.  If that happens, `file.list(pattern)` will now return `nil, errorstr`, as typical).

This has been tested by running comprehensive test cases:
```
for k,v in pairs(file.list()) do print(k,v) end -- all files
for k,v in pairs(file.list("asdf")) do print(k,v) end -- pattern with no matches
for k,v in pairs(file.list("ini")) do print(k,v) end -- pattern some matches
for k,v in pairs(file.list({})) do print(k,v) end -- wrong type passed as argument
_, y = file.list("%fx"); print (y) -- pattern error passed up to caller
```