### PR TITLE
ESP32: added uart.getconfig()

### DIFF
--- a/components/base_nodemcu/uart.c
+++ b/components/base_nodemcu/uart.c
@@ -237,6 +237,24 @@ static int uart_start( lua_State* L )
   return 1;
 }
 
+static int uart_getconfig(lua_State* L) {
+    uint32_t id, baud, databits, parity, stopbits;
+
+    id = luaL_checkinteger(L, 1);
+    MOD_CHECK_ID(uart, id);
+
+    int err = platform_uart_get_config(id, &baud, &databits, &parity, &stopbits);
+    if (err) {
+      luaL_error(L, "Error reading UART config");
+    }
+
+    lua_pushinteger(L, baud);
+    lua_pushinteger(L, databits);
+    lua_pushinteger(L, parity);
+    lua_pushinteger(L, stopbits);
+    return 4;
+}
+
 // Module function map
 static const LUA_REG_TYPE uart_map[] =  {
   { LSTRKEY( "setup" ), LFUNCVAL( uart_setup ) },
@@ -245,6 +263,7 @@ static const LUA_REG_TYPE uart_map[] =  {
   { LSTRKEY( "stop" ), LFUNCVAL( uart_stop ) },
   { LSTRKEY( "on" ),    LFUNCVAL( uart_on ) },
   { LSTRKEY( "setmode" ), LFUNCVAL( uart_setmode ) },
+  { LSTRKEY( "getconfig" ), LFUNCVAL( uart_getconfig ) },
   { LSTRKEY( "STOPBITS_1" ),   LNUMVAL( PLATFORM_UART_STOPBITS_1 ) },
   { LSTRKEY( "STOPBITS_1_5" ), LNUMVAL( PLATFORM_UART_STOPBITS_1_5 ) },
   { LSTRKEY( "STOPBITS_2" ),   LNUMVAL( PLATFORM_UART_STOPBITS_2 ) },

--- a/components/platform/include/platform.h
+++ b/components/platform/include/platform.h
@@ -122,6 +122,7 @@ void platform_uart_send( unsigned id, uint8_t data );
 void platform_uart_flush( unsigned id );
 int platform_uart_start( unsigned id );
 void platform_uart_stop( unsigned id );
+int platform_uart_get_config(unsigned id, uint32_t *baudp, uint32_t *databitsp, uint32_t *parityp, uint32_t *stopbitsp);
 
 
 // *****************************************************************************

--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -336,6 +336,43 @@ void platform_uart_stop( unsigned id )
   }
 }
 
+int platform_uart_get_config(unsigned id, uint32_t *baudp, uint32_t *databitsp, uint32_t *parityp, uint32_t *stopbitsp) {
+    int err;
+
+    err = uart_get_baudrate(id, baudp);
+    if (err != ESP_OK) return -1;
+    *baudp &= 0xFFFFFFFE; // round down
+
+    uint32_t databits;
+    err = uart_get_word_length(id, &databits);
+    if (err != ESP_OK) return -1;
+
+    switch (databits) {
+        case UART_DATA_5_BITS:
+            *databitsp = 5;
+            break;
+        case UART_DATA_6_BITS:
+            *databitsp = 6;
+            break;
+        case UART_DATA_7_BITS:
+            *databitsp = 7;
+            break;
+        case UART_DATA_8_BITS:
+            *databitsp = 8;
+            break;
+        default:
+            return -1;
+    }
+
+    err = uart_get_parity(id, parityp);
+    if (err != ESP_OK) return -1;
+
+    err = uart_get_stop_bits(id, stopbitsp);
+    if (err != ESP_OK) return -1;
+
+    return 0;
+}
+
 // *****************************************************************************
 // Sigma-Delta platform interface
 

--- a/docs/modules/uart.md
+++ b/docs/modules/uart.md
@@ -105,6 +105,30 @@ uart.setup(0, 9600, 8, uart.PARITY_NONE, uart.STOPBITS_1, 1)
 uart.setup(2, 115200, 8, uart.PARITY_NONE, uart.STOPBITS_1, {tx = 16, rx = 17})
 ```
 
+## uart.getconfig()
+
+Returns the current configuration parameters of the UART. 
+
+#### Syntax
+`uart.getconfig(id)`
+
+#### Parameters
+- `id` UART id (0 or 1).
+
+#### Returns
+Four values as follows:
+
+- `baud` one of 300, 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 256000, 460800, 921600, 1843200, 3686400
+- `databits` one of 5, 6, 7, 8
+- `parity` `uart.PARITY_NONE`, `uart.PARITY_ODD`, or `uart.PARITY_EVEN`
+- `stopbits` `uart.STOPBITS_1`, `uart.STOPBITS_1_5`, or `uart.STOPBITS_2`
+
+#### Example
+```lua
+print (uart.getconfig(0))
+-- prints 9600 8 0 1   for 9600, 8N1
+```
+
 ## uart.start()
 Start the UART. You do not need to call `start()` on the console uart.
 


### PR DESCRIPTION
This PR adds the missing `uart.getconfig()` call present in ESP8266 but missing in ESP32.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X ] The code changes are reflected in the documentation at `docs/en/*`.
