### PR TITLE
mqtt: add ceritificate handling to support server verification and mutual authentication

### DIFF
--- a/components/modules/mqtt.c
+++ b/components/modules/mqtt.c
@@ -6,7 +6,6 @@
 #include "module.h"
 #include "platform.h"
 #include "task/task.h"
-#include "common.h"
 
 #include <string.h>
 #include "mqtt_client.h"

--- a/docs/modules/mqtt.md
+++ b/docs/modules/mqtt.md
@@ -98,7 +98,12 @@ Connects to the broker specified by the given host, port, and secure options.
 #### Parameters
 - `host` host, domain or IP (string)
 - `port` broker port (number), default 1883
-- `secure` 0/1 for `false`/`true`, default 0. Take note of constraints documented in the [net module](net.md).
+- `secure` either an interger with 0/1 for `false`/`true` (default 0),
+    or a table with optional entries
+    - `ca_cert` CA certificate data in PEM format for server verify with SSL
+    - `client_cert` client certificate data in PEM format for SSL mutual authentication
+    - `client_key` client private key data in PEM format for SSL mutual authentication
+    Note that *both* `client_cert` and `client_key` have to be provided for mutual authentication.
 - `autoreconnect` 0/1 for `false`/`true`, default 0. This option is *deprecated*.
 - `function(client)` callback function for when the connection was established
 - `function(client, reason)` callback function for when the connection could not be established. No further callbacks should be called.


### PR DESCRIPTION
Follow-up to #2628, #2626.

- [x] This PR is for the `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

As discussed in #2628, this PR rebases @kevinresol's proposal to current mqtt code. The certificates  are provided with the `secure` table parameter.

I was able to verify this change against a local mosquitto testbed which enforces client certificate verification (certificates were generated locally with private CA). An independent check by @kevinresol is highly appreciated nonetheless :smiley:

A note on certification handling with ESP32 and mbedtls - I connect to my local broker instance using its server IP address. This messed up server certificate verification completely, and it took me some time to figure out the reason.
The mbedtls stack verifies the Common Name (CN) based on the connection address (some private IP in my case) against the certificate provided by the server during connection handshake. The IP is different from the CN field in the server certificate, but the IP is listed in "Subject Alternative Name". However, mbedtls ignores all alternative names *except* for type `DNS`. By default, `localhost` was the only alternative name with `DNS` type, thus mbedtls failed to match CN `localhost` with the numerical IP address.
I had to add another alternative name for the server IP address with type `DNS` to the server certificate. That did the trick to satisfy mbedtls.
