### PR TITLE
Default to "Release" code optimization level with -Os

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -30,3 +30,6 @@ CONFIG_MQTT_USE_CUSTOM_CONFIG=n
 # Disable esp-idf's bluetooth component by default.
 # The bthci module is also disabled and will enable bt when selected
 CONFIG_BT_ENABLED=n
+
+# Set "Release" code optimization level for -Os
+CONFIG_OPTIMIZATION_LEVEL_RELEASE=y


### PR DESCRIPTION
- [ ] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

I've been using the Release optimization level for quite some time now with my local builds.
@jmattsson is there a need to still default to Debug?