### PR TITLE
Changed ESP32 http user agent to "NodeMCU (ESP32)"

### DIFF
--- a/components/modules/http.c
+++ b/components/modules/http.c
@@ -76,6 +76,7 @@ typedef struct
 } lhttp_event;
 
 static const char http_context_mt[] = "http.context";
+static const char http_default_user_agent[] = "NodeMCU (ESP32)";
 #define DELAY_ACK (-99) // Chosen not to conflict with any other esp_err_t
 #define HTTP_REQUEST_COMPLETE (-1)
 
@@ -507,6 +508,9 @@ static int http_lapi_createConnection(lua_State *L)
   if (!context->client) {
     return luaL_error(L, "esp_http_client_init failed");
   }
+
+  // override the default user agent with our own default
+  esp_http_client_set_header(context->client, "User-Agent", http_default_user_agent);
 
   if (lua_istable(L, -1)) {
     lua_getfield(L, -1, "headers");

--- a/docs/en/modules/http.md
+++ b/docs/en/modules/http.md
@@ -5,7 +5,7 @@
 
 HTTP *client* module that provides an interface to do GET/POST/PUT/DELETE over HTTP and HTTPS, as well as customized requests. It can support large requests with an API similar to that of the `net` module. Multiple concurrent HTTP requests are supported. Both synchronous and asynchronous modes are supported.
 
-For each operation it is possible to provide custom HTTP headers or override standard headers. By default the `Host` header is deduced from the URL and `User-Agent` is `ESP32 HTTP Client/1.0`. Requests are always sent as `HTTP/1.1`. Keep-alive is supported (unless using the one-shot APIs) by default, disable by adding a `Connection: close` header or by explicitly closing the connection once complete.
+For each operation it is possible to provide custom HTTP headers or override standard headers. By default the `Host` header is deduced from the URL and `User-Agent` is `NodeMCU (ESP32)`. Requests are always sent as `HTTP/1.1`. Keep-alive is supported (unless using the one-shot APIs) by default, disable by adding a `Connection: close` header or by explicitly closing the connection once complete.
 
 HTTP redirects (HTTP status 300-308) are followed automatically up to a limit of 10 to avoid redirect loops. This behavior may be customized by setting the `max_redirects` option.
 

--- a/lua_examples/httptest.lua
+++ b/lua_examples/httptest.lua
@@ -81,7 +81,7 @@ function test_keepalive()
     assertEquals(connected, false)
     assertEquals(seenConnect, false) -- You don't get another connect callback
     assert(seenHeaders) -- But you do get new headers
-    assertEquals(seenData, '{\n  "user-agent": "ESP32 HTTP Client/1.0"\n}\n')
+    assertEquals(seenData, '{\n  "user-agent": "NodeMCU (ESP32)"\n}\n')
     assertEquals(seenFinish, 200)
     c:close()
 end


### PR DESCRIPTION
- [ ] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
    - Checked httptest.lua failed until test was updated, confirmed now passes
- [x] The code changes are reflected in the documentation at `docs/en/*`.

As discussed with @marcelstoer and @devsaurus on #2540, changed the default user agent to something NodeMCU-specific. Updated httptest.lua  and the docs as a result.