### PR TITLE
u8g2: include "large" fonts

### DIFF
--- a/app/u8g2lib/Makefile
+++ b/app/u8g2lib/Makefile
@@ -24,7 +24,7 @@ STD_CFLAGS=-std=gnu11 -Wimplicit
 #   makefile at its root level - these are then overridden
 #   for a subtree within the makefile rooted therein
 #
-DEFINES += -DU8X8_USE_PINS
+DEFINES += -DU8X8_USE_PINS -DU8G2_USE_LARGE_FONTS
 
 #############################################################
 # Recursion Magic - Don't touch this!!


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

As reported by @marcelstoer (thanks!). Large fonts (e.g. font_unifont_t_chinese3) aren't usable even though they're contained in the font source file. This happens because the respective macro `U8G2_USE_LARGE_FONTS` is not defined.
PR defines the macro and respective fonts are compiled now.
