### PR TITLE
Fix build error with luac.cross when DEVELOPMENT_USE_GDB is used

### DIFF
--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -958,12 +958,12 @@ LUALIB_API void luaL_assertfail(const char *file, int line, const char *message)
 #endif
 }
 
-#ifdef DEVELOPMENT_USE_GDB
+#if defined(DEVELOPMENT_USE_GDB) && !defined(LUA_CROSS_COMPILER)
 /*
  *  This is a simple stub used by lua_assert() if DEVELOPMENT_USE_GDB is defined.
  *  Instead of crashing out with an assert error, this hook starts the GDB remote
  *  stub if not already running and then issues a break.  The rationale here is 
- *  that when testing the developer migght be using screen/PuTTY to work ineractively
+ *  that when testing the developer might be using screen/PuTTY to work interactively
  *  with the Lua Interpreter via UART0.  However if an assert triggers, then there 
  * is the option to exit the interactive session and start the Xtensa remote GDB 
  * which will then sync up with the remote GDB client to allow forensics of the error. 


### PR DESCRIPTION
- [ ] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md)
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

When DEVELOPMENT_USE_GDB is used, make would fail with error when building luac.cross:
`../lauxlib.c:980: Error: no such instruction: 'break 0,0'`
This change fixes it.
