### PR TITLE
Minor fix to wifi documentation

### DIFF
--- a/docs/en/modules/wifi.md
+++ b/docs/en/modules/wifi.md
@@ -604,7 +604,7 @@ wifi.sta.config(station_cfg)
 - [`wifi.sta.clearconfig()`](#wifistaclearconfig)
 - [`wifi.sta.connect()`](#wifistaconnect)
 - [`wifi.sta.disconnect()`](#wifistadisconnect)
-- [`wifi.sta.apinfo()`](#wifistaapinfo)
+- [`wifi.sta.getapinfo()`](#wifistagetapinfo)
 
 ## wifi.sta.connect()
 
@@ -768,8 +768,8 @@ print("the index of the currently selected AP is: "..wifi.sta.getapindex())
 
 #### See also
 - [`wifi.sta.getapindex()`](#wifistagetapindex)
-- [`wifi.sta.apinfo()`](#wifistaapinfo)
-- [`wifi.sta.apchange()`](#wifistaapchange)
+- [`wifi.sta.getapinfo()`](#wifistagetapinfo)
+- [`wifi.sta.changeap()`](#wifistachangeap)
 
 ## wifi.sta.getapinfo()
 


### PR DESCRIPTION
Fixes wrong reference to `wifi.sta.changeap()` in the  `wifi.sta.getapindex()` documentation.

- [x ] This PR is for the `dev` branch rather than for `master`.
- [ x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ x] I have thoroughly tested my contribution.
- [ x] The code changes are reflected in the documentation at `docs/en/*`.

