### PR TITLE
fix memory leak in http one-shot requests

### DIFF
--- a/components/modules/http.c
+++ b/components/modules/http.c
@@ -648,10 +648,9 @@ static int http_accumulate_complete(lua_State *L)
     lua_rawseti(L, cache_table, i);
   }
   luaL_pushresult(&b); // data now pushed
+  lhttp_context_t *context = (lhttp_context_t *)luaL_checkudata(L, context_idx, http_context_mt);
   if (lua_isnoneornil(L, 1)) {
     // No callback fn so must be sync, meaning just need to stash headers and data in the context
-    lhttp_context_t *context = (lhttp_context_t *)luaL_checkudata(L, context_idx, http_context_mt);
-    
     // steal some completion refs, nothing's going to need them again in a one-shot
     context_setref(L, context, DataCallback); // pops data
     lua_rawgeti(L, cache_table, 2); // headers
@@ -660,6 +659,8 @@ static int http_accumulate_complete(lua_State *L)
     lua_rawgeti(L, cache_table, 2); // headers
     lua_call(L, 3, 0);
   }
+  // unset this since it contains a reference to the context and would prevent the context to be garbage collected
+  context_unsetref(L, context,CompleteCallback); 
   return 0;
 }
 


### PR DESCRIPTION
Fixes #2614

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [X] This PR is for the `dev-esp32` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

When working in "one shot" mode, the http module does not free resources appropriately and loses around 2k ram on each call (!!). The referenced issue has some code you can run to see your precious heap evaporate very quickly.

After much pain, I traced this to the `http_accumulate_complete()` function. This function is a closure and had the request context as an upvalue, thus creating a circular reference that prevented the context userdatum to be garbage collected, along with all esp_http-related resources.

This fix explicitly clears this closure after it is finished executing, thus triggering gc.
