### PR TITLE
ESP32 crypto module

### DIFF
--- a/components/modules/Kconfig
+++ b/components/modules/Kconfig
@@ -74,6 +74,12 @@ config LUA_MODULE_CAN
   help
       Includes the can module.
 
+config LUA_MODULE_CRYPTO
+  bool "Crypto module"
+  default "n"
+  help
+      Includes the crypto module.
+
 config LUA_MODULE_DAC
   bool "DAC module"
   default "n"

--- a/components/modules/Kconfig
+++ b/components/modules/Kconfig
@@ -80,6 +80,30 @@ config LUA_MODULE_CRYPTO
   help
       Includes the crypto module.
 
+menu "Crypto module hashing algorithms"
+  config CRYPTO_HASH_SHA1
+    bool "SHA1"
+    default "y"
+    help
+      Includes the SHA1 hashing algorithm
+  config CRYPTO_HASH_SHA256
+    bool "SHA256 and SHA224"
+    default "y"
+    help
+      Includes the SHA256 and SHA224 hashing algorithms
+  config CRYPTO_HASH_SHA512
+    bool "SHA512 and SHA384"
+    default "y"
+    help
+      Includes the SHA256 and SHA384 hashing algorithms
+  config CRYPTO_HASH_MD5
+    bool "MD5"
+    default "y"
+    help
+      Includes the MD5 hashing algorithm
+endmenu
+
+
 config LUA_MODULE_DAC
   bool "DAC module"
   default "n"

--- a/components/modules/Kconfig
+++ b/components/modules/Kconfig
@@ -81,6 +81,8 @@ config LUA_MODULE_CRYPTO
       Includes the crypto module.
 
 menu "Crypto module hashing algorithms"
+  depends on LUA_MODULE_CRYPTO
+
   config CRYPTO_HASH_SHA1
     bool "SHA1"
     default "y"
@@ -98,7 +100,7 @@ menu "Crypto module hashing algorithms"
       Includes the SHA256 and SHA384 hashing algorithms
   config CRYPTO_HASH_MD5
     bool "MD5"
-    default "y"
+    default "n"
     help
       Includes the MD5 hashing algorithm
 endmenu

--- a/components/modules/crypto.c
+++ b/components/modules/crypto.c
@@ -230,24 +230,6 @@ static int crypto_hash_gc(lua_State* L) {
     return 0;
 }
 
