### PR TITLE
Calling vol:umount() would fail

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -587,7 +587,7 @@ static int file_mount( lua_State *L )
 
   if (vol->vol = vfs_mount( ldrv, num )) {
     /* set its metatable */
-    luaL_getmetatable(L, "vfs.vol");
+    luaL_getmetatable(L, "file.vol");
     lua_setmetatable(L, -2);
     return 1;
   } else {


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

No documentation change needed

The volume returned by file.mount() could not be unmounted, because vol:umount() would fail with a cryptic error about the uncallable nature of the volume userdata object. This was due to the wrong metatable name being used for setting up the volume structure. The correct name, as registered elsewhere in file.c, is now used, and vol:umount() is callable.
