### PR TITLE
Add set clock div

### DIFF
--- a/app/modules/spi.c
+++ b/app/modules/spi.c
@@ -301,6 +301,22 @@ static int spi_transaction( lua_State *L )
   return 0;
 }
 
+// Lua: old_div = spi.set_clock_div( id, new_div )
+static int spi_set_clock_div( lua_State *L )
+{
+  int id = luaL_checkinteger( L, 1 );
+
+  MOD_CHECK_ID( spi, id );
+
+  u32 clk_div = luaL_checkinteger( L, 2 );
+
+  u32 old_div = spi_set_clkdiv(id, clk_div);
+
+  lua_pushinteger( L, old_div );
+
+  return 1;
+}
+
 
 // Module function map
 static const LUA_REG_TYPE spi_map[] = {
@@ -310,6 +326,7 @@ static const LUA_REG_TYPE spi_map[] = {
   { LSTRKEY( "set_mosi" ),    LFUNCVAL( spi_set_mosi ) },
   { LSTRKEY( "get_miso" ),    LFUNCVAL( spi_get_miso ) },
   { LSTRKEY( "transaction" ), LFUNCVAL( spi_transaction ) },
+  { LSTRKEY( "set_clock_div" ), LFUNCVAL( spi_set_clock_div ) },
   { LSTRKEY( "MASTER" ),      LNUMVAL( PLATFORM_SPI_MASTER ) },
   { LSTRKEY( "SLAVE" ),       LNUMVAL( PLATFORM_SPI_SLAVE) },
   { LSTRKEY( "CPHA_LOW" ),    LNUMVAL( PLATFORM_SPI_CPHA_LOW) },

--- a/docs/en/modules/spi.md
+++ b/docs/en/modules/spi.md
@@ -129,6 +129,26 @@ spi.setup(1, spi.MASTER, spi.CPOL_LOW, spi.CPHA_LOW, 8, 8)
 gpio.mode(8, gpio.INPUT, gpio.PULLUP)
 ```
 
+## spi.set_clock_div()
+Set the SPI clock divider.
+
+#### Syntax
+`old_div = spi.set_clock_div(id, clock_div)`
+
+#### Parameters
+- `id` SPI ID number: 0 for SPI, 1 for HSPI
+- `clock_div` SPI clock divider, f(SPI) = 80 MHz / `clock_div`, 1 .. n
+
+#### Returns
+Number: Old clock divider
+
+#### Example
+```lua
+old_div = spi.set_clock_div(1, 84) --drop to slow clock for slow device
+spi.send(1, 0x0B, 0xFF)
+spi.set_clock_div(1, old_div)
+```
+
 ## Low Level Hardware Functions
 The low level functions provide a hardware-centric API for application
 scenarios that need to excercise more complex SPI transactions. The


### PR DESCRIPTION
This will allow the SPI clock divider to be changed relatively simply,
to better support multiple devices with varying SPI clock rate support

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This is just a simple change to expose the `spi_set_clkdiv` function to lua.  I'm working on support for a SPI display screen/touch screen combo(https://learn.adafruit.com/adafruit-2-4-tft-touch-screen-featherwing), but the screen can handle clock divider as low as 4 (that's as far as I've pushed it, at least).  Unfortunately, the touch screen controller doesn't seem to like anything lower then 84 or so.  Setting the clock divider up at 84 causes the ucg library to hit the watchdog timer during a clearScreen, and reboot the esp8266, which is obviously a bit of a problem.

With this change, I can keep the clock divider at 4 for normal operations, and let the screen update blazing fast, and set it up to 84 when I'm talking to the touchscreen.

Note: I've tested this under the master branch, but the dev branch doesn't compile for me...

Alternative implementation idea:  Something inspired by https://www.arduino.cc/en/Reference/SPISettings?  The only thing we'd be lacking is the data mode stuff, as it seems to be currently out of scope to change the data order.  I'm not sure how often the data mode would need to be adjusted.
