### PR TITLE
ESP32: Select custom partition table in sdkconfig.defaults

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -1,6 +1,9 @@
 # set custom partition table for 1.5MB firmware
 CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="components/platform/partitions.csv"
 CONFIG_PARTITION_TABLE_FILENAME="components/platform/partitions.csv"
+CONFIG_PARTITION_TABLE_SINGLE_APP=n
+CONFIG_PARTITION_TABLE_TWO_OTA=n
+CONFIG_PARTITION_TABLE_CUSTOM=y
 
 # Don't warn about undefined variables
 CONFIG_MAKE_WARN_UNDEFINED_VARIABLES=n


### PR DESCRIPTION
- [x] This PR is for the `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

#2567 added a custom 1.5MB partition table definition but I missed to actually select it.
This will break @marcelstoer's [docker build script for esp32](https://github.com/marcelstoer/docker-nodemcu-build/blob/6e35bbaa5d50dcd8475c710aff8b724509ce2a04/build-esp32#L70) since the partition table file name is changed. Marcel, please check and let me know when this can be merged.
