### PR TITLE
Fix typo in example (parameters were mixed)

### DIFF
--- a/docs/lua-modules/ftpserver.md
+++ b/docs/lua-modules/ftpserver.md
@@ -67,7 +67,7 @@ Wrapper to createServer() which also connects to the WiFi channel.
 
 #### Example
 ```Lua
-require("ftpserver").open('myWifi', 'wifiPassword', 'user', 'password')
+require("ftpserver").open('user', 'password', 'myWifi', 'wifiPassword')
 ```
 
 ## close()


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Parameters are mixed in "open" method example. Method definistion says that ftp credentials go first but in example these are wifi ones.
Just changed  
require("ftpserver").open('myWifi', 'wifiPassword', 'user', 'password')
to
require("ftpserver").open('user', 'password', 'myWifi', 'wifiPassword')
in example row
