### PR TITLE
Bugfix/2632 luaccrash

### DIFF
--- a/app/uzlib/uzlib_deflate.c
+++ b/app/uzlib/uzlib_deflate.c
@@ -568,7 +568,6 @@ int uzlib_compress (uchar **dest, uint *destLen, const uchar *src, uint srcLen) 
     status = UZLIB_OK;
   }
 
-  FREE(dynamicTables);
   for (i=0; i<20;i++) DBG_PRINT("count %u = %u\n",i,debugCounts[i]);
 
   if (status == UZLIB_OK) {
@@ -580,6 +579,8 @@ int uzlib_compress (uchar **dest, uint *destLen, const uchar *src, uint srcLen) 
     *destLen = 0;
     FREE(oBuf->buffer);
   }
+
+  FREE(dynamicTables);
 
   return status;
 }


### PR DESCRIPTION
Fixes #2632 .

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.  ??? I see no such path.

A block of memory is accessed after having been freed.  This was obscured by the fact that 'oBuf' is a pointer into the middle of the block 'dynamicTables', so when dynamicTables is freed, oBuf is pointing to freed memory.  Occasionally, luac.cross would crash because of this.
