### PR TITLE
Optimise ROTable accesses and interface

### DIFF
--- a/app/include/module.h
+++ b/app/include/module.h
@@ -60,15 +60,6 @@
     luaR_entry MODULE_EXPAND_PASTE_(cfgname,MODULE_EXPAND_PASTE_(_module_selected,MODULE_PASTE_(LUA_USE_MODULES_,cfgname))) \
     = {LSTRKEY(luaname), LROVAL(map)}
 
-/* System module registration support, not using LUA_USE_MODULES_XYZ. */
-#define BUILTIN_LIB_INIT(name, luaname, initfunc) \
-  const LOCK_IN_SECTION(libs) \
-    luaL_Reg MODULE_PASTE_(lua_lib_,name) = { luaname, initfunc }
-
-#define BUILTIN_LIB(name, luaname, map) \
-  const LOCK_IN_SECTION(rotable) \
-    luaR_entry MODULE_PASTE_(lua_rotable_,name) = {LSTRKEY(luaname), LROVAL(map)}
-
 #if !defined(LUA_CROSS_COMPILER) && !(MIN_OPT_LEVEL==2 && LUA_OPTIMIZE_MEMORY==2)
 # error "NodeMCU modules must be built with LTR enabled (MIN_OPT_LEVEL=2 and LUA_OPTIMIZE_MEMORY=2)"
 #endif

--- a/app/include/module.h
+++ b/app/include/module.h
@@ -57,9 +57,8 @@
   const LOCK_IN_SECTION(libs) \
     luaL_Reg MODULE_PASTE_(lua_lib_,cfgname) = { luaname, initfunc }; \
   const LOCK_IN_SECTION(rotable) \
-    luaR_table MODULE_EXPAND_PASTE_(cfgname,MODULE_EXPAND_PASTE_(_module_selected,MODULE_PASTE_(LUA_USE_MODULES_,cfgname))) \
-    = { luaname, map }
-
+    luaR_entry MODULE_EXPAND_PASTE_(cfgname,MODULE_EXPAND_PASTE_(_module_selected,MODULE_PASTE_(LUA_USE_MODULES_,cfgname))) \
+    = {LSTRKEY(luaname), LROVAL(map)}
 
 /* System module registration support, not using LUA_USE_MODULES_XYZ. */
 #define BUILTIN_LIB_INIT(name, luaname, initfunc) \
@@ -68,7 +67,7 @@
 
 #define BUILTIN_LIB(name, luaname, map) \
   const LOCK_IN_SECTION(rotable) \
-    luaR_table MODULE_PASTE_(lua_rotable_,name) = { luaname, map }
+    luaR_entry MODULE_PASTE_(lua_rotable_,name) = {LSTRKEY(luaname), LROVAL(map)}
 
 #if !defined(LUA_CROSS_COMPILER) && !(MIN_OPT_LEVEL==2 && LUA_OPTIMIZE_MEMORY==2)
 # error "NodeMCU modules must be built with LTR enabled (MIN_OPT_LEVEL=2 and LUA_OPTIMIZE_MEMORY=2)"

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -25,8 +25,6 @@
 #define lauxlib_c
 #define LUA_LIB
 
-#include "lrotable.h"
-
 #include "lauxlib.h"
 #include "lgc.h"
 #include "ldo.h"
