### PR TITLE
ESP32: remove use of luaM_free in file module

### DIFF
--- a/components/base_nodemcu/include/lnodeaux.h
+++ b/components/base_nodemcu/include/lnodeaux.h
@@ -65,4 +65,9 @@ inline bool luaX_valid_ref(lua_ref_t ref) {
     return ref > 0;
 }
 
+// luaX_pushlstring is the same as lua_pushlstring except it will return nonzero in case of error
+// (instead of throwing an exception and never returning) and will put the error message on the top of the stack.
+int luaX_pushlstring(lua_State* L, const char* s, size_t l);
+ 
+
 #endif


### PR DESCRIPTION
Works toward fixing #2377 for ESP32

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/en/*`.

modifications in `file_g_read()` to avoid use of `luaM_free()`