### PR TITLE
DHT11 read sometimes failed with checksum error

### DIFF
--- a/app/dht/dht.c
+++ b/app/dht/dht.c
@@ -151,12 +151,12 @@ int dht_read11(uint8_t pin)
     }
 
     // CONVERT AND STORE
-    dht_humidity    = dht_bytes[0];  // dht_bytes[1] == 0;
-    dht_temperature = dht_bytes[2];  // dht_bytes[3] == 0;
+    dht_humidity = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[0], dht_bytes[1]) / 256.0;
+    dht_temperature = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[2], dht_bytes[3]) / 256.0;
 
     // TEST CHECKSUM
     // dht_bytes[1] && dht_bytes[3] both 0
-    uint8_t sum = dht_bytes[0] + dht_bytes[2];
+    uint8_t sum = dht_bytes[0] + dht_bytes[1] + dht_bytes[2] + dht_bytes[3];
     if (dht_bytes[4] != sum) return DHTLIB_ERROR_CHECKSUM;
 
     return DHTLIB_OK;

--- a/app/dht/dht.c
+++ b/app/dht/dht.c
@@ -151,8 +151,8 @@ int dht_read11(uint8_t pin)
     }
 
     // CONVERT AND STORE
-    dht_humidity = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[0], dht_bytes[1]) / 256.0;
-    dht_temperature = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[2], dht_bytes[3]) / 256.0;
+    dht_humidity    = dht_bytes[0];  // dht_bytes[1] == 0;
+    dht_temperature = dht_bytes[2];  // dht_bytes[3] == 0;
 
     // TEST CHECKSUM
     // dht_bytes[1] && dht_bytes[3] both 0


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

Documentation change is not needed.

The code assumed DHT11 devices only ever return zero in the temperature and humidity decimal fraction bytes. The datasheet doesn't guarantee this is the case, and by observation I have noticed that indeed the DHT11 may sometimes return another number, usually close to zero. This means that the code would fail with a checksum error, as the fraction bytes were not included when the checksum was calculated. These bytes are now taken into account and also returned as part of the measurement.

This also means that the related dht.read() function is non-functional. If you have a DHT11 device that returns a non-zero decimal part, dht.read() will interpret it as a DHT22 result and return the wrong measurement. For this reason dht.read() should be retired. This patch does not address this issue.