### PR TITLE
Increase http timeout 10s -> 60s

### DIFF
--- a/app/http/httpclient.h
+++ b/app/http/httpclient.h
@@ -44,7 +44,7 @@ static const char log_prefix[] = "HTTP client: ";
 /*
  * Timeout of http request.
  */
-#define HTTP_REQUEST_TIMEOUT_MS    (10000)
+#define HTTP_REQUEST_TIMEOUT_MS    (60000)
 
 /*
  * "full_response" is a string containing all response headers and the response body.

--- a/docs/modules/http.md
+++ b/docs/modules/http.md
@@ -9,7 +9,7 @@ Basic HTTP *client* module that provides an interface to do GET/POST/PUT/DELETE 
 
     It is **not** possible to execute concurrent HTTP requests using this module. 
 
-Each request method takes a callback which is invoked when the response has been received from the server. The first argument is the status code, which is either a regular HTTP status code, or -1 to denote a DNS, connection or out-of-memory failure, or a timeout (currently at 10 seconds).
+Each request method takes a callback which is invoked when the response has been received from the server. The first argument is the status code, which is either a regular HTTP status code, or -1 to denote a DNS, connection or out-of-memory failure, or a timeout (currently at 60 seconds).
 
 For each operation it is possible to provide custom HTTP headers or override standard headers. By default the `Host` header is deduced from the URL and `User-Agent` is `ESP8266`. Note, however, that the `Connection` header *can not* be overridden! It is always set to `close`.
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

HTTP timeout of 10s is very low, especially for IoT devices and slow responding servers. I often ran into issues with 10s. Using 60s should reduce errors because of slow responding servers.
