### PR TITLE
Use custom parition table with 1.5MB for firmware

### DIFF
--- a/components/platform/partitions.csv
+++ b/components/platform/partitions.csv
@@ -3,5 +3,3 @@
 nvs,      data, nvs,     0x9000,  0x6000
 phy_init, data, phy,     0xf000,  0x1000
 factory,  app,  factory, 0x10000, 0x180000
-# 0xC2 => NodeMCU, 0x0 => Spiffs
-nodemcuspiffs,  0xC2, 0x0,      , 0x70000

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -92,9 +92,9 @@ Serial flasher config --->
 ```
 
 ### Partition Table
-It is not required to set a custom partition table. Per default the IDF will select `Single factory app, no OTA` and the firmware will create a partition for SPIFFS automatically which fills the remaining flash space.
+IDF's default partition table `Single factory app, no OTA` does not provide enough room for a firmware including large modules like e.g. `http` or `sodium`. To enable full feature sets, NodeMCU uses a custom partition table from `components/platform/partitions.csv`.
 
-There is a template partition table available in `components/platform/partitions-2MB.csv` locates the SPIFFS partition at a fixed location. The file can be used as a template for custom partition tables with menuconfig:
+For 2MB flash modules an alternative partition table available as `components/platform/partitions-2MB.csv`. It restricts the SPIFFS partition to  ~448&nbsp;kB and can be used with menuconfig:
 
 ```
 Partition Table --->

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -92,7 +92,7 @@ Serial flasher config --->
 ```
 
 ### Partition Table
-IDF's default partition table `Single factory app, no OTA` does not provide enough room for a firmware including large modules like e.g. `http` or `sodium`. To enable full feature sets, NodeMCU uses a custom partition table from `components/platform/partitions.csv`.
+IDF's default partition table `Single factory app, no OTA` does not provide enough room for a firmware including large modules like e.g. `http` or `sodium`. To enable full feature sets, NodeMCU uses a custom partition table from `components/platform/partitions.csv` which allocates ~1.5&nbsp;MB for the firmware image. During first boot, the firmware creates an additional partition for SPIFFS in the remaining flash space.
 
 For 2MB flash modules an alternative partition table available as `components/platform/partitions-2MB.csv`. It restricts the SPIFFS partition to  ~448&nbsp;kB and can be used with menuconfig:
 

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,3 +1,7 @@
+# set custom partition table for 1.5MB firmware
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="components/platform/partitions.csv"
+CONFIG_PARTITION_TABLE_FILENAME="components/platform/partitions.csv"
+
 # Don't warn about undefined variables
 CONFIG_MAKE_WARN_UNDEFINED_VARIABLES=n
 


### PR DESCRIPTION
Fixes marcelstoer/docker-nodemcu-build#55.

- [x] This PR is for the `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Preparations for docker highlighted (once again) that the esp32 set of modules grew well beyond the 1&nbsp;MB of esp-idf's default partition configuration. This PR adds a custom partition table that extends the space for the firmware image to ~1.5&nbsp;MB and establishes it as the new default table when building a firmware.
This should help new users to avoid the basic pitfall of "firmware image too big". Especially for the use cases with docker and web-based custom builds.
