### PR TITLE
fix output filename of LFS image built in tools

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -73,16 +73,16 @@ spiffsimg/spiffsimg:
 spiffsscript: remove-image LFSimage spiffsimg/spiffsimg
 	rm -f ./spiffsimg/spiffs.lst
 	@echo "" >> ./spiffsimg/spiffs.lst
-	@$(foreach f, $(SPIFFSFILES), echo "import $(FSSOURCE)$(f) $(f)" >> ./spiffsimg/spiffs.lst ;)
+	@$(foreach f, $(SPIFFSFILES), echo "import $(FSSOURCE)/$(f) $(f)" >> ./spiffsimg/spiffs.lst ;)
 	$(foreach sz, $(FLASHSIZE), spiffsimg/spiffsimg -f ../bin/0x%x-$(sz).img  $(FLASH_SW) $(sz) -U $(FLASH_FS_LOC) -r ./spiffsimg/spiffs.lst -d; )
 	@$(foreach sz, $(FLASHSIZE), if [ -r ../bin/spiffs-$(sz).dat ]; then echo Built $$(cat ../bin/spiffs-$(sz).dat)-$(sz).bin; fi; )
 
 ifneq ($(LFSSOURCES),)
 LFSimage: $(LFSSOURCES)
-	$(LUAC_CROSS) -f -o $(FSSOURCE)flash.img $(LFSSOURCES)
+	$(LUAC_CROSS) -f -o $(FSSOURCE)/LFS.img $(LFSSOURCES)
 else
 LFSimage: 
-	rm -f $(FSSOURCE)flash.img
+	rm -f $(FSSOURCE)/LFS.img
 endif
 
 remove-image:


### PR DESCRIPTION
+ fix spiffs image creation

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

\<Description of and rationale behind this PR\>
In my last PR there was a bug in generating the LFS image to the wrong folder.
Also adapted the name to LFS.img instead of flash.img
