### PR TITLE
MQTT: handle large/chunked/fragmented messages properly

### DIFF
--- a/app/mqtt/mqtt_msg.h
+++ b/app/mqtt/mqtt_msg.h
@@ -108,21 +108,22 @@ typedef struct mqtt_connect_info
   int will_qos;
   int will_retain;
   int clean_session;
+  uint16_t max_message_length;
 
 } mqtt_connect_info_t;
 
 
-static inline int mqtt_get_type(uint8_t* buffer) { return (buffer[0] & 0xf0) >> 4; }
-static inline int mqtt_get_dup(uint8_t* buffer) { return (buffer[0] & 0x08) >> 3; }
-static inline int mqtt_get_qos(uint8_t* buffer) { return (buffer[0] & 0x06) >> 1; }
-static inline int mqtt_get_retain(uint8_t* buffer) { return (buffer[0] & 0x01); }
-static inline int mqtt_get_connect_ret_code(uint8_t* buffer) { return (buffer[3]); }
+static inline uint8_t mqtt_get_type(uint8_t* buffer) { return (buffer[0] & 0xf0) >> 4; }
+static inline uint8_t mqtt_get_dup(uint8_t* buffer) { return (buffer[0] & 0x08) >> 3; }
+static inline uint8_t mqtt_get_qos(uint8_t* buffer) { return (buffer[0] & 0x06) >> 1; }
+static inline uint8_t mqtt_get_retain(uint8_t* buffer) { return (buffer[0] & 0x01); }
+static inline uint8_t mqtt_get_connect_ret_code(uint8_t* buffer) { return (buffer[3]); }
 
 void mqtt_msg_init(mqtt_connection_t* connection, uint8_t* buffer, uint16_t buffer_length);
-int mqtt_get_total_length(uint8_t* buffer, uint16_t length);
-const char* mqtt_get_publish_topic(uint8_t* buffer, uint16_t* length);
-const char* mqtt_get_publish_data(uint8_t* buffer, uint16_t* length);
-uint16_t mqtt_get_id(uint8_t* buffer, uint16_t length);
+int32_t mqtt_get_total_length(uint8_t* buffer, uint16_t buffer_length);
+const char* mqtt_get_publish_topic(uint8_t* buffer, uint16_t* buffer_length);
+const char* mqtt_get_publish_data(uint8_t* buffer, uint16_t* buffer_length);
+uint16_t mqtt_get_id(uint8_t* buffer, uint16_t buffer_length);
 
 mqtt_message_t* mqtt_msg_connect(mqtt_connection_t* connection, mqtt_connect_info_t* info);
 mqtt_message_t* mqtt_msg_publish(mqtt_connection_t* connection, const char* topic, const char* data, int data_length, int qos, int retain, uint16_t* message_id);

--- a/docs/en/modules/mqtt.md
+++ b/docs/en/modules/mqtt.md
@@ -34,14 +34,17 @@ The default 1024 was chosen as this was the implicit limit in NodeMCU 2.2.1 and 
 Any message *larger* than `max_message_length` will be (partially) delivered to the `overflow` callback, if defined. The rest
 of the message will be discarded. Any following messages should be handled properly.
 
-If raising this, heap memory will be used o buffer the received message data between each incoming TCP packet.
-A single allocation for the full message will be performed when the first TCP packet is received, to avoid fragmentation.
+Heap memory will be used to buffer any message which spans more than a single TCP packet. A single allocation for the full
+message will be performed when the message header is first seen, to avoid heap fragmentation.
 If allocation fails, the MQTT session will be disconnected.
 
-Note that allocation may occur even if the message is not larger than the configured max! For example, the broker may send
-multiple smaller messages in quick succession, which could go into the same TCP packet. If the last message does not fit into
-the TCP packet (or an intermediate router fragments it), a heap buffer will be allocated to hold the incomplete message
-while waiting for the next TCP packet.
+Note that heap allocation may occur even if the message is not larger than the configured max! For example, the broker may send
+multiple smaller messages in quick succession, which could go into the same TCP packet. If the last message in the TCP packet
+did not fit fully, a heap buffer will be allocated to hold the incomplete message while waiting for the next TCP packet.
+
+The typical maximum size for a message to fit into a single TCP packet is 1460 bytes, but this depends on the network's MTU
+configuration, any packet fragmentation, and as described above, multiple messages in the same TCP packet.
+
 
 
 #### Example

--- a/docs/en/modules/mqtt.md
+++ b/docs/en/modules/mqtt.md
@@ -32,7 +32,7 @@ In practice, this only affects incoming PUBLISH messages since all regular contr
 The default 1024 was chosen as this was the implicit limit in NodeMCU 2.2.1 and older (where this was not handled at all).
 
 Note that "message length" refers to the full MQTT message size, including fixed & variable headers, topic name, packet ID (if applicable),
-and payload. For exact details, please see the MQTT specification.
+and payload. For exact details, please see [the MQTT specification](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718037).
 
 Any message *larger* than `max_message_length` will be (partially) delivered to the `overflow` callback, if defined. The rest
 of the message will be discarded. Any subsequent messages should be handled as expected.


### PR DESCRIPTION
If a message spans multiple TCP packets it must be buffered before delivered to LUA. Prior code did not do this at all, so this "patch" really adds proper handling of fragmented MQTT packets.
This could also occur if multiple small messages was sent in a single TCP packet, and the last message did not completely fit in that packet.

For in-depth description of the problem, please see discussion in #2544 (avoiding repeating it here)

Introduces a new option to the mqtt.Client constructor: max_publish_length which defaults to 1024    
Also introduces a new 'overflow' callback.

Fixes issue #2308, and is a proper fix for PR #2544 (ping @nwf and @marcelstoer who was involved in that PR).

I opted to straighten up the use of uint16_t instead of int and some similar changes. I deliberately selected uint16_t as max buffer length, with the assumption that no platform where NodeMCU runs on will be able to handle anything above 64k. Let me know if that is an bad assumption :)

All in all, this is quite a big commit, and as a first-time commiter on NodeMCU, you may very well find some valid concerns and input on how to improve it. Feel free to give pointers :)

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.
