### PR TITLE
Initial version of code to support multiple hardware timers

### DIFF
--- a/app/modules/gpio_pulse.c
+++ b/app/modules/gpio_pulse.c
@@ -10,7 +10,7 @@
 #include "pin_map.h"
 #include "driver/gpio16.h"
 
-#define TIMER_OWNER 'P'
+#define TIMER_OWNER (('P' << 8) + 'U')
 
 #define xstr(s) str(s)
 #define str(s) #s

--- a/app/modules/gpio_pulse.c
+++ b/app/modules/gpio_pulse.c
@@ -434,7 +434,7 @@ static int gpio_pulse_start(lua_State *L) {
   pulser->next_adjust = initial_adjust;
 
   // Now start things up
-  if (!platform_hw_timer_init(TIMER_OWNER, FRC1_SOURCE, TRUE)) {
+  if (!platform_hw_timer_init(TIMER_OWNER, FRC1_SOURCE, FALSE)) {
     // Failed to init the timer
     luaL_error(L, "Unable to initialize timer");
   }

--- a/app/platform/hw_timer.c
+++ b/app/platform/hw_timer.c
@@ -16,6 +16,9 @@
 * where module_init is a function. For builtin modules, it might be 
 * a small numeric value that is known not to clash.
 *******************************************************************************/
+#include "platform.h"
+#include "c_stdio.h"
+#include "c_stdlib.h"
 #include "ets_sys.h"
 #include "os_type.h"
 #include "osapi.h"
@@ -37,11 +40,154 @@ typedef enum {			//timer interrupt mode
     TM_EDGE_INT   = 0,	//edge interrupt
 } TIMER_INT_MODE;
 
-static os_param_t the_owner;
-static os_param_t callback_arg;
-static void (* user_hw_timer_cb)(os_param_t);
+typedef struct _timer_user {
+  struct _timer_user *next;
+  bool autoload;
+  int32_t delay;
+  int32_t autoload_delay;
+  os_param_t owner;
+  os_param_t callback_arg;
+  void (* user_hw_timer_cb)(os_param_t);
+  int cb_count;
+} timer_user;
 
-#define VERIFY_OWNER(owner)  if (owner != the_owner) { if (the_owner) { return 0; } the_owner = owner; }
+static timer_user *active;
+static timer_user *inactive;
+static uint8_t lock_count;
+static uint8_t timer_running;
+
+#define LOCK()   do { ets_intr_lock(); lock_count++; } while (0)
+#define UNLOCK()   if (--lock_count == 0) ets_intr_unlock()
+
+#if 0
+void hw_timer_debug() {
+  dbg_printf("timer_running=%d\n", timer_running);
+  timer_user *tu;
+  for (tu = active; tu; tu = tu->next) {
+    dbg_printf("Owner: 0x%x, delay=%d, autoload=%d, autoload_delay=%d, cb_count=%d\n",
+        tu->owner, tu->delay, tu->autoload, tu->autoload_delay, tu->cb_count);
+  }
+}
+#endif
+
+static void adjust_root() {
+  // Can only ge called with interrupts disabled
+  // change the initial active delay so that relative stuff still works
+  if (active && timer_running) {
+    int32_t time_left = (RTC_REG_READ(FRC1_COUNT_ADDRESS)) & ((1 << 23) - 1);
+    if (time_left > active->delay) {
+      // We have missed the interrupt
+      time_left -= 1 << 23;
+    }
+    active->delay = time_left;
+  }
+}
+
+static timer_user *find_tu(os_param_t owner) {
+  // Try the inactive chain first
+  timer_user **p;
+
+  LOCK();
+
+  for (p = &inactive; *p; p = &((*p)->next)) {
+    if ((*p)->owner == owner) {
+      timer_user *result = *p;
+
+      UNLOCK();
+
+      return result;
+    }
+  }
+
+  for (p = &active; *p; p = &((*p)->next)) {
+    if ((*p)->owner == owner) {
+      timer_user *result = *p;
+
+      UNLOCK();
+
+      return result;
+    }
+  }
+
+  UNLOCK();
+  return NULL;
+}
+
+static timer_user *find_tu_and_remove(os_param_t owner) {
+  // Try the inactive chain first
+  timer_user **p;
+
+  LOCK();
+
+  for (p = &inactive; *p; p = &((*p)->next)) {
+    if ((*p)->owner == owner) {
+      timer_user *result = *p;
+      *p = result->next;
+      result->next = NULL;
+
+      UNLOCK();
+
+      return result;
+    }
+  }
+
+  for (p = &active; *p; p = &((*p)->next)) {
+    if ((*p)->owner == owner) {
+      timer_user *result = *p;
+
+      bool need_to_reset = (result == active) && result->next;
+
+      if (need_to_reset) {
+        adjust_root();
+      }
+
+      // Increase the delay on the next element
+      if (result->next) {
+        result->next->delay += result->delay;
+      }
+
+      // Cut out of chain
+      *p = result->next;
+      result->next = NULL;
+
+      if (need_to_reset) {
+        RTC_REG_WRITE(FRC1_LOAD_ADDRESS, active->delay);
+        timer_running = 1;
+      }
+
+      UNLOCK();
+      return result;
+    }
+  }
+
+  UNLOCK();
+  return NULL;
+}
+
+static void insert_active_tu(timer_user *tu) {
+  timer_user **p;
+
+  LOCK();
+  for (p = &active; *p; p = &((*p)->next)) {
+    if ((*p)->delay >= tu->delay) {
+      break;
+    }
+    tu->delay -= (*p)->delay;
+  }
+
+  if (*p) {
+    (*p)->delay -= tu->delay;
+  }
+  tu->next = *p;
+  *p = tu;
+
+  if (*p == active) {
+    // We have a new leader
+    RTC_REG_WRITE(FRC1_LOAD_ADDRESS, active->delay > 0 ? active->delay : 1);
+    timer_running = 1;
+  }
+  UNLOCK();
+}
 
 /******************************************************************************
 * FunctionName : platform_hw_timer_arm_ticks
@@ -52,10 +198,21 @@ static void (* user_hw_timer_cb)(os_param_t);
 *******************************************************************************/
 bool ICACHE_RAM_ATTR platform_hw_timer_arm_ticks(os_param_t owner, uint32_t ticks)
 {
-  VERIFY_OWNER(owner);
-  RTC_REG_WRITE(FRC1_LOAD_ADDRESS, ticks);
+  timer_user *tu = find_tu_and_remove(owner);
 
-  return 1;
+  if (!tu) {
+    return false;
+  }
+
+  tu->delay = ticks;
+  tu->autoload_delay = ticks;
+
+  LOCK();
+  adjust_root();
+  insert_active_tu(tu);
+  UNLOCK();
+
+  return true;
 }
 
 /******************************************************************************
@@ -72,10 +229,7 @@ bool ICACHE_RAM_ATTR platform_hw_timer_arm_ticks(os_param_t owner, uint32_t tick
 *******************************************************************************/
 bool ICACHE_RAM_ATTR platform_hw_timer_arm_us(os_param_t owner, uint32_t microseconds)
 {
-  VERIFY_OWNER(owner);
-  RTC_REG_WRITE(FRC1_LOAD_ADDRESS, US_TO_RTC_TIMER_TICKS(microseconds));
-
-  return 1;
+  return platform_hw_timer_arm_ticks(owner, US_TO_RTC_TIMER_TICKS(microseconds));
 }
 
 /******************************************************************************
@@ -89,24 +243,56 @@ bool ICACHE_RAM_ATTR platform_hw_timer_arm_us(os_param_t owner, uint32_t microse
 *******************************************************************************/
 bool platform_hw_timer_set_func(os_param_t owner, void (* user_hw_timer_cb_set)(os_param_t), os_param_t arg)
 {
-  VERIFY_OWNER(owner);
-  callback_arg = arg;
-  user_hw_timer_cb = user_hw_timer_cb_set;
-  return 1;
+  timer_user *tu = find_tu(owner);
+  if (!tu) {
+    return false;
+  }
+  tu->callback_arg = arg;
+  tu->user_hw_timer_cb = user_hw_timer_cb_set;
+  return true;
 }
 
 static void ICACHE_RAM_ATTR hw_timer_isr_cb(void *arg)
 {
-  if (user_hw_timer_cb != NULL) {
-    (*(user_hw_timer_cb))(callback_arg);
+  bool keep_going = true;
+  adjust_root();
+  timer_running = 0;
+
+  while (keep_going && active) {
+    keep_going = false;
+
+    timer_user *fired = active;
+    active = fired->next;
+    if (fired->autoload) {
+      fired->delay = fired->autoload_delay;
+      insert_active_tu(fired);
+      if (active->delay <= 0) {
+        keep_going = true;
+      }
+    } else {
+      fired->next = inactive;
+      inactive = fired;
+      if (active) {
+        active->delay += fired->delay;
+        if (active->delay <= 0) {
+          keep_going = true;
+        }
+      }
+    }
+    if (fired->user_hw_timer_cb) {
+      fired->cb_count++;
+      (*(fired->user_hw_timer_cb))(fired->callback_arg);
+    }
+  }
+  if (active && !timer_running) {
+    RTC_REG_WRITE(FRC1_LOAD_ADDRESS, active->delay);
+    timer_running = 1;
   }
 }
 
 static void ICACHE_RAM_ATTR hw_timer_nmi_cb(void)
 {
-  if (user_hw_timer_cb != NULL) {
-    (*(user_hw_timer_cb))(callback_arg);
-  }
+  hw_timer_isr_cb(NULL);
 }
 
 /******************************************************************************
@@ -114,12 +300,13 @@ static void ICACHE_RAM_ATTR hw_timer_nmi_cb(void)
 * Description  : figure out how long since th last timer interrupt
 * Parameters   : os_param_t owner
 * Returns      : the number of ticks
+* This is actually the last timer interrupt and not the interrupt for your
+* timer. This may cause problems.
 *******************************************************************************/
 uint32_t ICACHE_RAM_ATTR platform_hw_timer_get_delay_ticks(os_param_t owner)
 {
-  VERIFY_OWNER(owner);
-
-  return (- RTC_REG_READ(FRC1_COUNT_ADDRESS)) & ((1 << 23) - 1);
+  return 0;
+  //return (- RTC_REG_READ(FRC1_COUNT_ADDRESS)) & ((1 << 23) - 1);
 }
 
 /******************************************************************************
@@ -136,25 +323,34 @@ uint32_t ICACHE_RAM_ATTR platform_hw_timer_get_delay_ticks(os_param_t owner)
 *******************************************************************************/
 bool platform_hw_timer_init(os_param_t owner, FRC1_TIMER_SOURCE_TYPE source_type, bool autoload)
 {
-  VERIFY_OWNER(owner);
-  if (autoload) {
-    RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
-		  FRC1_AUTO_LOAD | DIVIDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
-  } else {
+  timer_user *tu = find_tu_and_remove(owner);
+
+  if (!tu) {
+    tu = (timer_user *) c_malloc(sizeof(*tu));
+    if (!tu) {
+      return false;
+    }
+    memset(tu, 0, sizeof(*tu));
+    tu->owner = owner;
+  }
+
+  tu->autoload = autoload;
+
+  if (!active && !inactive) {
     RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
 		  DIVIDED_BY_16 | FRC1_ENABLE_TIMER | TM_EDGE_INT);
-  }
-
-  if (source_type == NMI_SOURCE) {
-    ETS_FRC_TIMER1_NMI_INTR_ATTACH(hw_timer_nmi_cb);
-  } else {
     ETS_FRC_TIMER1_INTR_ATTACH(hw_timer_isr_cb, NULL);
+
+    TM1_EDGE_INT_ENABLE();
+    ETS_FRC1_INTR_ENABLE();
   }
 
-  TM1_EDGE_INT_ENABLE();
-  ETS_FRC1_INTR_ENABLE();
+  LOCK();
+  tu->next = inactive;
+  inactive = tu;
+  UNLOCK();
 
-  return 1;
+  return true;
 }
 
 /******************************************************************************
@@ -165,19 +361,25 @@ bool platform_hw_timer_init(os_param_t owner, FRC1_TIMER_SOURCE_TYPE source_type
 *******************************************************************************/
 bool ICACHE_RAM_ATTR platform_hw_timer_close(os_param_t owner)
 {
-  VERIFY_OWNER(owner);
+  timer_user *tu = find_tu_and_remove(owner);
 
-  /* Set no reload mode */
-  RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
-		DIVIDED_BY_16 | TM_EDGE_INT);
+  if (tu) {
+    LOCK();
+    tu->next = inactive;
+    inactive = tu;
+    UNLOCK();
+  }
 
-  TM1_EDGE_INT_DISABLE();
-  ETS_FRC1_INTR_DISABLE();
+  // This will never actually run....
+  if (!active && !inactive) {
+    /* Set no reload mode */
+    RTC_REG_WRITE(FRC1_CTRL_ADDRESS,
+                  DIVIDED_BY_16 | TM_EDGE_INT);
 
-  user_hw_timer_cb = NULL;
+    TM1_EDGE_INT_DISABLE();
+    ETS_FRC1_INTR_DISABLE();
+  }
 
-  the_owner = 0;
-
-  return 1;
+  return true;
 }
 


### PR DESCRIPTION
Fixes #2494.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

This adds support to the hw_timer.c file to be able to have multiple timers running at the same time (multiplexed in software). This code is just about working and could do with some cleanup. It also may crash, burn or cause other problems. However, it does run gpio.pulse and pwm at the same time (in a simple case) and appear to work.
