### PR TITLE
fix number2integer conversion in ESP8266 for floating-point builds

### DIFF
--- a/app/lua/luaconf.h
+++ b/app/lua/luaconf.h
@@ -717,8 +717,18 @@ union luai_Cast { double l_d; long l_l; };
 
 /* this option always works, but may be slow */
 #else
-#define lua_number2int(i,d)	((i)=(int)(d))
-#define lua_number2integer(i,d)	((i)=(lua_Integer)(d))
+
+#ifdef LUA_NUMBER_INTEGRAL
+
+#define lua_number2int(i, d) ((i) = (int)(d))
+#define lua_number2integer(i, d) ((i) = (lua_Integer)(d))
+
+#else // for floating-point builds, cast to a larger integer first to avoid undefined behavior on overflows.
+
+#define lua_number2int(i, d) ((i) = (int)(long long)(d))
+#define lua_number2integer(i, d) ((i) = (lua_Integer)(long long)(d))
+
+#endif // LUA_NUMBER_INTEGRAL
 
 #endif
 


### PR DESCRIPTION
Fixes #2604 for ESP8266 .

ESP32 PR: #2605 

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

This PR fixes a quirk in floating point builds whereupon conversion of a large integer (>= 0x80000000) contained in a lua value is not properly done, resulting in the most significant bit set to zero. This manifests itself visibly when using the `bit` module. Notably, `bit.lshift(0xFFFFFFFF,0)` (shifting **zero** bits) does not result in the same number.

I tracked this down to the `lua_number2integer` macro, so now it casts it to a `long long` (at least 64 bits) before truncating it. This fixes the issue.