### PR TITLE
reduce default make verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,22 @@ else
   CCFLAGS += -O2
 endif
 
+#Handling of V=1/VERBOSE=1 flag
+#
+# if V=1, $(summary) does nothing
+# if V is unset or not 1, $(summary) echoes a summary
+VERBOSE ?=
+V ?= $(VERBOSE)
+ifeq ("$(V)","1")
+export summary := @true
+else
+export summary := @echo
+
+# disable echoing of commands, directory names
+MAKEFLAGS += --silent -w
+endif  # $(V)==1
+
+
 #############################################################
 # Select compile
 #
@@ -186,6 +202,7 @@ $$(LIBODIR)/$(1).a: $$(OBJS) $$(DEP_OBJS_$(1)) $$(DEP_LIBS_$(1)) $$(DEPENDS_$(1)
 	@mkdir -p $$(LIBODIR)
 	$$(if $$(filter %.a,$$?),mkdir -p $$(EXTRACT_DIR)_$(1))
 	$$(if $$(filter %.a,$$?),cd $$(EXTRACT_DIR)_$(1); $$(foreach lib,$$(filter %.a,$$?),$$(AR) xo $$(UP_EXTRACT_DIR)/$$(lib);))
+	$(summary) AR $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$<
 	$$(AR) ru $$@ $$(filter %.o,$$?) $$(if $$(filter %.a,$$?),$$(EXTRACT_DIR)_$(1)/*.o)
 	$$(if $$(filter %.a,$$?),$$(RM) -r $$(EXTRACT_DIR)_$(1))
 endef
@@ -195,12 +212,15 @@ DEP_LIBS_$(1) = $$(foreach lib,$$(filter %.a,$$(COMPONENTS_$(1))),$$(dir $$(lib)
 DEP_OBJS_$(1) = $$(foreach obj,$$(filter %.o,$$(COMPONENTS_$(1))),$$(dir $$(obj))$$(OBJODIR)/$$(notdir $$(obj)))
 $$(IMAGEODIR)/$(1).out: $$(OBJS) $$(DEP_OBJS_$(1)) $$(DEP_LIBS_$(1)) $$(DEPENDS_$(1))
 	@mkdir -p $$(IMAGEODIR)
+	$(summary) LD $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$$@
 	$$(CC) $$(LDFLAGS) $$(if $$(LINKFLAGS_$(1)),$$(LINKFLAGS_$(1)),$$(LINKFLAGS_DEFAULT) $$(OBJS) $$(DEP_OBJS_$(1)) $$(DEP_LIBS_$(1))) -o $$@
 endef
 
 $(BINODIR)/%.bin: $(IMAGEODIR)/%.out
 	@mkdir -p $(BINODIR)
+	$(summary) NM $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$@
 	@$(NM) $< | grep -w U && { echo "Firmware has undefined (but unused) symbols!"; exit 1; } || true
+	$(summary) ESPTOOL $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$< $(FIRMWAREDIR)
 	$(ESPTOOL) elf2image --flash_mode dio --flash_freq 40m $< -o $(FIRMWAREDIR)
 
 #############################################################
@@ -226,38 +246,45 @@ toolchain: $(TOP_DIR)/tools/toolchains/esp8266-$(PLATFORM)-$(TOOLCHAIN_VERSION)/
 
 $(TOP_DIR)/tools/toolchains/esp8266-$(PLATFORM)-$(TOOLCHAIN_VERSION)/bin/xtensa-lx106-elf-gcc: $(TOP_DIR)/cache/toolchain-esp8266-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz
 	mkdir -p $(TOP_DIR)/tools/toolchains/
+	$(summary) EXTRACT $(patsubst $(TOP_DIR)/%,%,$<)
 	tar -xJf $< -C $(TOP_DIR)/tools/toolchains/
 	touch $@
 
 $(TOP_DIR)/cache/toolchain-esp8266-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz:
 	mkdir -p $(TOP_DIR)/cache
+	$(summary) WGET $(patsubst $(TOP_DIR)/%,%,$@)
 	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused https://github.com/jmattsson/esp-toolchains/releases/download/$(PLATFORM)-$(TOOLCHAIN_VERSION)/toolchain-esp8266-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz -O $@ || { rm -f "$@"; exit 1; }
 endif
 
 $(TOP_DIR)/sdk/.extracted-$(SDK_BASE_VER): $(TOP_DIR)/cache/v$(SDK_FILE_VER).zip
 	mkdir -p "$(dir $@)"
+	$(summary) UNZIP $(patsubst $(TOP_DIR)/%,%,$<)
 	(cd "$(dir $@)" && rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK-$(SDK_BASE_VER) && unzip $(TOP_DIR)/cache/v$(SDK_FILE_VER).zip ESP8266_NONOS_SDK-$(SDK_BASE_VER)/lib/* ESP8266_NONOS_SDK-$(SDK_BASE_VER)/ld/eagle.rom.addr.v6.ld ESP8266_NONOS_SDK-$(SDK_BASE_VER)/include/* ESP8266_NONOS_SDK-$(SDK_BASE_VER)/bin/esp_init_data_default_v05.bin)
 	mv $(dir $@)/ESP8266_NONOS_SDK-$(SDK_BASE_VER) $(dir $@)/esp_iot_sdk_v$(SDK_BASE_VER)
 	touch $@
 
 $(TOP_DIR)/sdk/.patched-$(SDK_VER): $(TOP_DIR)/cache/$(SDK_PATCH_VER).patch
 	mv $(dir $@)/esp_iot_sdk_v$(SDK_BASE_VER) $(dir $@)/esp_iot_sdk_v$(SDK_VER)
+	$(summary) APPLY $(patsubst $(TOP_DIR)/%,%,$<)
 	git apply --verbose -p1 --exclude='*VERSION' --exclude='*bin/at*' --directory=$(SDK_REL_DIR) $<
 	touch $@
 
 $(TOP_DIR)/sdk/.pruned-$(SDK_VER):
 	rm -f $(SDK_DIR)/lib/liblwip.a $(SDK_DIR)/lib/libssl.a $(SDK_DIR)/lib/libmbedtls.a
+	$(summary) PRUNE libmain.a libc.a
 	$(AR) d $(SDK_DIR)/lib/libmain.a time.o
 	$(AR) d $(SDK_DIR)/lib/libc.a lib_a-time.o
 	touch $@
 
 $(TOP_DIR)/cache/v$(SDK_FILE_VER).zip:
 	mkdir -p "$(dir $@)"
+	$(summary) WGET $(patsubst $(TOP_DIR)/%,%,$@)
 	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused https://github.com/espressif/ESP8266_NONOS_SDK/archive/v$(SDK_FILE_VER).zip -O $@ || { rm -f "$@"; exit 1; }
 	(echo "$(SDK_FILE_SHA1)  $@" | sha1sum -c -) || { rm -f "$@"; exit 1; }
 
 $(TOP_DIR)/cache/$(SDK_PATCH_VER).patch:
 	mkdir -p "$(dir $@)"
+	$(summary) WGET $(SDK_PATCH_VER).patch
 	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused "https://github.com/espressif/ESP8266_NONOS_SDK/compare/v$(SDK_BASE_VER)...$(SDK_PATCH_VER).patch" -O $@ || { rm -f "$@"; exit 1; }
 	(echo "$(SDK_PATCH_SHA1)  $@" | sha1sum -c -) || { rm -f "$@"; exit 1; }
 
@@ -318,6 +345,7 @@ ifneq ($(wildcard $(TOP_DIR)/server-ca.crt),)
 pre_build: $(TOP_DIR)/app/modules/server-ca.crt.h
 
 $(TOP_DIR)/app/modules/server-ca.crt.h: $(TOP_DIR)/server-ca.crt
+	$(summary) MKCERT $(patsubst $(TOP_DIR)/%,%,$<)
 	python $(TOP_DIR)/tools/make_server_cert.py $(TOP_DIR)/server-ca.crt > $(TOP_DIR)/app/modules/server-ca.crt.h
 
 DEFINES += -DHAVE_SSL_SERVER_CRT=\"server-ca.crt.h\"
@@ -326,14 +354,14 @@ pre_build:
 	@-rm -f $(TOP_DIR)/app/modules/server-ca.crt.h
 endif
 
-
 $(OBJODIR)/%.o: %.c
 	@mkdir -p $(dir $@);
+	$(summary) CC $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$<
 	$(CC) $(if $(findstring $<,$(DSRCS)),$(DFLAGS),$(CFLAGS)) $(COPTS_$(*F)) -o $@ -c $<
 
 $(OBJODIR)/%.d: %.c
 	@mkdir -p $(dir $@);
-	@echo DEPEND: $(CC) -M $(CFLAGS) $<
+	$(summary) DEPEND: CC $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$<
 	@set -e; rm -f $@; \
 	$(CC) -M $(CFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\.o\)[ :]*,$(OBJODIR)/\1 $@ : ,g' < $@.$$$$ > $@; \
@@ -341,17 +369,19 @@ $(OBJODIR)/%.d: %.c
 
 $(OBJODIR)/%.o: %.cpp
 	@mkdir -p $(OBJODIR);
+	$(summary) CXX $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$<
 	$(CXX) $(if $(findstring $<,$(DSRCS)),$(DFLAGS),$(CFLAGS)) $(COPTS_$(*F)) -o $@ -c $<
 
 $(OBJODIR)/%.d: %.cpp
 	@mkdir -p $(OBJODIR);
-	@echo DEPEND: $(CXX) -M $(CFLAGS) $<
+	$(summary) DEPEND: CXX $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$<
 	@set -e; rm -f $@; \
 	sed 's,\($*\.o\)[ :]*,$(OBJODIR)/\1 $@ : ,g' < $@.$$$$ > $@; \
 	rm -f $@.$$$$
 
 $(OBJODIR)/%.o: %.s
 	@mkdir -p $(dir $@);
+	$(summary) CC $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$<
 	$(CC) $(CFLAGS) -o $@ -c $<
 
 $(OBJODIR)/%.d: %.s
@@ -363,6 +393,7 @@ $(OBJODIR)/%.d: %.s
 
 $(OBJODIR)/%.o: %.S
 	@mkdir -p $(dir $@);
+	$(summary) CC $(patsubst $(TOP_DIR)/%,%,$(CURDIR))/$<
 	$(CC) $(CFLAGS) -D__ASSEMBLER__ -o $@ -c $<
 
 $(OBJODIR)/%.d: %.S

--- a/app/lua/luac_cross/Makefile
+++ b/app/lua/luac_cross/Makefile
@@ -59,6 +59,7 @@ IMAGE  := ../../../luac.cross
 all: $(DEPS) $(IMAGE)
 
 $(IMAGE) : $(OBJS)
+	$(summary) HOSTLD $@
 	$(CC) $(OBJS) -o $@ $(LDFLAGS)
 
 test :
@@ -76,11 +77,12 @@ endif
 
 $(ODIR)/%.o: %.c
 	@mkdir -p $(ODIR);
+	$(summary) HOSTCC $(CURDIR)/$<
 	$(CC) $(if $(findstring $<,$(DSRCS)),$(DFLAGS),$(CFLAGS)) $(COPTS_$(*F)) -o $@ -c $<
 
 $(ODIR)/%.d: %.c
 	@mkdir -p $(ODIR);
-	@echo DEPEND: $(CC) -M $(CFLAGS) $<
+	$(summary) DEPEND: HOSTCC $(CURDIR)/$<
 	@set -e; rm -f $@; \
 	$(CC) -M $(CFLAGS) $< > $@.$$$$; \
 	sed 's,\($*\.o\)[ :]*,$(ODIR)/\1 $@ : ,g' < $@.$$$$ > $@; \

--- a/app/uzlib/host/Makefile
+++ b/app/uzlib/host/Makefile
@@ -47,9 +47,11 @@ IMAGES :=  $(ROOT)/uz_zip $(ROOT)/uz_unzip
 all: $(IMAGES)
 
 $(ROOT)/uz_zip : $(ODIR)/uz_zip.o $(ODIR)/crc32.o $(ODIR)/uzlib_deflate.o
+	$(summary) HOSTLD $@
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 $(ROOT)/uz_unzip : $(ODIR)/uz_unzip.o $(ODIR)/crc32.o $(ODIR)/uzlib_inflate.o
+	$(summary) HOSTLD $@
 	$(CC) $^ -o $@ $(LDFLAGS)
 
 test :
@@ -63,5 +65,6 @@ clean :
 
 $(ODIR)/%.o: %.c
 	@mkdir -p $(ODIR);
+	$(summary) HOSTCC $(CURDIR)/$<
 	$(CC) $(CFLAGS) -o $@ -c $<
 

--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -14,6 +14,11 @@ NodeMCU firmware developers commit or contribute to the project on GitHub and mi
 make
 ```
 
+The default build setup reduces output verbosity to a minimum. The verbositiy level can be increased by setting the `V` environment variable to 1, e.g. with
+```
+V=1 make
+```
+
 !!! note
 
     Building the tool chain from scratch is out of NodeMCU's scope. Refer to [ESP toolchains](https://github.com/jmattsson/esp-toolchains) for related information.

--- a/tools/spiffsimg/Makefile
+++ b/tools/spiffsimg/Makefile
@@ -7,6 +7,7 @@ SRCS=\
 CFLAGS=-g -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -I. -I../../app/spiffs -I../../app/include -DNODEMCU_SPIFFS_NO_INCLUDE --include spiffs_typedefs.h -Ddbg_printf=printf
 
 spiffsimg: $(SRCS)
+	$(summary) HOSTCC $(CURDIR)/$<
 	$(CC) $(CFLAGS) $^ $(LDFLAGS) -o $@
 
 clean:


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

As a developer, I need to observe the console output from the build process to monitor the flow and to get an overview on overall fitness. Its current high verbosity is counter-productive IMO - it doesn't provide any benefit for regular programming sessions and, even worse, de-focuses developers and eclipses potential issues.

This PR reduces the verbosity of make's console output to a "summary level" by applying Makefile techniques commonly found in other projects (e.g. ESP-IDF). By emitting just a single line of text per source file, there is less distraction when monitoring the build process.
CI builds generate a much smaller log file as a side effect (~130kB instead of ~987kB), although we're not yet even close to [TravisCI's 4MB limit](https://docs.travis-ci.com/user/common-build-problems/#log-length-exceeded).

Full verbosity can be re-gained by setting environment variable `V` to 1:
```
V=1 make
```
