### PR TITLE
Increase MQTT recv buffer size to support MTU 1500  (#2308)

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -17,7 +17,7 @@
 
 #include "user_interface.h"
 
-#define MQTT_BUF_SIZE 1024
+#define MQTT_BUF_SIZE 1460
 #define MQTT_DEFAULT_KEEPALIVE 60
 #define MQTT_MAX_CLIENT_LEN   64
 #define MQTT_MAX_USER_LEN     64


### PR DESCRIPTION
Any TCP packet with more than 1024 bytes of payload was silently
dropped. With MTU of 1500 the TCP payload can be up to 1460 bytes
(1500 - 20(IP hdr) - 20(TCP hdr))

Fixes #2308

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution... **But I'm quite a new NodeMCU & MQTT user so I might be unaware of some weird circumstances**
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

(Not sure what documentation would be appropriate to update, as this is more of a "fix what was expected to work" than anything else)




I've done some experiments and tcpdumps, based on what I wrote here: https://github.com/nodemcu/nodemcu-firmware/issues/2308#issuecomment-435518706

I had some issues with small but rapidly sent messages getting dropped by my ESP12-F on NodeMCU 2.2.1.
The messages where just 52 bytes long (33 byte topic), but sent with 15 consecutive calls to mosquitto_pub (so at most some shell & connect overhead between msgs). Problem was that I was just getting the first one or two messages.

Doing some tcpdump revealed that  rapidly sending small messages to a standard mosquitto broker, to a topic which a NodeMCU is subscribed to, the broker will send the first msg in a separate TCP packet, then (I suppose) it is waiting for the TCP ACK before it goes on to send the next packet/message. By that time, the broker has received all the messages, and the rest of them are sent in one TCP packet with payload length of 1126b. This will not fit in MQTT_BUF_SIZE of 1024, and the full payload is dropped.

Another test, when sending a single message of 990bytes to a 29 bytes topic (=1020) bytes, the TCP payload length equals 1024, and this is properly delivered to the LUA callback. Adding 1 bytes to the message and it is dropped silently.

Sending a message of let's say 2000b, on my network it makes one IP packet of 1500 bytes (max MTU), with a payload size of 1460.
The IP header is at least 20 bytes, and TCP header is at least 20 bytes (=40b), giving us 1460 bytes for payload data in a MTU 1500 network.

Given my understanding of the code, the `MQTT_BUF_SIZE` must be at least 1460 to support a normal local network with a MTU of 1500.

Setting this to 1460 and running the above same tests yields expected results (messages arriving to LUA-land).
---

A sane default for this should thus be 1460, rather than 1024 which is quite non-standard and creates broken behaviour in (what I would expect to be) normal situation