-// crypto_hex_encode (LUA: crypto.toHex(data) takes a binary string
-// and returns its hexadecimal representation as a string
-static int crypto_toHex(lua_State* L) {
-    const char crypto_hexbytes[] = "0123456789abcdef";
-    size_t len;
-    const char* msg = luaL_checklstring(L, 1, &len);
-    size_t hexLen = len * 2;
-    char* out = (char*)luaM_malloc(L, hexLen);
-    int i, j = 0;
-    for (i = 0; i < len; i++) {
-        out[j++] = crypto_hexbytes[msg[i] >> 4];
-        out[j++] = crypto_hexbytes[msg[i] & 0x0F];
-    }
-    lua_pushlstring(L, out, hexLen);
-    luaM_freemem(L, out, hexLen);
-    return 1;
-}
-
 // The following table defines methods of the hasher object
 static const LUA_REG_TYPE crypto_hasher_map[] = {
     {LSTRKEY("update"), LFUNCVAL(crypto_hash_update)},
@@ -259,7 +241,6 @@ static const LUA_REG_TYPE crypto_hasher_map[] = {
 // This table defines the functions of the crypto module:
 static const LUA_REG_TYPE crypto_map[] = {
     {LSTRKEY("new_hash"), LFUNCVAL(crypto_new_hash)},
-    {LSTRKEY("toHex"), LFUNCVAL(crypto_toHex)},
     {LNILKEY, LNILVAL}};
 
 // luaopen_crypto is the crypto module initialization function

--- a/components/modules/crypto.c
+++ b/components/modules/crypto.c
@@ -9,14 +9,18 @@
 #include "module.h"
 #include "platform.h"
 
-#define HASH_METATABLE "crypto.sha1hasher"
+#define HASH_METATABLE "crypto.hasher"
 
+// The following function typedefs aim to generalize mbedtls functions
+// so that we can use the same code independent of what hashing algorithm
 typedef void (*hash_init_t)(void* ctx);
 typedef int (*hash_starts_ret_t)(void* ctx);
 typedef int (*hash_update_ret_t)(void* ctx, const unsigned char* input, size_t ilen);
 typedef int (*hash_finish_ret_t)(void* ctx, unsigned char* output);
 typedef void (*hash_free_t)(void* ctx);
 
+// algo_info_t describes a hashing algorithm and the mbedtls functions
+// for initializing, hashing data, finalizing and freeing resources.
 typedef struct {
     const char* name;
     const size_t size;
@@ -28,29 +32,36 @@ typedef struct {
     const hash_free_t free;
 } algo_info_t;
 
+// hash_context_t contains information about an ongoing hash operation
 typedef struct {
     void* mbedtls_context;
     const algo_info_t* ainfo;
 } hash_context_t;
 
+// if SHA256+SHA224 are enabled, the following two functions
+// allow to call mbedtls appropriately depending on the algorithm
 #ifdef CONFIG_CRYPTO_HASH_SHA256
 static int sha256_starts_ret(mbedtls_sha256_context* ctx) {
-    return mbedtls_sha256_starts_ret(ctx, false);
+    return mbedtls_sha256_starts_ret(ctx, false);  // false=SHA256
 }
 static int sha224_starts_ret(mbedtls_sha256_context* ctx) {
-    return mbedtls_sha256_starts_ret(ctx, true);
+    return mbedtls_sha256_starts_ret(ctx, true);  // true=SHA224
 }
 #endif
 
+// if SHA512+SHA384 are enabled, the following two functions
+// allow to call mbedtls appropriately depending on the algorithm
 #ifdef CONFIG_CRYPTO_HASH_SHA512
 static int sha512_starts_ret(mbedtls_sha512_context* ctx) {
-    return mbedtls_sha512_starts_ret(ctx, false);
+    return mbedtls_sha512_starts_ret(ctx, false);  // false=SHA512
 }
 static int sha384_starts_ret(mbedtls_sha512_context* ctx) {
-    return mbedtls_sha512_starts_ret(ctx, true);
+    return mbedtls_sha512_starts_ret(ctx, true);  // true=SHA384
 }
 #endif
 
+// the constant algorithms array below contains a table of functions and other
+// information about each enabled hashing algorithm
 static const algo_info_t algorithms[] = {
 #ifdef CONFIG_CRYPTO_HASH_SHA1
     {
@@ -122,8 +133,11 @@ static const algo_info_t algorithms[] = {
 #endif
 };
 
+//NUM_ALGORITHMS contains the actual number of enabled algorithms
 const int NUM_ALGORITHMS = sizeof(algorithms) / sizeof(algo_info_t);
 
+// crypto_new_hash (LUA: hasher = crypto.new_hash(algo)) allocates
+// a hashing context for the requested algorithm
 static int crypto_new_hash(lua_State* L) {
     const char* algo = luaL_checkstring(L, 1);
     const algo_info_t* ainfo = NULL;
@@ -139,27 +153,38 @@ static int crypto_new_hash(lua_State* L) {
         luaL_error(L, "Unsupported algorithm: %s", algo);  // returns
     }
 
+    // Instantiate a hasher object as a Lua userdata object
+    // it will contain a pointer to a hash_context_t structure in which
+    // we will store the mbedtls context information and also
+    // what hashing algorithm this context is for.
     hash_context_t* phctx = (hash_context_t*)lua_newuserdata(L, sizeof(hash_context_t));
     luaL_getmetatable(L, HASH_METATABLE);
     lua_setmetatable(L, -2);
-    phctx->ainfo = ainfo;
-    phctx->mbedtls_context = luaM_malloc(L, ainfo->context_size);
+
+    phctx->ainfo = ainfo;                                          // save a pointer to the algorithm function table and information
+    phctx->mbedtls_context = luaM_malloc(L, ainfo->context_size);  // make some space for the mbedtls context
     if (phctx->mbedtls_context == NULL) {
         luaL_error(L, "Out of memory allocating context");
     }
 
-    ainfo->init(phctx->mbedtls_context);
+    ainfo->init(phctx->mbedtls_context);  // initialize the hashing function
     if (ainfo->starts(phctx->mbedtls_context) != 0) {
         luaL_error(L, "Error starting context");
     }
-    return 1;
+    return 1;  // one object returned, the hasher userdata object.
 }
 
+// crypto_hash_update (LUA: hasher:update(data)) submits data
+// to be hashed.
 static int crypto_hash_update(lua_State* L) {
+    // retrieve the hashing context:
     hash_context_t* phctx = (hash_context_t*)luaL_checkudata(L, 1, HASH_METATABLE);
-    size_t size;
+
+    size_t size;  // size of the input string
+    // retrieve the input string:
     const unsigned char* input = (const unsigned char*)luaL_checklstring(L, 2, &size);
 
+    // call the update hashing function:
     if (phctx->ainfo->update(phctx->mbedtls_context, input, size) != 0) {
         luaL_error(L, "Error updating hash");
     }
@@ -167,33 +192,48 @@ static int crypto_hash_update(lua_State* L) {
     return 0;  // no return value
 }
 
+// crypto_hash_finalize (LUA: hasher:finalize()) returns the hash result
+// as a binary string.
 static int crypto_hash_finalize(lua_State* L) {
+    // retrieve the hashing context:
     hash_context_t* phctx = (hash_context_t*)luaL_checkudata(L, 1, HASH_METATABLE);
+
+    // reserve some space to retrieve the output hash, according to the current algorithm
     unsigned char output[phctx->ainfo->size];
+
+    // call the hash finish function to retrieve the result
     if (phctx->ainfo->finish(phctx->mbedtls_context, output) != 0) {
         luaL_error(L, "Error finalizing hash");
     }
+
+    // pack the output into a lua string
     lua_pushlstring(L, (const char*)output, phctx->ainfo->size);
-    return 1;
+
+    return 1;  // 1 result returned, the hash.
 }
 
+// crypto_hash_gc is called automatically by LUA when the hasher object is
+// dereferenced, in order to free resources associated with the hashing process.
 static int crypto_hash_gc(lua_State* L) {
+    // retrieve the hashing context:
     hash_context_t* phctx = (hash_context_t*)luaL_checkudata(L, 1, HASH_METATABLE);
+
+    // if the mbedtls context is NULL, it means allocation failed in new_hash(), so nothing to do.
     if (phctx->mbedtls_context == NULL)
         return 0;
 
+    // free mbedtls-related resources for this hash operation:
     phctx->ainfo->free(phctx->mbedtls_context);
+
+    // free the memory allocated to store the mbedtls context:
     luaM_free(L, phctx->mbedtls_context);
     return 0;
 }
 
-const char crypto_hexbytes[] = "0123456789abcdef";
-/**
-  * encoded = crypto.toHex(raw)
-  *
-  *	Encodes raw binary string as hex string.
-  */
-static int crypto_hex_encode(lua_State* L) {
+// crypto_hex_encode (LUA: crypto.toHex(data) takes a binary string
+// and returns its hexadecimal representation as a string
+static int crypto_toHex(lua_State* L) {
+    const char crypto_hexbytes[] = "0123456789abcdef";
     size_t len;
     const char* msg = luaL_checklstring(L, 1, &len);
     char* out = (char*)luaM_malloc(L, len * 2);
@@ -207,6 +247,7 @@ static int crypto_hex_encode(lua_State* L) {
     return 1;
 }
 
+// The following table defines methods of the hasher object
 static const LUA_REG_TYPE crypto_hasher_map[] = {
     {LSTRKEY("update"), LFUNCVAL(crypto_hash_update)},
     {LSTRKEY("finalize"), LFUNCVAL(crypto_hash_finalize)},
@@ -214,15 +255,18 @@ static const LUA_REG_TYPE crypto_hasher_map[] = {
     {LSTRKEY("__index"), LROVAL(crypto_hasher_map)},
     {LNILKEY, LNILVAL}};
 
+// This table defines the functions of the crypto module:
 static const LUA_REG_TYPE crypto_map[] = {
     {LSTRKEY("new_hash"), LFUNCVAL(crypto_new_hash)},
-    {LSTRKEY("toHex"), LFUNCVAL(crypto_hex_encode)},
+    {LSTRKEY("toHex"), LFUNCVAL(crypto_toHex)},
     {LNILKEY, LNILVAL}};
 
+// luaopen_crypto is the crypto module initialization function
 int luaopen_crypto(lua_State* L) {
     luaL_rometatable(L, HASH_METATABLE, (void*)crypto_hasher_map);  // create metatable for crypto.hash
 
     return 0;
 }
 
+// define the crypto NodeMCU module
 NODEMCU_MODULE(CRYPTO, "crypto", crypto_map, luaopen_crypto);

--- a/components/modules/crypto.c
+++ b/components/modules/crypto.c
@@ -1,0 +1,132 @@
+#define MBEDTLS_SHA1_ALT
+#include <limits.h>
+#include <string.h>
+#include "lauxlib.h"
+#include "lmem.h"
+#include "mbedtls/sha1.h"
+#include "module.h"
+
+#define SHA1_METATABLE "crypto.sha1hasher"
+
+static int crypto_test(lua_State* L) {
+    lua_Integer v = luaL_checkinteger(L, 1);
+
+    lua_pushinteger(L, v * 2);
+    return 1;
+}
+
+static int crypto_sha1test(lua_State* L) {
+    size_t size;
+    const unsigned char* input = (const unsigned char*)luaL_checklstring(L, 1, &size);
+    unsigned char output[20];
+    int ret;
+
+    mbedtls_sha1_context* ctx = (mbedtls_sha1_context*)luaM_malloc(L, sizeof(mbedtls_sha1_context));
+
+    mbedtls_sha1_init(ctx);
+
+    if ((ret = mbedtls_sha1_starts_ret(ctx)) != 0)
+        goto fail;
+
+    if ((ret = mbedtls_sha1_update_ret(ctx, input, size)) != 0)
+        goto fail;
+
+    if ((ret = mbedtls_sha1_finish_ret(ctx, output)) != 0)
+        goto fail;
+
+    lua_pushlstring(L, (const char*)output, 20);
+    goto exit;
+fail:
+    lua_pushnil(L);
+exit:
+    mbedtls_sha1_free(ctx);
+    luaM_free(L, ctx);
+
+    return 1;
+}
+
+static int crypto_new_hash(lua_State* L) {
+    const char* algo = luaL_checkstring(L, 1);
+    if (strcmp("SHA1", algo) != 0) {
+        luaL_error(L, "Unsupported algorithm: %s", algo);  // returns
+    }
+    printf("before ud\n");
+    /* create a userdatum to store a hashing context address*/
+    mbedtls_sha1_context** ppctx = (mbedtls_sha1_context**)lua_newuserdata(L, sizeof(mbedtls_sha1_context*));
+    /* set its metatable */
+    luaL_getmetatable(L, SHA1_METATABLE);
+    lua_setmetatable(L, -2);
+
+    printf("before malloc\n");
+    *ppctx = (mbedtls_sha1_context*)luaM_malloc(L, sizeof(mbedtls_sha1_context));
+    if (*ppctx == NULL) {
+        luaL_error(L, "Out of memory allocating context");
+    }
+    printf("before sha init\n");
+    mbedtls_sha1_init(*ppctx);
+    printf("before starts\n");
+    if (!mbedtls_sha1_starts_ret(*ppctx)) {
+        luaL_error(L, "Error starting sha1 context");
+    }
+    printf("before return\n");
+    return 1;
+}
+
+static int crypto_sha1_update(lua_State* L) {
+    mbedtls_sha1_context* pctx = (mbedtls_sha1_context*)luaL_checkudata(L, 1, SHA1_METATABLE);
+    size_t size;
+    const unsigned char* input = (const unsigned char*)luaL_checklstring(L, 2, &size);
+
+    if (!mbedtls_sha1_update_ret(pctx, input, size)) {
+        luaL_error(L, "Error updating hash");
+    }
+
+    return 0;  // no return value
+}
+
+static int crypto_sha1_finalize(lua_State* L) {
+    mbedtls_sha1_context* pctx = (mbedtls_sha1_context*)luaL_checkudata(L, 1, SHA1_METATABLE);
+    unsigned char output[20];
+    if (!mbedtls_sha1_finish_ret(pctx, output)) {
+        luaL_error(L, "Error finalizing hash");
+    }
+    lua_pushlstring(L, (const char*)output, 20);
+    return 1;
+}
+
+static int crypto_sha1_gc(lua_State* L) {
+    mbedtls_sha1_context* pctx = (mbedtls_sha1_context*)luaL_checkudata(L, 1, SHA1_METATABLE);
+    if (!pctx)
+        return 0;
+
+    mbedtls_sha1_free(pctx);
+    luaM_free(L, pctx);
+    return 0;
+}
+
+int luaopen_crypto(lua_State* L) {
+    luaL_newmetatable(L, SHA1_METATABLE);
+
+    /* set its __gc field */
+    lua_pushstring(L, "__gc");
+    lua_pushcfunction(L, crypto_sha1_gc);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "update");
+    lua_pushcfunction(L, crypto_sha1_update);
+    lua_settable(L, -3);
+
+    lua_pushstring(L, "finalize");
+    lua_pushcfunction(L, crypto_sha1_finalize);
+    lua_settable(L, -3);
+
+    return 0;
+}
+
+static const LUA_REG_TYPE crypto_map[] = {
+    {LSTRKEY("test"), LFUNCVAL(crypto_test)},
+    {LSTRKEY("sha1test"), LFUNCVAL(crypto_sha1test)},
+    {LSTRKEY("new_hash"), LFUNCVAL(crypto_new_hash)},
+    {LNILKEY, LNILVAL}};
+
+NODEMCU_MODULE(CRYPTO, "crypto", crypto_map, luaopen_crypto);

--- a/components/modules/crypto.c
+++ b/components/modules/crypto.c
@@ -226,7 +226,7 @@ static int crypto_hash_gc(lua_State* L) {
     phctx->ainfo->free(phctx->mbedtls_context);
 
     // free the memory allocated to store the mbedtls context:
-    luaM_free(L, phctx->mbedtls_context);
+    luaM_freemem(L, phctx->mbedtls_context, phctx->ainfo->context_size);
     return 0;
 }
 
@@ -236,14 +236,15 @@ static int crypto_toHex(lua_State* L) {
     const char crypto_hexbytes[] = "0123456789abcdef";
     size_t len;
     const char* msg = luaL_checklstring(L, 1, &len);
-    char* out = (char*)luaM_malloc(L, len * 2);
+    size_t hexLen = len * 2;
+    char* out = (char*)luaM_malloc(L, hexLen);
     int i, j = 0;
     for (i = 0; i < len; i++) {
         out[j++] = crypto_hexbytes[msg[i] >> 4];
         out[j++] = crypto_hexbytes[msg[i] & 0x0F];
     }
-    lua_pushlstring(L, out, len * 2);
-    luaM_free(L, out);
+    lua_pushlstring(L, out, hexLen);
+    luaM_freemem(L, out, hexLen);
     return 1;
 }
 

--- a/docs/en/modules/crypto.md
+++ b/docs/en/modules/crypto.md
@@ -1,0 +1,58 @@
+# crypto Module
+| Since  | Origin / Contributor  | Maintainer  | Source  |
+| :----- | :-------------------- | :---------- | :------ |
+| 2019-01-13 | [Javier Peletier](https://github.com/jpeletier) | [Javier Peletier](https://github.com/jpeletier) | [crypto.c](../../../components/modules/crypto.c)|
+
+The crypto module provides various functions for working with cryptographic algorithms.
+
+This is work in progress, for now only a number of hashing functions are available:
+
+* SHA1
+* SHA256
+* SHA224
+* SHA512
+* SHA384
+* MD5
+
+All are enabled by default. To disable algorithms you don't need, find the "Crypto module hashing algorithms" under the NodeMCU modules section in menuconfig.
+
+## crypto.new_hash()
+
+Create a digest/hash object that can have any number of strings added to it. Object has `update` and `finalize` functions.
+
+#### Syntax
+`hashobj = crypto.new_hash(algo)`
+
+#### Parameters
+`algo` the hash algorithm to use, case insensitive string
+
+#### Returns
+Hasher object with `update` and `finalize` functions available.
+
+#### Example
+```lua
+hashobj = crypto.new_hash("SHA1")
+hashobj:update("FirstString"))
+hashobj:update("SecondString"))
+digest = hashobj:finalize()
+print(crypto.toHex(digest))
+```
+
+## crypto.toHex()
+
+Provides an ASCII hex representation of a (binary) Lua string. Each byte in the input string is represented as two hex characters in the output.
+
+#### Syntax
+`hexstr = crypto.toHex(binary)`
+
+#### Parameters
+`binary` input string to get hex representation for
+
+#### Returns
+An ASCII hex string.
+
+#### Example
+```lua
+print(crypto.toHex("\001\002\003"))
+-- prints 010203
+```

--- a/docs/en/modules/crypto.md
+++ b/docs/en/modules/crypto.md
@@ -14,7 +14,7 @@ This is work in progress, for now only a number of hashing functions are availab
 * SHA384
 * MD5
 
-All are enabled by default. To disable algorithms you don't need, find the "Crypto module hashing algorithms" under the NodeMCU modules section in menuconfig.
+All except MD5 are enabled by default. To disable algorithms you don't need, find the "Crypto module hashing algorithms" under the NodeMCU modules section in menuconfig.
 
 ## crypto.new_hash()
 

--- a/docs/modules/crypto.md
+++ b/docs/modules/crypto.md
@@ -35,24 +35,5 @@ hashobj = crypto.new_hash("SHA1")
 hashobj:update("FirstString"))
 hashobj:update("SecondString"))
 digest = hashobj:finalize()
-print(crypto.toHex(digest))
-```
-
-## crypto.toHex()
-
-Provides an ASCII hex representation of a (binary) Lua string. Each byte in the input string is represented as two hex characters in the output.
-
-#### Syntax
-`hexstr = crypto.toHex(binary)`
-
-#### Parameters
-`binary` input string to get hex representation for
-
-#### Returns
-An ASCII hex string.
-
-#### Example
-```lua
-print(crypto.toHex("\001\002\003"))
--- prints 010203
+print(encoder.toHex(digest))
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,7 @@ pages:
     - 'bit':          'modules/bit.md'
     - 'bthci':        'modules/bthci.md'
     - 'can':          'modules/can.md'
-    - 'crypto':       'en/modules/crypto.md'
+    - 'crypto':       'modules/crypto.md'
     - 'dac':          'modules/dac.md'
     - 'dht':          'modules/dht.md'
     - 'encoder':      'modules/encoder.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ pages:
     - 'bit':          'modules/bit.md'
     - 'bthci':        'modules/bthci.md'
     - 'can':          'modules/can.md'
+    - 'crypto':       'en/modules/crypto.md'
     - 'dac':          'modules/dac.md'
     - 'dht':          'modules/dht.md'
     - 'encoder':      'modules/encoder.md'


### PR DESCRIPTION
- [x] This PR is for the `esp32-dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This PR is a minimal implementation for ESP32 of a `crypto` module using mbedtls. For now, it contains the SHA1, SHA256, SHA224, SHA512, SHA384 and MD5 hashing functions, as well as the `toHex()` function to convert binary strings to hexadecimal.

If hardware acceleration is enabled for mbedtls, this module will make use of it as well.

The interface of this module aims to be backward-compatible to the one in the `master` branch (ESP8266). Not all functions have been implemented, but those who are, are backward compatible. The updated documentation shows only the functions that have been implemented.

To enable/disable this module, use `make menuconfig` and select/deselect it in the NodeMCU modules section. You can also disable hashing algorithms there in order to reduce the binary image size