### PR TITLE
Re-rename ENABLE_TIMER_SUSPEND to TIMER_SUSPEND_ENABLE in user_config.h

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -110,7 +110,7 @@
 // firmware to manage timer rescheduling over sleeps (the CPU clock is
 // suspended so timers get out of sync) then enable the following options
 
-//#define ENABLE_TIMER_SUSPEND
+//#define TIMER_SUSPEND_ENABLE
 //#define PMSLEEP_ENABLE
 
 

--- a/app/modules/tmr.c
+++ b/app/modules/tmr.c
@@ -378,22 +378,6 @@ static int tmr_create( lua_State *L ) {
 }
 
 
-#if defined(ENABLE_TIMER_SUSPEND) && defined(SWTMR_DEBUG)
-static void tmr_printRegistry(lua_State* L){
-  swtmr_print_registry();
-}
-
-static void tmr_printSuspended(lua_State* L){
-  swtmr_print_suspended();
-}
-
-static void tmr_printTimerlist(lua_State* L){
-  swtmr_print_timer_list();
-}
-
-
-#endif
-
 // Module function map
 
 static const LUA_REG_TYPE tmr_dyn_map[] = {


### PR DESCRIPTION
Follow-up to #2518.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.

As reported by @ChrisTBarnes in #2518, the switch for enabling the timer suspend feature is wrongly mentioned as `ENABLE_TIMER_SUSPEND` in `app/include/user_config.h`. The code base expects `TIMER_SUSPEND_ENABLE` instead.

Please note that I don't have a setup to actually verify correct functionality of the timer suspend. Maybe someone can jump in for testing.
