### PR TITLE
Update user_config.h

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -110,7 +110,7 @@
 // firmware to manage timer rescheduling over sleeps (the CPU clock is
 // suspended so timers get out of sync) then enable the following options
 
-//#define ENABLE_TIMER_SUSPEND
+//#define TIMER_SUSPEND_ENABLE
 //#define PMSLEEP_ENABLE
 
 


### PR DESCRIPTION
This line is a commented out code line, ready to be uncommented if required in a firmware build for node.sleep().  
However, TIMER_SUSPEND_ENABLE is used in module node.c not ENABLE_TIMER_SUSPEND

Fixes #\<GitHub-issue-number\>.
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

\<Description of and rationale behind this PR\>
