### PR TITLE
Establish delay as event to trigger flushing of SPI buffer

### DIFF
--- a/app/platform/u8x8_nodemcu_hal.c
+++ b/app/platform/u8x8_nodemcu_hal.c
@@ -13,6 +13,42 @@
 #define U8X8_USE_PINS
 #include "u8x8_nodemcu_hal.h"
 
+// static variables containing info about the i2c link
+// TODO: move to user space in u8x8_t once available
+typedef struct {
+  uint8_t id;
+} hal_i2c_t;
+
+// static variables containing info about the spi link
+// TODO: move to user space in u8x8_t once available
+typedef struct {
+  uint8_t host;
+  //spi_device_handle_t device;
+  uint8_t last_dc;
+  struct {
+    uint8_t *data;
+    size_t size, used;
+  } buffer;
+} hal_spi_t;
+
+
+static void flush_buffer_spi( hal_spi_t *hal )
+{
+  if (hal->buffer.data && hal->buffer.used > 0) {
+    platform_spi_blkwrite( hal->host, hal->buffer.used, hal->buffer.data );
+
+    hal->buffer.used = 0;
+  }
+}
+
+static void force_flush_buffer(u8x8_t *u8x8)
+{
+  // spi hal has a buffer that can be flushed
+  if (u8x8->byte_cb == u8x8_byte_nodemcu_spi) {
+    hal_spi_t *hal = ((u8g2_nodemcu_t *)u8x8)->hal;
+    flush_buffer_spi( hal );
+  }
+}
 
 uint8_t u8x8_gpio_and_delay_nodemcu(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
@@ -35,25 +71,30 @@ uint8_t u8x8_gpio_and_delay_nodemcu(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, 
     break;
 
   case U8X8_MSG_DELAY_NANO:           // delay arg_int * 1 nano second
+    force_flush_buffer(u8x8);
     os_delay_us( 1 );
     break;    
 
   case U8X8_MSG_DELAY_100NANO:        // delay arg_int * 100 nano seconds
+    force_flush_buffer(u8x8);
     temp = arg_int * 100;
     temp /= 1000;
     os_delay_us( temp > 0 ? temp : 1 );
     break;
 
   case U8X8_MSG_DELAY_10MICRO:        // delay arg_int * 10 micro seconds
+    force_flush_buffer(u8x8);
     os_delay_us( arg_int * 10 );
     break;
 
   case U8X8_MSG_DELAY_MILLI:          // delay arg_int * 1 milli second
+    force_flush_buffer(u8x8);
     os_delay_us( arg_int * 1000 );
     system_soft_wdt_feed();
     break;
 
   case U8X8_MSG_DELAY_I2C:                // arg_int is the I2C speed in 100KHz, e.g. 4 = 400 KHz
+    force_flush_buffer(u8x8);
     temp = 5000 / arg_int;                // arg_int=1: delay by 5us, arg_int = 4: delay by 1.25us
     temp /= 1000;
     os_delay_us( temp > 0 ? temp : 1 );
@@ -119,12 +160,6 @@ uint8_t u8x8_gpio_and_delay_nodemcu(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, 
   return 1;
 }
 
-
-// static variables containing info about the i2c link
-// TODO: move to user space in u8x8_t once available
-typedef struct {
-  uint8_t id;
-} hal_i2c_t;
 
 uint8_t u8x8_byte_nodemcu_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
@@ -192,27 +227,6 @@ uint8_t u8x8_byte_nodemcu_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
 }
 
 
-// static variables containing info about the spi link
-// TODO: move to user space in u8x8_t once available
-typedef struct {
-  uint8_t host;
-  //spi_device_handle_t device;
-  uint8_t last_dc;
-  struct {
-    uint8_t *data;
-    size_t size, used;
-  } buffer;
-} hal_spi_t;
-
-static void flush_buffer_spi( hal_spi_t *hal )
-{
-  if (hal->buffer.used > 0) {
-    platform_spi_blkwrite( hal->host, hal->buffer.used, hal->buffer.data );
-
-    hal->buffer.used = 0;
-  }
-}
-
 uint8_t u8x8_byte_nodemcu_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
   hal_spi_t *hal = ((u8g2_nodemcu_t *)u8x8)->hal;
@@ -229,6 +243,7 @@ uint8_t u8x8_byte_nodemcu_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
         return 0;
       hal->host = host;
       ((u8g2_nodemcu_t *)u8x8)->hal = hal;
+      hal->buffer.data = NULL;
 
       hal->last_dc = 0;
     }
@@ -280,6 +295,7 @@ uint8_t u8x8_byte_nodemcu_spi(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
     u8x8_gpio_SetCS( u8x8, u8x8->display_info->chip_disable_level );
 
     c_free( hal->buffer.data );
+    hal->buffer.data = NULL;
     break;
 
   default:


### PR DESCRIPTION
Addresses #2510.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

As discussed in #2510, the current implementation of the SPI buffer lacks flushing when a delay phase begins. This leads to out-of-order execution of cad sequences in a way that command or data bytes are sent *after* a delay instead of *before* the delay.
As a consequence, displays might exhibit erratic behavior.

This PR adds SPI buffer flushing at the beginning of delays.