@@ -555,14 +553,7 @@ LUALIB_API const char *luaL_findtable (lua_State *L, int idx,
     if (e == NULL) e = fname + c_strlen(fname);
     lua_pushlstring(L, fname, e - fname);
     lua_rawget(L, -2);
-    if (lua_isnil(L, -1)) {
-      /* If looking for a global variable, check the rotables too */
-      void *ptable = luaR_findglobal(fname, e - fname);
-      if (ptable) {
-        lua_pop(L, 1);
-        lua_pushrotable(L, ptable);
-      }
-    }
+
     if (lua_isnil(L, -1)) {  /* no such field? */
       lua_pop(L, 1);  /* remove this nil */
       lua_createtable(L, 0, (*e == '.' ? 1 : szhint)); /* new table for field */

--- a/app/lua/ldblib.c
+++ b/app/lua/ldblib.c
@@ -16,7 +16,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lrotable.h"
 #include "lstring.h"
 #include "lflash.h"
 #include "user_modules.h"

--- a/app/lua/lgc.c
+++ b/app/lua/lgc.c
@@ -168,10 +168,14 @@ static int traversetable (global_State *g, Table *h) {
   int i;
   int weakkey = 0;
   int weakvalue = 0;
-  const TValue *mode;
-  if (h->metatable && !luaR_isrotable(h->metatable))
-    markobject(g, h->metatable);
-  mode = gfasttm(g, h->metatable, TM_MODE);
+  const TValue *mode = luaO_nilobject;
+
+  if (h->metatable) {
+    if (!luaR_isrotable(h->metatable))
+      markobject(g, h->metatable);
+    mode = gfasttm(g, h->metatable, TM_MODE);
+  }
+    
   if (mode && ttisstring(mode)) {  /* is there a weak mode? */
     weakkey = (c_strchr(svalue(mode), 'k') != NULL);
     weakvalue = (c_strchr(svalue(mode), 'v') != NULL);

--- a/app/lua/linit.c
+++ b/app/lua/linit.c
@@ -15,71 +15,69 @@
 #include "lauxlib.h"
 #include "luaconf.h"
 #include "module.h"
+
+#if !defined(LUA_CROSS_COMPILER) && !(MIN_OPT_LEVEL==2 && LUA_OPTIMIZE_MEMORY==2)
+# error "NodeMCU modules must be built with LTR enabled (MIN_OPT_LEVEL=2 and LUA_OPTIMIZE_MEMORY=2)"
+#endif
+
 extern const luaR_entry strlib[], tab_funcs[],  dblib[], 
                         co_funcs[], math_map[], syslib[];
-#if defined(LUA_CROSS_COMPILER)
-BUILTIN_LIB_INIT( start_list,  NULL,               NULL);
-#if !defined(LUA_DEBUG_BUILD)
-const LOCK_IN_SECTION(rotable) luaR_entry lua_rotable_end_list =  {LNILKEY, LNILVAL};
-#endif
-#endif
-BUILTIN_LIB_INIT( LOADLIB,   LUA_LOADLIBNAME,   luaopen_package);
-BUILTIN_LIB_INIT( STRING,    LUA_STRLIBNAME,    luaopen_string);
-BUILTIN_LIB_INIT( TABLE,     LUA_TABLIBNAME,    luaopen_table);
-BUILTIN_LIB_INIT( DBG,       LUA_DBLIBNAME,     luaopen_debug);
+extern const luaR_entry syslib[], io_funcs[];  // Only used on cross-compile builds
 
-BUILTIN_LIB(      STRING,    LUA_STRLIBNAME,    strlib);
-BUILTIN_LIB(      TABLE,     LUA_TABLIBNAME,    tab_funcs);
-BUILTIN_LIB(      DBG,       LUA_DBLIBNAME,     dblib);
-BUILTIN_LIB(      CO,        LUA_COLIBNAME,     co_funcs);
-BUILTIN_LIB(      MATH,      LUA_MATHLIBNAME,   math_map);
-
-#if defined(LUA_CROSS_COMPILER)
-extern const luaR_entry syslib[], io_funcs[];
-BUILTIN_LIB(      OS,        LUA_OSLIBNAME,     syslib);
-BUILTIN_LIB_INIT( IO,        LUA_IOLIBNAME,     luaopen_io);
-#if defined(LUA_DEBUG_BUILD)
-const LOCK_IN_SECTION(rotable) luaR_entry lua_rotable_end_list =  {LNILKEY, LNILVAL};
-#endif
-BUILTIN_LIB_INIT( end_list,  NULL,               NULL);
-#endif
-
-#if defined(LUA_CROSS_COMPILER)
 /*
- * These base addresses are internal to this module for cross compile builds
- * This also exploits feature of the GCC code generator that the variables are
- * emitted in either normal OR reverse order within PSECT.  A bit of a cludge,
- * but exploiting these characteristics and ditto of the GNU linker is simpler
- * than replacing the default ld setup.
+ * The NodeMCU Lua initalisation has been adapted to use linker-based module 
+ * registration.  This uses a PSECT naming convention to allow the lib and rotab
+ * entries to be collected by the linker into consoliated tables.  The linker
+ * defines lua_libs_base and lua_rotable_base.
+ *
+ * This is not practical on Posix builds which use a standard loader declaration
+ * so for cross compiler builds, separate ROTables are used for the base functions
+ * and library ROTables, with the latter chained from the former using its __index 
+ * meta-method. In this case all library ROTables are defined here, avoiding the
+ * need for linker magic is avoided on host builds. 
  */
-extern const luaR_entry lua_rotable_start_list;  // Declared in lbaselib.c
 
-#if defined(LUA_DEBUG_BUILD)
-const        luaL_Reg   *lua_libs    = &lua_lib_start_list+1;
-#else
-const        luaL_Reg   *lua_libs    = &lua_lib_end_list+1;
-#endif
-const        luaR_entry *lua_rotable = &lua_rotable_start_list+1;
-
-#else /* Xtensa build */
-/*
- * These base addresses are Xtensa toolchain linker constants for Firmware builds 
- */ 
+#if defined(LUA_CROSS_COMPILER)
+#define LUA_ROTABLES lua_rotable_base
+#define LUA_LIBS     lua_libs_base
+#else /* declare Xtensa toolchain linker defined constants */ 
 extern const luaL_Reg    lua_libs_base[];
 extern const luaR_entry  lua_rotable_base[];
-const        luaL_Reg   *lua_libs    = lua_libs_base;
-const        luaR_entry *lua_rotable = lua_rotable_base;
+#define LUA_ROTABLES lua_rotable_core
+#define LUA_LIBS     lua_libs_core
 #endif
+             
+static const LOCK_IN_SECTION(libs) luaL_reg LUA_LIBS[] = {
+  {"",              luaopen_base},
+  {LUA_LOADLIBNAME, luaopen_package},
+  {LUA_STRLIBNAME,  luaopen_string},
+  {LUA_TABLIBNAME,  luaopen_table},
+  {LUA_DBLIBNAME,   luaopen_debug}
+#if defined(LUA_CROSS_COMPILER)
+ ,{LUA_IOLIBNAME,   luaopen_io},
+  {NULL,            NULL}
+#endif
+};
+
+#define ENTRY(n,t)  {LSTRKEY(n), LRO_ROVAL(t)}
+
+const LOCK_IN_SECTION(rotable) ROTable LUA_ROTABLES[] = {
+  ENTRY("ROM",           LUA_ROTABLES),
+  ENTRY(LUA_STRLIBNAME,  strlib),
+  ENTRY(LUA_TABLIBNAME,  tab_funcs),
+  ENTRY(LUA_DBLIBNAME,   dblib),
+  ENTRY(LUA_COLIBNAME,   co_funcs),
+  ENTRY(LUA_MATHLIBNAME, math_map)
+#if defined(LUA_CROSS_COMPILER)
+ ,ENTRY(LUA_OSLIBNAME,   syslib),
+  LROT_END
+#endif
+  };
 
 void luaL_openlibs (lua_State *L) {
-  const luaL_Reg *lib = lua_libs;
+  const luaL_Reg *lib = lua_libs_base;
 
-  /* Always open Base first */
-  lua_pushcfunction(L, luaopen_base);
-  lua_pushliteral(L, "");
-  lua_call(L, 1, 0);
-
-  /* Now loop round and open other libraries */
+  /* loop round and open libraries */
   for (; lib->name; lib++) {
     if (lib->func) {
       lua_pushcfunction(L, lib->func);

--- a/app/lua/linit.c
+++ b/app/lua/linit.c
@@ -15,60 +15,73 @@
 #include "lauxlib.h"
 #include "luaconf.h"
 #include "module.h"
-#if defined(LUA_CROSS_COMPILER)
-BUILTIN_LIB(      start_list,  NULL,               NULL);
-BUILTIN_LIB_INIT( start_list,  NULL,               NULL);
-#endif
 extern const luaR_entry strlib[], tab_funcs[],  dblib[], 
                         co_funcs[], math_map[], syslib[];
-
-BUILTIN_LIB_INIT( BASE,      "",                luaopen_base);
+#if defined(LUA_CROSS_COMPILER)
+BUILTIN_LIB_INIT( start_list,  NULL,               NULL);
+#if !defined(LUA_DEBUG_BUILD)
+const LOCK_IN_SECTION(rotable) luaR_entry lua_rotable_end_list =  {LNILKEY, LNILVAL};
+#endif
+#endif
 BUILTIN_LIB_INIT( LOADLIB,   LUA_LOADLIBNAME,   luaopen_package);
-
-BUILTIN_LIB(      STRING,    LUA_STRLIBNAME,    strlib);
 BUILTIN_LIB_INIT( STRING,    LUA_STRLIBNAME,    luaopen_string);
-
-BUILTIN_LIB(      TABLE,     LUA_TABLIBNAME,    tab_funcs);
 BUILTIN_LIB_INIT( TABLE,     LUA_TABLIBNAME,    luaopen_table);
-
-BUILTIN_LIB(      DBG,       LUA_DBLIBNAME,     dblib);
 BUILTIN_LIB_INIT( DBG,       LUA_DBLIBNAME,     luaopen_debug);
 
+BUILTIN_LIB(      STRING,    LUA_STRLIBNAME,    strlib);
+BUILTIN_LIB(      TABLE,     LUA_TABLIBNAME,    tab_funcs);
+BUILTIN_LIB(      DBG,       LUA_DBLIBNAME,     dblib);
 BUILTIN_LIB(      CO,        LUA_COLIBNAME,     co_funcs);
-
 BUILTIN_LIB(      MATH,      LUA_MATHLIBNAME,   math_map);
 
 #if defined(LUA_CROSS_COMPILER)
-extern const luaR_entry syslib[], iolib[];
+extern const luaR_entry syslib[], io_funcs[];
 BUILTIN_LIB(      OS,        LUA_OSLIBNAME,     syslib);
 BUILTIN_LIB_INIT( IO,        LUA_IOLIBNAME,     luaopen_io);
-BUILTIN_LIB(      end_list,  NULL,               NULL);
+#if defined(LUA_DEBUG_BUILD)
+const LOCK_IN_SECTION(rotable) luaR_entry lua_rotable_end_list =  {LNILKEY, LNILVAL};
+#endif
 BUILTIN_LIB_INIT( end_list,  NULL,               NULL);
+#endif
+
+#if defined(LUA_CROSS_COMPILER)
 /*
  * These base addresses are internal to this module for cross compile builds
  * This also exploits feature of the GCC code generator that the variables are
- * emitted in either normal OR reverse order within PSECT.
+ * emitted in either normal OR reverse order within PSECT.  A bit of a cludge,
+ * but exploiting these characteristics and ditto of the GNU linker is simpler
+ * than replacing the default ld setup.
  */
-#define isascending(n) ((&(n ## _end_list)-&(n ## _start_list))>0)
-static const luaL_Reg   *lua_libs;
-const        luaR_table *lua_rotable;
-#else 
-/* These base addresses are Xtensa toolchain linker constants for Firmware builds */ 
+extern const luaR_entry lua_rotable_start_list;  // Declared in lbaselib.c
+
+#if defined(LUA_DEBUG_BUILD)
+const        luaL_Reg   *lua_libs    = &lua_lib_start_list+1;
+#else
+const        luaL_Reg   *lua_libs    = &lua_lib_end_list+1;
+#endif
+const        luaR_entry *lua_rotable = &lua_rotable_start_list+1;
+
+#else /* Xtensa build */
+/*
+ * These base addresses are Xtensa toolchain linker constants for Firmware builds 
+ */ 
 extern const luaL_Reg    lua_libs_base[];
-extern const luaR_table  lua_rotable_base[];
-static const luaL_Reg   *lua_libs    = lua_libs_base;
-const        luaR_table *lua_rotable = lua_rotable_base;
+extern const luaR_entry  lua_rotable_base[];
+const        luaL_Reg   *lua_libs    = lua_libs_base;
+const        luaR_entry *lua_rotable = lua_rotable_base;
 #endif
 
 void luaL_openlibs (lua_State *L) {
-#if defined(LUA_CROSS_COMPILER)
-lua_libs    = (isascending(lua_lib) ? &lua_lib_start_list : &lua_lib_end_list) + 1;
-lua_rotable = (isascending(lua_rotable) ? &lua_rotable_start_list : &lua_rotable_end_list) + 1;
-#endif
   const luaL_Reg *lib = lua_libs;
+
+  /* Always open Base first */
+  lua_pushcfunction(L, luaopen_base);
+  lua_pushliteral(L, "");
+  lua_call(L, 1, 0);
+
+  /* Now loop round and open other libraries */
   for (; lib->name; lib++) {
-    if (lib->func)
-    {
+    if (lib->func) {
       lua_pushcfunction(L, lib->func);
       lua_pushstring(L, lib->name);
       lua_call(L, 1, 0);

--- a/app/lua/lmathlib.c
+++ b/app/lua/lmathlib.c
@@ -15,7 +15,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lrotable.h"
 
 #undef PI
 #define PI (3.14159265358979323846)

--- a/app/lua/lobject.h
+++ b/app/lua/lobject.h
@@ -405,6 +405,7 @@ typedef struct Table {
   int sizearray;  /* size of `array' array */
 } Table;
 
+typedef const struct luaR_entry ROTable;
 
 /*
 ** `module' operation for hashing (size is always a power of 2)

--- a/app/lua/lrodefs.h
+++ b/app/lua/lrodefs.h
@@ -38,5 +38,10 @@
   return 1
 #endif
 
+#define LROT_TABENTRY(n,t)  {LSTRKEY(#n), LRO_ROVAL(t)}
+#define LROT_FUNCENTRY(n,f) {LSTRKEY(#n), LRO_FUNCVAL(f)}
+#define LROT_NUMENTRY(n,x)  {LSTRKEY(#n), LRO_NUMVAL(x)}
+#define LROT_END            {LNILKEY, LNILVAL}
+
 #endif /* lrodefs_h */
 

--- a/app/lua/lrotable.c
+++ b/app/lua/lrotable.c
@@ -9,77 +9,139 @@
 #include "lobject.h"
 #include "lapi.h"
 
-/* Local defines */
-#define LUAR_FINDFUNCTION     0
-#define LUAR_FINDVALUE        1
+#define ALIGNED_STRING (__attribute__((aligned(4))) char *)
+#define LA_LINES 16
+#define LA_SLOTS 4
+//#define COLLECT_STATS
 
-/* Externally defined read-only table array */
-extern const luaR_table *lua_rotable;
+/*
+ * All keyed ROtable access passes through luaR_findentry().  ROTables
+ * are simply a list of <key><TValue value> pairs.  The existing algo
+ * did a linear scan of this vector of pairs looking for a match.
+ *
+ * A N×M lookaside cache has been added, with a simple hash on the key's
+ * TString addr and the ROTable addr to identify one of N lines.  Each
+ * line has M slots which are scanned. This is all done in RAM and is
+ * perhaps 20x faster than the corresponding random Flash accesses which
+ * will cause flash faults.
+ *
+ * If a match is found and the table addresses match, then this entry is
+ * probed first. In practice the hit-rate here is over 99% so the code
+ * rarely fails back to doing the linear scan in ROM.
+ *
+ * Note that this hash does a couple of prime multiples and a modulus 2^X
+ * with is all evaluated in H/W, and adequately randomizes the lookup.
+ */
+#define HASH(a,b) (519*((size_t)(a)>>4) + 17*((size_t)(b)>>4))
 
-/* Find a global "read only table" in the constant lua_rotable array */
-void* luaR_findglobal(const char *name, unsigned len) {
-  unsigned i;
+static struct {
+  unsigned hash;
+  unsigned addr:24;
+  unsigned ndx:8;
+} cache[LA_LINES][LA_SLOTS];
 
-  if (c_strlen(name) > LUA_MAX_ROTABLE_NAME)
-    return NULL;
-  for (i=0; lua_rotable[i].name; i ++)
-    if (*lua_rotable[i].name != '\0' && c_strlen(lua_rotable[i].name) == len && !c_strncmp(lua_rotable[i].name, name, len)) {
-      return (void*)(lua_rotable[i].pentries);
+#ifdef COLLECT_STATS
+unsigned cache_stats[3];
+#define COUNT(i) cache_stats[i]++
+#else
+#define COUNT(i)
+#endif
+
+static int lookup_cache(unsigned hash, ROTable *rotable) {
+  int i = (hash>>2) & (LA_LINES-1), j;
+
+  for (j = 0; j<LA_SLOTS; j++) {
+    if (cache[i][j].hash == hash &&
+        ((size_t)rotable & 0xffffffu) == cache[i][j].addr) {
+      COUNT(0);
+      return cache[i][j].ndx;
     }
+  }
+  COUNT(1);
+  return -1;
+}
+
+static void update_cache(unsigned hash, ROTable *rotable, unsigned ndx) {
+  int i = (hash)>>2 & (LA_LINES-1), j;
+  COUNT(2);
+  if (ndx>0xffu)
+    return;
+  for (j = LA_SLOTS-1; j>0; j--)
+    cache[i][j] = cache[i][j-1];
+  cache[i][0].hash = hash;
+  cache[i][0].addr = (size_t) rotable;
+  cache[i][0].ndx  = ndx;
+}
+/*
+ * Find a string key entry in a rotable and return it.  Note that this internally
+ * uses a null key to denote a metatable search.
+ */
+const TValue* luaR_findentry(ROTable *rotable, TString *key, unsigned *ppos) {
+  const luaR_entry *pentry = rotable;
+  const char *strkey = key ? getstr(key) : ALIGNED_STRING "__metatable" ;
+  size_t      hash   = HASH(rotable, key);
+  unsigned    i      = 0;
+  int         j      = lookup_cache(hash, rotable);
+
+  if (pentry) {
+    if (j >= 0){
+      if ((pentry[j].key.type == LUA_TSTRING) &&
+        !c_strcmp(pentry[j].key.id.strkey, strkey)) {
+        if (ppos)
+          *ppos = i;
+        return &pentry[j].value;
+      }
+    }
+    /*
+     * The invariants for 1st word comparison are deferred to here since they
+     * aren't needed if there is a cache hit. Note that the termination null
+     * is included so a "on\0" has a mask of 0xFFFFFF and "a\0" has 0xFFFF.
+     */
+    unsigned name4 = *(unsigned *)strkey;
+    unsigned l     = key ? key->tsv.len : sizeof("__metatable"-1);
+    unsigned mask4 = l > 2 ? (~0u) : (~0u)>>((3-l)*8);
+    for(;pentry->key.type != LUA_TNIL; i++, pentry++) {
+      if ((pentry->key.type == LUA_TSTRING) &&
+          ((*(unsigned *)pentry->key.id.strkey ^ name4) & mask4) == 0 &&
+          !c_strcmp(pentry->key.id.strkey, strkey)) {
+        if (ppos)
+          *ppos = i;
+        if (j==-1) {
+          update_cache(hash, rotable, pentry - rotable);
+        } else if (j != (pentry - rotable)) {
+          j = 0;
+        }
+        return &pentry->value;
+      }
+    }
+  }
+  return luaO_nilobject;
+}
+
+const TValue* luaR_findentryN(ROTable *rotable, luaR_numkey numkey, unsigned *ppos) {
+  unsigned i = 0;
+  const luaR_entry *pentry = rotable;
+  if (pentry) {
+    for ( ;pentry->key.type != LUA_TNIL; i++, pentry++) {
+      if (pentry->key.type == LUA_TNUMBER && (luaR_numkey) pentry->key.id.numkey == numkey) {
+        if (ppos)
+          *ppos = i;
+        return &pentry->value;
+      }
+    }
+  }
   return NULL;
 }
 
-/* Find an entry in a rotable and return it */
-static const TValue* luaR_auxfind(const luaR_entry *pentry, const char *strkey, luaR_numkey numkey, unsigned *ppos) {
-  const TValue *res = NULL;
-  unsigned i = 0;
-  
-  if (pentry == NULL)
-    return NULL;  
-  while(pentry->key.type != LUA_TNIL) {
-    if ((strkey && (pentry->key.type == LUA_TSTRING) && (!c_strcmp(pentry->key.id.strkey, strkey))) || 
-        (!strkey && (pentry->key.type == LUA_TNUMBER) && ((luaR_numkey)pentry->key.id.numkey == numkey))) {
-      res = &pentry->value;
-      break;
-    }
-    i ++; pentry ++;
-  }
-  if (res && ppos)
-    *ppos = i;   
-  return res;
-}
-
-int luaR_findfunction(lua_State *L, const luaR_entry *ptable) {
-  const TValue *res = NULL;
-  const char *key = luaL_checkstring(L, 2);
-    
-  res = luaR_auxfind(ptable, key, 0, NULL);  
-  if (res && ttislightfunction(res)) {
-    luaA_pushobject(L, res);
-    return 1;
-  }
-  else
-    return 0;
-}
-
-/* Find an entry in a rotable and return its type 
-   If "strkey" is not NULL, the function will look for a string key,
-   otherwise it will look for a number key */
-const TValue* luaR_findentry(void *data, const char *strkey, luaR_numkey numkey, unsigned *ppos) {
-  return luaR_auxfind((const luaR_entry*)data, strkey, numkey, ppos);
-}
 
 /* Find the metatable of a given table */
-void* luaR_getmeta(void *data) {
-#ifdef LUA_META_ROTABLES
-  const TValue *res = luaR_auxfind((const luaR_entry*)data, "__metatable", 0, NULL);
+void* luaR_getmeta(ROTable *rotable) {
+  const TValue *res = luaR_findentry(rotable, NULL, NULL);
   return res && ttisrotable(res) ? rvalue(res) : NULL;
-#else
-  return NULL;
-#endif
 }
 
-static void luaR_next_helper(lua_State *L, const luaR_entry *pentries, int pos, TValue *key, TValue *val) {
+static void luaR_next_helper(lua_State *L, ROTable *pentries, int pos,
+                             TValue *key, TValue *val) {
   setnilvalue(key);
   setnilvalue(val);
   if (pentries[pos].key.type != LUA_TNIL) {
@@ -91,56 +153,24 @@ static void luaR_next_helper(lua_State *L, const luaR_entry *pentries, int pos, 
    setobj2s(L, val, &pentries[pos].value);
   }
 }
+
+
 /* next (used for iteration) */
-void luaR_next(lua_State *L, void *data, TValue *key, TValue *val) {
-  const luaR_entry* pentries = (const luaR_entry*)data;
-  char strkey[LUA_MAX_ROTABLE_NAME + 1], *pstrkey = NULL;
-  luaR_numkey numkey = 0;
+void luaR_next(lua_State *L, ROTable *rotable, TValue *key, TValue *val) {
   unsigned keypos;
-  
+
   /* Special case: if key is nil, return the first element of the rotable */
-  if (ttisnil(key)) 
-    luaR_next_helper(L, pentries, 0, key, val);
+  if (ttisnil(key))
+    luaR_next_helper(L, rotable, 0, key, val);
   else if (ttisstring(key) || ttisnumber(key)) {
-    /* Find the previoud key again */  
+    /* Find the previous key again */
     if (ttisstring(key)) {
-      luaR_getcstr(strkey, rawtsvalue(key), LUA_MAX_ROTABLE_NAME);          
-      pstrkey = strkey;
-    } else   
-      numkey = (luaR_numkey)nvalue(key);
-    luaR_findentry(data, pstrkey, numkey, &keypos);
+      luaR_findentry(rotable, rawtsvalue(key), &keypos);
+    } else {
+      luaR_findentryN(rotable, (luaR_numkey)nvalue(key), &keypos);
+    }
     /* Advance to next key */
-    keypos ++;    
-    luaR_next_helper(L, pentries, keypos, key, val);
+    keypos ++;
+    luaR_next_helper(L, rotable, keypos, key, val);
   }
 }
-
-/* Convert a Lua string to a C string */
-void luaR_getcstr(char *dest, const TString *src, size_t maxsize) {
-  if (src->tsv.len+1 > maxsize)
-    dest[0] = '\0';
-  else {
-    c_memcpy(dest, getstr(src), src->tsv.len);
-    dest[src->tsv.len] = '\0';
-  } 
-}
-
-#ifdef LUA_META_ROTABLES  
-/* Set in RO check depending on platform */
-#if defined(LUA_CROSS_COMPILER) && defined(__CYGWIN__)
-extern char __end__[];
-#define IN_RO_AREA(p) ((p) < __end__)
-#elif defined(LUA_CROSS_COMPILER)
-extern char  _edata[];
-#define IN_RO_AREA(p) ((p) < _edata)
-#else  /* xtensa tool chain for ESP target */
-extern char _irom0_text_start[];
-extern char _irom0_text_end[];
-#define IN_RO_AREA(p) ((p) >= _irom0_text_start && (p) <= _irom0_text_end)
-#endif
-
-/* Return 1 if the given pointer is a rotable */
-int luaR_isrotable(void *p) {
-  return IN_RO_AREA((char *)p);
-}
-#endif

--- a/app/lua/lrotable.c
+++ b/app/lua/lrotable.c
@@ -88,7 +88,7 @@ const TValue* luaR_findentry(ROTable *rotable, TString *key, unsigned *ppos) {
       if ((pentry[j].key.type == LUA_TSTRING) &&
         !c_strcmp(pentry[j].key.id.strkey, strkey)) {
         if (ppos)
-          *ppos = i;
+          *ppos = j;
         return &pentry[j].value;
       }
     }
@@ -98,7 +98,7 @@ const TValue* luaR_findentry(ROTable *rotable, TString *key, unsigned *ppos) {
      * is included so a "on\0" has a mask of 0xFFFFFF and "a\0" has 0xFFFF.
      */
     unsigned name4 = *(unsigned *)strkey;
-    unsigned l     = key ? key->tsv.len : sizeof("__metatable"-1);
+    unsigned l     = key ? key->tsv.len : sizeof("__metatable")-1;
     unsigned mask4 = l > 2 ? (~0u) : (~0u)>>((3-l)*8);
     for(;pentry->key.type != LUA_TNIL; i++, pentry++) {
       if ((pentry->key.type == LUA_TSTRING) &&

--- a/app/lua/lstring.c
+++ b/app/lua/lstring.c
@@ -80,16 +80,12 @@ static TString *newlstr (lua_State *L, const char *str, size_t l,
   return ts;
 }
 
-#ifdef LUA_CROSS_COMPILER
-#define IN_RO_AREA(p) (0)
-#else /* xtensa tool chain for ESP */
-extern char _irom0_text_start[];
-extern char _irom0_text_end[];
-#define IN_RO_AREA(p) ((p) >= _irom0_text_start && (p) <= _irom0_text_end)
+static int lua_is_ptr_in_ro_area(const char *p) {
+#ifdef LUA_CROSS_COMPILER 
+  return 0;         // TStrings are never in RO in luac.cross
+#else
+  return IN_RODATA_AREA(p);
 #endif
-
-int lua_is_ptr_in_ro_area(const char *p) {
-  return IN_RO_AREA(p);
 }
 
 /*

--- a/app/lua/lstrlib.c
+++ b/app/lua/lstrlib.c
@@ -15,7 +15,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lrotable.h"
 
 /* macro to `unsign' a character */
 #define uchar(c)        ((unsigned char)(c))

--- a/app/lua/ltable.c
+++ b/app/lua/ltable.c
@@ -580,7 +580,7 @@ const TValue *luaH_getnum (Table *t, int key) {
 
 /* same thing for rotables */
 const TValue *luaH_getnum_ro (void *t, int key) {
-  const TValue *res = luaR_findentry(t, NULL, key, NULL);
+  const TValue *res = luaR_findentryN(t, key, NULL);
   return res ? res : luaO_nilobject;
 }
 
@@ -599,14 +599,10 @@ const TValue *luaH_getstr (Table *t, TString *key) {
 }
 
 /* same thing for rotables */
-const TValue *luaH_getstr_ro (void *t, TString *key) {
-  char keyname[LUA_MAX_ROTABLE_NAME + 1];
-  const TValue *res;  
-  if (!t)
+const TValue *luaH_getstr_ro (void *t, TString *key) {  
+  if (!t || key->tsv.len>LUA_MAX_ROTABLE_NAME)
     return luaO_nilobject;
-  luaR_getcstr(keyname, key, LUA_MAX_ROTABLE_NAME);   
-  res = luaR_findentry(t, keyname, 0, NULL);
-  return res ? res : luaO_nilobject;
+  return luaR_findentry(t, key, NULL);
 }
 
 
@@ -745,7 +741,7 @@ int luaH_getn (Table *t) {
 int luaH_getn_ro (void *t) {
   int i = 1, len=0;
   
-  while(luaR_findentry(t, NULL, i ++, NULL))
+  while(luaR_findentryN(t, i ++, NULL))
     len ++;
   return len;
 }

--- a/app/lua/ltablib.c
+++ b/app/lua/ltablib.c
@@ -13,7 +13,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lrotable.h"
 
 
 #define aux_getn(L,n)	(luaL_checktype(L, n, LUA_TTABLE), luaL_getn(L, n))

--- a/app/lua/ltm.c
+++ b/app/lua/ltm.c
@@ -50,14 +50,22 @@ void luaT_init (lua_State *L) {
 ** tag methods
 */
 const TValue *luaT_gettm (Table *events, TMS event, TString *ename) {
-  const TValue *tm = luaR_isrotable(events) ? luaH_getstr_ro(events, ename) : luaH_getstr(events, ename); 
+  const TValue *tm;
   lua_assert(event <= TM_EQ);
-  if (ttisnil(tm)) {  /* no tag method? */
-    if (!luaR_isrotable(events))
+
+  if (luaR_isrotable(events)) {
+    tm =  luaH_getstr_ro(events, ename); 
+    if (ttisnil(tm)) {  /* no tag method? */
+      return NULL;
+    }
+  } else {
+    tm = luaH_getstr(events, ename); 
+    if (ttisnil(tm)) {  /* no tag method? */
       events->flags |= cast_byte(1u<<event);  /* cache this fact */
-    return NULL;
-  }
-  else return tm;
+      return NULL;
+    }
+  } 
+  return tm;
 }
 
 

--- a/app/lua/ltm.h
+++ b/app/lua/ltm.h
@@ -36,12 +36,10 @@ typedef enum {
   TM_N		/* number of elements in the enum */
 } TMS;
 
-
-
 #define gfasttm(g,et,e) ((et) == NULL ? NULL : \
-  !luaR_isrotable(et) && ((et)->flags & (1u<<(e))) ? NULL : luaT_gettm(et, e, (g)->tmname[e]))
+  (!luaR_isrotable(et) && ((et)->flags & (1u<<(e)))) ? NULL : luaT_gettm(et, e, (g)->tmname[e]))
 
-#define fasttm(l,et,e)	gfasttm(G(l), et, e)
+#define fasttm(l,et,e) gfasttm(G(l), et, e)
 
 LUAI_DATA const char *const luaT_typenames[];
 

--- a/app/lua/ltm.h
+++ b/app/lua/ltm.h
@@ -9,7 +9,7 @@
 
 
 #include "lobject.h"
-
+#include "lrotable.h"
 
 /*
 * WARNING: if you change the order of this enumeration,

--- a/app/lua/luac_cross/Makefile
+++ b/app/lua/luac_cross/Makefile
@@ -18,6 +18,7 @@ TARGET = host
 ifeq ($(FLAVOR),debug)
     CCFLAGS        += -O0 -g
     TARGET_LDFLAGS += -O0 -g
+    DEFINES        += -DLUA_DEBUG_BUILD
 else
     FLAVOR         =  release
     CCFLAGS        += -O2

--- a/app/lua/luac_cross/loslib.c
+++ b/app/lua/luac_cross/loslib.c
@@ -20,8 +20,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lrotable.h"
-
 
 static int os_pushresult (lua_State *L, int i, const char *filename) {
   int en = errno;  /* calls to Lua API may change this value */

--- a/app/lua/luaconf.h
+++ b/app/lua/luaconf.h
@@ -896,13 +896,6 @@ union luai_Cast { double l_d; long l_l; };
 ** without modifying the main part of the file.
 */
 
-/* If you define the next macro you'll get the ability to set rotables as
-   metatables for tables/userdata/types (but the VM might run slower)
-*/
-#if (LUA_OPTIMIZE_MEMORY == 2)
-#define LUA_META_ROTABLES 
-#endif
-
 #if LUA_OPTIMIZE_MEMORY == 2 && defined(LUA_USE_POPEN)
 #error "Pipes not supported in aggresive optimization mode (LUA_OPTIMIZE_MEMORY=2)"
 #endif

--- a/app/modules/wifi_monitor.c
+++ b/app/modules/wifi_monitor.c
@@ -570,9 +570,9 @@ static int packet_map_lookup(lua_State *L) {
     }
 
     // Now search the packet function map
-    const TValue *res = luaR_findentry((void *) packet_function_map, field, 0, NULL);
-    if (res) {
-      luaA_pushobject(L, res);
+    lua_pushrotable(L, (void *)packet_function_map);
+    lua_getfield(L, -1, field);
+    if (!lua_isnil(L, -1)) {
       return 1;
     }
   }

--- a/app/uzlib/host/uz_unzip.c
+++ b/app/uzlib/host/uz_unzip.c
@@ -131,20 +131,20 @@ int main(int argc, char *argv[]) {
   assert(sizeof(unsigned int) == 4);
 
   /* allocate and zero the in and out Blocks */
-  assert(in  = uz_malloc(sizeof(*in)));
-  assert(out = uz_malloc(sizeof(*out)));
+  assert((in  = uz_malloc(sizeof(*in))) != NULL);
+  assert((out = uz_malloc(sizeof(*out))) != NULL);
 
   memset(in, 0, sizeof(*in));
   memset(out, 0, sizeof(*out));
 
   /* open input files and probe end to read the expanded length */
-  assert((in->fin = fopen(inFile, "rb")));
+  assert((in->fin = fopen(inFile, "rb")) != NULL);
   fseek(in->fin, -4, SEEK_END);
   assert(fread((uchar*)&(out->len), 1, 4, in->fin) == 4);
   in->len = ftell(in->fin);
   fseek(in->fin, 0, SEEK_SET);
   
-  assert((out->fout = fopen(outFile, "wb")));
+  assert((out->fout = fopen(outFile, "wb")) != NULL);
 
   printf ("Inflating in=%s out=%s\n", inFile, outFile);
 
@@ -152,7 +152,7 @@ int main(int argc, char *argv[]) {
   n = (out->len > DICTIONARY_WINDOW) ? WRITE_BLOCKS : 
                                       1 + (out->len-1) / WRITE_BLOCKSIZE;
   for(i = WRITE_BLOCKS - n + 1;  i <= WRITE_BLOCKS; i++)
-    assert(out->block[i % WRITE_BLOCKS] = uz_malloc(sizeof(outBlock)));
+    assert((out->block[i % WRITE_BLOCKS] = uz_malloc(sizeof(outBlock))) != NULL);
   
   out->breakNdx  = (out->len < WRITE_BLOCKSIZE) ? out->len : WRITE_BLOCKSIZE;
   out->fullBlkCB = processOutRec;


### PR DESCRIPTION
Addresses Issue #2504

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

See #2504 for detailed discussion of the background and scope of this patch.  There isn't any change at an application level, apart from making ROTable access times comparable to RAM Table access times.  The code changes therefore don't impact the documentation at `docs/en/*` excepting the following points:

-  We might want to mention the speedup in the FAQ, but this is due a major update anyway.
-  We might want to document how you can list off the installed ROM libraries by enumerating `pairs(_G.__index)`.


