### PR TITLE
Add support for SDMMC cards in SD-SPI mode

### DIFF
--- a/components/fatfs/diskio.c
+++ b/components/fatfs/diskio.c
@@ -12,7 +12,7 @@
 #include "sdmmc_cmd.h"
 
 // defined in components/modules/sdmmc.c
-extern sdmmc_card_t lsdmmc_card[2];
+extern sdmmc_card_t *lsdmmc_card[];
 
 
 static DSTATUS m_status = STA_NOINIT;
@@ -60,7 +60,7 @@ DRESULT disk_read (
 	UINT count		/* Number of sectors to read */
 )
 {
-  if (sdmmc_read_sectors( &(lsdmmc_card[pdrv]), buff, sector, count ) == ESP_OK)
+  if (sdmmc_read_sectors( lsdmmc_card[pdrv], buff, sector, count ) == ESP_OK)
     return RES_OK;
 
   return RES_ERROR;
@@ -80,7 +80,7 @@ DRESULT disk_write (
 	UINT count			/* Number of sectors to write */
 )
 {
-  if (sdmmc_write_sectors( &(lsdmmc_card[pdrv]), buff, sector, count ) == ESP_OK)
+  if (sdmmc_write_sectors( lsdmmc_card[pdrv], buff, sector, count ) == ESP_OK)
     return RES_OK;
 
   return RES_ERROR;

--- a/components/fatfs/fatfs_config.h
+++ b/components/fatfs/fatfs_config.h
@@ -13,12 +13,11 @@ typedef struct {
 // Table to map physical drive & partition to a logical volume.
 // The first value is the physical drive which relates to the SDMMC slot number
 // The second value is the partition number.
-#define NUM_LOGICAL_DRIVES 4
-PARTITION VolToPart[NUM_LOGICAL_DRIVES] = {
-  {1, 1},   /* Logical drive "0:" ==> slot 1, 1st partition */
-  {1, 2},   /* Logical drive "1:" ==> slot 1, 2st partition */
-  {1, 3},   /* Logical drive "2:" ==> slot 1, 3st partition */
-  {1, 4}    /* Logical drive "3:" ==> slot 1, 4st partition */
+PARTITION VolToPart[FF_VOLUMES] = {
+  {0, 1},   /* Logical drive "0:" ==> slot 0, 1st partition */
+  {0, 2},   /* Logical drive "1:" ==> slot 0, 2st partition */
+  {0, 3},   /* Logical drive "2:" ==> slot 0, 3st partition */
+  {0, 4}    /* Logical drive "3:" ==> slot 0, 4st partition */
 };
 
 #endif	/* __FATFS_CONFIG_H__ */

--- a/components/fatfs/myfatfs.c
+++ b/components/fatfs/myfatfs.c
@@ -348,7 +348,7 @@ static vfs_vol *myfatfs_mount( const char *name, int num )
 
   // num argument specifies the physical driver
   if (num >= 0) {
-    for (int i = 0; i < NUM_LOGICAL_DRIVES; i++) {
+    for (int i = 0; i < FF_VOLUMES; i++) {
       if (0 == strncmp( name, volstr[i], strlen( volstr[i] ) )) {
         VolToPart[i].pd = num;
       }

--- a/components/modules/spi_master.c
+++ b/components/modules/spi_master.c
@@ -224,7 +224,15 @@ int lspi_master( lua_State *L )
                  stack,
                  "invalid host" );
 
-  luaL_checktype( L, ++stack, LUA_TTABLE );
+  if (lua_type( L, ++stack ) != LUA_TTABLE) {
+    // no configuration table provided
+    // assume that host is already initialized and just provide the object
+    lspi_host_t *ud = (lspi_host_t *)lua_newuserdata( L, sizeof( lspi_host_t ) );
+    luaL_getmetatable( L, UD_HOST_STR );
+    lua_setmetatable( L, -2 );
+    ud->host = host;
+    return 1;
+  }
 
   spi_bus_config_t config;
   memset( &config, 0, sizeof( config ) );

--- a/docs/modules/sdmmc.md
+++ b/docs/modules/sdmmc.md
@@ -5,11 +5,19 @@
 
 !!! note
 
-    MMC cards are not yet supported due to missing functionality in the IDF driver.
+    MMC cards are not yet supported on HS1/HS2 interfaces due to missing functionality in the IDF driver. Use the SD SPI mode on HSPI/VSPI instead.
 
 ## SD Card connection
 
-The SD card is operated in SDMMC mode, thus the card has to be wired to the ESP pins of the HS1_* or HS2_* interfaces. There are several naming schemes used on different adapters - the following list shows alternative terms:
+!!! caution
+
+    The adapter does not require level shifters since SD and ESP are supposed to be powered with the same voltage. If your specific model contains level shifters then make sure that both sides can be operated at 3V3.
+
+![1:1 micro-sd adapter](../img/micro_sd-small.jpg "1:1 micro-sd adapter")
+
+### SDMMC Mode
+
+If the SD card is operated in SDMMC mode, then the card has to be wired to the ESP pins of the HS1_* or HS2_* interfaces. There are several naming schemes used on different adapters - the following list shows alternative terms:
 
 | SD mode name  | SPI mode name   | ESP32 HS1 I/F                  | ESP32 HS2 I/F             |
 | :---          | :---            | :---                           | :---                      |
@@ -32,11 +40,24 @@ Connections to `CLK`, `CMD`, and `DAT0` are mandatory and enable basic operation
 
     Connecting DAT0 to GPIO2 can block firmware flashing depending on the electrical configuration at this pin. Disconnect GPIO2 from the card adapter during flashing if unsure.
 
-!!! caution
+### SD SPI Mode
 
-    The adapter does not require level shifters since SD and ESP are supposed to be powered with the same voltage. If your specific model contains level shifters then make sure that both sides can be operated at 3V3.
+In SD SPI mode the SD or MMC card is operated by the SPI host interfaces (HSPI or VSPI). Both hosts can be assigned to any GPIO pins.
 
-![1:1 micro-sd adapter](../img/micro_sd-small.jpg "1:1 micro-sd adapter")
+| SPI mode name   | ESP32 HSPI, VSPI I/F |
+| :---            | :---                 |
+| `CK, SCLK`      | Any GPIO             |
+| `DI, MOSI`      | Any GPIO             |
+| `DO, MISO`      | Any GPIO             |
+| n/a             | n/a                  |
+| n/a             | n/a                  |
+| `CS, SS`        | Any GPIO             |
+| n/a             | n/a                  |
+| n/a             | n/a                  |
+| n/a             | n/a                  |
+| n/a             | n/a                  |
+| `VCC, VDD`      | 3V3 supply           |
+| `VSS, GND`      | common ground        |
 
 ## sdmmc.init()
 Initialize the SDMMC and probe the attached SD card.
@@ -44,7 +65,7 @@ Initialize the SDMMC and probe the attached SD card.
 #### Syntax
 `sdmmc.init(slot[, cfg])`
 
-#### Parameters
+#### Parameters SDMMC Mode
 - `slot` SDMMC slot, one of `sdmmc.HS1` or `sdmmc.HS2`
 - `cfg` optional table containing slot configuration:
     - `cd_pin` card detect pin, none if omitted
@@ -54,6 +75,17 @@ Initialize the SDMMC and probe the attached SD card.
         - `sdmmc.W1BIT`
         - `sdmmc.W4BIT`
         - `sdmmc.W8BIT`, not supported yet
+
+#### Parameters SD SPI Mode
+- `slot` SD SPI slot, one of `sdmmc.HSPI` or `sdmmc.VSPI`
+- `cfg` mandatory table containing slot configuration:
+    - `sck_pin` SPI SCK pin, mandatory
+    - `mosi_pin`, SPI MOSI pin, mandatory
+    - `miso_pin`, SPI MISO pin, mandatory
+    - `cs_pin`, SPI CS pin, mandatory
+    - `cd_pin` card detect pin, none if omitted
+    - `wp_pin` write-protcet pin, none if omitted
+    - `fmax` maximum communication frequency, defaults to 20&nbsp; if omitted
 
 #### Returns
 Card object.

--- a/docs/modules/spi.md
+++ b/docs/modules/spi.md
@@ -17,7 +17,7 @@ The host signals can be mapped to any suitable GPIO pins.
 Initializes a bus in master mode and returns a bus master object.
 
 #### Syntax
-`spi.master(host, config[, dma])`
+`spi.master(host[, config[, dma]])`
 
 #### Parameters
 - `host` id, one of
@@ -33,6 +33,10 @@ Initializes a bus in master mode and returns a bus master object.
 - `dma` set DMA channel (1 or 2) or disable DMA (0), defaults to 1 if omitted.
   Enabling DMA allows sending and receiving an unlimited amount of bytes but has restrictions in halfduplex mode (see [`spi.master:device()`](#spimasterdevice)).
   Disabling DMA limits a transaction to 32&nbsp;bytes max.
+
+!!! not
+
+    Omitting the `config` table returns an SPI bus master object without further initialization. This enables sharing the same SPI host with `sdmmc` in SD-SPI mode. First call `sdmmc.init(sdmmc.VSPI, ...)`, then `spi.master(spi.VSPI)`.
 
 #### Returns
 SPI bus master object

--- a/docs/sdcard.md
+++ b/docs/sdcard.md
@@ -23,7 +23,11 @@ Refer to the [`sdmmc` module documentation](modules/sdmmc.md).
 Before mounting the volume(s) on the SD card, you need to initialize the SDMMC interface from Lua.
 
 ```lua
+-- for SDMMC mode:
 card = sdmmc.init(sdmmc.HS2, {width = sdmmc.W1BIT})
+
+-- for SD SPI mode:
+card = sdmmc.init(sdmmc.VSPI, {sck_pin = 18, mosi_pin = 23, miso_pin = 19, cs_pin = 22})
 
 -- then mount the sd
 -- note: the card initialization process during `card:mount()` will set spi divider temporarily to 200 (400 kHz)


### PR DESCRIPTION
Fixes #2514.

- [x] This PR is for the `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

* Integrates IDF's sdspi_host driver for the `sdmmc` module in parallel to the sdmmc_host driver.
* Minor clean-ups in diskio layer.
* `luaM_freearray` for #2377.
