### PR TITLE
added MSVC project configuration for host-side tools

### DIFF
--- a/app/include/module.h
+++ b/app/include/module.h
@@ -39,7 +39,19 @@
 #define MODULE_EXPAND_PASTE_(x,y) MODULE_PASTE_(x,y)
 
 #ifdef LUA_CROSS_COMPILER
+#ifdef _MSC_VER
+//on msvc it is necessary to go through more pre-processor hoops to get the
+//section name built; string merging does not happen in the _declspecs.
+//NOTE: linker magic is invoked via the magical '$' character. Caveat editor.
+#define __TOKIFY(s) .rodata1$##s
+#define __TOTOK(s) __TOKIFY(s)
+#define __STRINGIFY(x) #x
+#define __TOSTRING(x) __STRINGIFY(x)
+#define __ROSECNAME(s) __TOSTRING(__TOTOK(s))
+#define LOCK_IN_SECTION(s) __declspec ( allocate( __ROSECNAME(s) ) )
+#else
 #define LOCK_IN_SECTION(s) __attribute__((used,unused,section(".rodata1." #s)))
+#endif
 #else
 #define LOCK_IN_SECTION(s) __attribute__((used,unused,section(".lua_" #s)))
 #endif

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -8,6 +8,9 @@
 
 #include "lua.h"
 #include C_HEADER_CTYPE
+#ifdef _MSC_VER	//msvc #defines errno, which interferes with our #include macro
+#undef errno
+#endif
 #include C_HEADER_ERRNO
 #include C_HEADER_STDIO
 #include C_HEADER_STDLIB

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -8,10 +8,14 @@
 
 #include "lua.h"
 #include C_HEADER_CTYPE
+#ifdef __MINGW__
+#include <errno.h>
+#else
 #ifdef _MSC_VER	//msvc #defines errno, which interferes with our #include macro
 #undef errno
 #endif
 #include C_HEADER_ERRNO
+#endif
 #include C_HEADER_STDIO
 #include C_HEADER_STDLIB
 #include C_HEADER_STRING

--- a/app/lua/linit.c
+++ b/app/lua/linit.c
@@ -46,7 +46,21 @@ extern const luaR_entry  lua_rotable_base[];
 #define LUA_ROTABLES lua_rotable_core
 #define LUA_LIBS     lua_libs_core
 #endif
+             
+#ifdef _MSC_VER
+//MSVC requires us to declare these sections before we refer to them
+#pragma section(__ROSECNAME(A), read)
+#pragma section(__ROSECNAME(zzzzzzzz), read)
+#pragma section(__ROSECNAME(libs), read)
+#pragma section(__ROSECNAME(rotable), read)
 
+//These help us to find the beginning and ending of the RO data.  NOTE:  linker
+//magic is used; the section names are lexically sorted, so 'a' and 'z' are
+//important to keep the other sections lexically between these two dummy
+//variables.  Check your mapfile output if you need to fiddle with this stuff.
+const LOCK_IN_SECTION(A) int _ro_start = 0;
+const LOCK_IN_SECTION(zzzzzzzz) int _ro_end = 0;
+#endif
 static const LOCK_IN_SECTION(libs) luaL_reg LUA_LIBS[] = {
   {"",              luaopen_base},
   {LUA_LOADLIBNAME, luaopen_package},

--- a/app/lua/linit.c
+++ b/app/lua/linit.c
@@ -46,7 +46,7 @@ extern const luaR_entry  lua_rotable_base[];
 #define LUA_ROTABLES lua_rotable_core
 #define LUA_LIBS     lua_libs_core
 #endif
-             
+
 #ifdef _MSC_VER
 //MSVC requires us to declare these sections before we refer to them
 #pragma section(__ROSECNAME(A), read)

--- a/app/lua/lrotable.c
+++ b/app/lua/lrotable.c
@@ -9,7 +9,11 @@
 #include "lobject.h"
 #include "lapi.h"
 
+#ifdef _MSC_VER
+#define ALIGNED_STRING (__declspec( align( 4 ) ) char*)
+#else
 #define ALIGNED_STRING (__attribute__((aligned(4))) char *)
+#endif
 #define LA_LINES 16
 #define LA_SLOTS 4
 //#define COLLECT_STATS

--- a/app/lua/lrotable.h
+++ b/app/lua/lrotable.h
@@ -64,23 +64,21 @@ int luaR_isrotable(void *p);
  */
 #if defined(LUA_CROSS_COMPILER)
 
+#if defined(_MSC_VER)
+//msvc build uses these dummy vars to locate the beginning and ending addresses of the RO data
+extern cons char _ro_start[], _ro_end[];
+#define IN_RODATA_AREA(p) (((const char*)(p)) >= _ro_start && ((const char *)(p)) <= _ro_end)
+#else /* one of the POSIX variants */
 #if defined(__CYGWIN__)
 #define _RODATA_END __end__
+#elif defined(__MINGW32__)
+#define _RODATA_END end
 #else
 #define _RODATA_END _edata
 #endif
 extern const char _RODATA_END[];
 #define IN_RODATA_AREA(p) (((const char *)(p)) < _RODATA_END)
-
-#if defined(_MSC_VER)
-//msvc build uses dummy vars to locate the beginning and ending addresses of the RO data
-extern const int _ro_start;
-extern const int _ro_end;
-//and this is how we see if something is in the RO section
-#undef IN_RODATA_AREA
-#define IN_RODATA_AREA(p) (((const int*)(p)) >= &_ro_start && ((const int *)(p)) <= &_ro_end)
-#endif
-
+#endif /* defined(_MSC_VER) */
 
 #else  /* xtensa tool chain for ESP target */
 
@@ -88,7 +86,7 @@ extern const char _irom0_text_start[];
 extern const char _irom0_text_end[];
 #define IN_RODATA_AREA(p) (((const char *)(p)) >= _irom0_text_start && ((const char *)(p)) <= _irom0_text_end)
 
-#endif
+#endif /* defined(LUA_CROSS_COMPILER) */
 
 /* Return 1 if the given pointer is a rotable */
 #define luaR_isrotable(p) IN_RODATA_AREA(p)

--- a/app/lua/lrotable.h
+++ b/app/lua/lrotable.h
@@ -72,6 +72,16 @@ int luaR_isrotable(void *p);
 extern const char _RODATA_END[];
 #define IN_RODATA_AREA(p) (((const char *)(p)) < _RODATA_END)
 
+#if defined(_MSC_VER)
+//msvc build uses dummy vars to locate the beginning and ending addresses of the RO data
+extern const int _ro_start;
+extern const int _ro_end;
+//and this is how we see if something is in the RO section
+#undef IN_RODATA_AREA
+#define IN_RODATA_AREA(p) (((const int*)(p)) >= &_ro_start && ((const int *)(p)) <= &_ro_end)
+#endif
+
+
 #else  /* xtensa tool chain for ESP target */
 
 extern const char _irom0_text_start[];

--- a/app/lua/luac_cross/lflashimg.c
+++ b/app/lua/luac_cross/lflashimg.c
@@ -112,7 +112,11 @@ static uint *flashAddrTag = flashImage + LUA_MAX_FLASH_SIZE;
 #define getFlashAddrTag(v) ((flashAddrTag[_TW(v)]&_TB(v)) != 0)
 
 #define fatal luac_fatal
+#ifdef _MSC_VER
+extern void __declspec( noreturn ) luac_fatal( const char* message );
+#else
 extern void __attribute__((noreturn)) luac_fatal(const char* message);
+#endif
 
 #ifdef LOCAL_DEBUG
 #define DBG_PRINT(...) printf(__VA_ARGS__)

--- a/app/lua/luac_cross/luac.c
+++ b/app/lua/luac_cross/luac.c
@@ -168,6 +168,7 @@ static TString *corename(lua_State *L, const TString *filename)
 {
  const char *fn = getstr(filename)+1;
  const char *s = strrchr(fn, '/');
+ if (!s) s = strrchr(fn, '\\');
  s = s ? s + 1 : fn;
  while (*s == '.') s++;
  const char *e = strchr(s, '.');

--- a/app/lua/luac_cross/luac.c
+++ b/app/lua/luac_cross/luac.c
@@ -273,7 +273,7 @@ struct Smain {
  char** argv;
 };
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__MINGW32__)
 typedef unsigned int uint;
 #endif
 extern uint dumpToFlashImage (lua_State* L,const Proto *main, lua_Writer w,

--- a/app/lua/luac_cross/luac.c
+++ b/app/lua/luac_cross/luac.c
@@ -272,6 +272,9 @@ struct Smain {
  char** argv;
 };
 
+#ifdef _MSC_VER
+typedef unsigned int uint;
+#endif
 extern uint dumpToFlashImage (lua_State* L,const Proto *main, lua_Writer w,
                               void* data, int strip,
                               lu_int32 address, lu_int32 maxSize);

--- a/app/lua/luac_cross/mingw32-Makefile.mak
+++ b/app/lua/luac_cross/mingw32-Makefile.mak
@@ -1,0 +1,72 @@
+#
+# This is a minimal Make file designed to be called from within a MinGW Cmd prompt.
+# So if the distro ZIP file has been unpacked into C:\nodemcu-firmware then 
+#
+# C:\nodemcu-firmware\app\lua\luac_cross> mingw32-make -f mingw32-makefile.mak
+#
+# will create the WinX EXE luac.cross.exe within the root C:\nodemcu-firmware folder.
+# This make has been stripped down to use the basic non-graphics MinGW32 install and 
+# standard Windows commands available at the Cmd> prompt.  This make is quite separate
+# from the normal toolchain build.
+
+.NOTPARALLEL:
+
+CCFLAGS:= -I.. -I../../include -I../../libc -I../../uzlib -Wall
+LDFLAGS:= -lm -Wl,-Map=mapfile
+DEFINES += -DLUA_CROSS_COMPILER -DLUA_OPTIMIZE_MEMORY=2
+
+CFLAGS  = $(CCFLAGS) $(DEFINES)  $(EXTRA_CCFLAGS) $(STD_CFLAGS) $(INCLUDES)
+
+TARGET = host
+CC     := gcc
+
+ifeq ($(FLAVOR),debug)
+    CCFLAGS        += -O0 -g
+    TARGET_LDFLAGS += -O0 -g
+    DEFINES        += -DLUA_DEBUG_BUILD
+else
+    FLAVOR         =  release
+    CCFLAGS        += -O2
+    TARGET_LDFLAGS += -O2
+endif
+#
+# C files needed to compile luac.cross
+#
+LUACSRC := luac.c      lflashimg.c liolib.c    loslib.c    print.c
+LUASRC  := lapi.c      lauxlib.c   lbaselib.c  lcode.c     ldblib.c    ldebug.c \
+           ldo.c       ldump.c     lfunc.c     lgc.c       linit.c     llex.c \
+           lmathlib.c  lmem.c      loadlib.c   lobject.c   lopcodes.c  lparser.c \
+           lrotable.c  lstate.c    lstring.c   lstrlib.c   ltable.c    ltablib.c \
+           ltm.c       lundump.c   lvm.c       lzio.c
+LIBCSRC := c_stdlib.c
+UZSRC   := uzlib_deflate.c crc32.c
+#
+# This relies on the files being unique on the vpath
+#
+SRC      := $(LUACSRC) $(LUASRC) $(LIBCSRC) $(UZSRC)
+
+vpath %.c .:..:../../libc:../../uzlib
+
+INCS   := -I.. -I../.. -I../../libc -I../../uzlib
+ODIR   := .output\obj
+OBJS   := $(SRC:%.c=$(ODIR)/%.o)
+IMAGE  := ../../../luac.cross.exe
+
+.PHONY: test clean all
+
+all: $(DEPS) $(IMAGE)
+
+$(IMAGE) : $(OBJS)
+	$(CC) $(OBJS) -o $@ $(LDFLAGS)
+
+test :
+	@echo CC: $(CC)
+	@echo SRC: $(SRC)
+	@echo OBJS: $(OBJS)
+
+clean :
+	del /s /q $(ODIR)
+
+$(ODIR)/%.o: %.c
+	@mkdir $(ODIR) || echo .
+	$(CC) $(INCS)  $(CFLAGS) -o $@ -c $<

--- a/app/lua/luaconf.h
+++ b/app/lua/luaconf.h
@@ -40,7 +40,10 @@
 
 
 #if defined(LUA_CROSS_COMPILER)
+#ifdef _MSC_VER
+#else
 #define LUA_USE_LINUX
+#endif
 #endif
 
 #if defined(LUA_USE_LINUX)
@@ -264,7 +267,7 @@
 #include <io.h>
 #ifdef LUA_CROSS_COMPILER
 #include <stdio.h>
-else
+#else
 #include "c_stdio.h"
 #endif
 
@@ -631,7 +634,11 @@ extern int readline4lua(const char *prompt, char *buffer, int length);
   #define lua_str2number(s,p) c_strtoll((s), (p), 10)
   #endif // #if !defined LUA_INTEGRAL_LONGLONG
 #else
+#ifdef _MSC_VER	//what's wrong with stdlib strtod?
+#define lua_str2number(s,p)	strtod((s), (p))
+#else
 #define lua_str2number(s,p)	c_strtod((s), (p))
+#endif
 #endif // #if defined LUA_NUMBER_INTEGRAL
 
 /*

--- a/app/uzlib/uzlib.h
+++ b/app/uzlib/uzlib.h
@@ -27,7 +27,11 @@
 #include <stdint.h>
 #include <stdlib.h>
 extern int dbg_break(void);
+#ifdef _MSC_VER	//msvc requires old name for longjmp
+#define UZLIB_THROW(v) {dbg_break();longjmp(unwindAddr, (v));}
+#else
 #define UZLIB_THROW(v) {dbg_break();_longjmp(unwindAddr, (v));}
+#endif
 #define UZLIB_SETJMP _setjmp
 #define uz_malloc malloc
 #define uz_free free

--- a/app/uzlib/uzlib.h
+++ b/app/uzlib/uzlib.h
@@ -22,21 +22,24 @@
 #define uz_malloc os_malloc
 #define uz_free os_free
 
-#else  /* POSIX */
+#else  /* Host */
 
 #include <stdint.h>
 #include <stdlib.h>
+
 extern int dbg_break(void);
-#ifdef _MSC_VER	//msvc requires old name for longjmp
+#if defined(_MSC_VER) || defined(__MINGW32__) //msvc requires old name for longjmp
 #define UZLIB_THROW(v) {dbg_break();longjmp(unwindAddr, (v));}
+#define UZLIB_SETJMP(n) setjmp(n)
 #else
 #define UZLIB_THROW(v) {dbg_break();_longjmp(unwindAddr, (v));}
+#define UZLIB_SETJMP(n) _setjmp(n)
 #endif
-#define UZLIB_SETJMP _setjmp
+
 #define uz_malloc malloc
 #define uz_free free
 
-#endif
+#endif /* defined(__XTENSA__) */
 
 extern jmp_buf unwindAddr;
 

--- a/msvc/.gitignore
+++ b/msvc/.gitignore
@@ -1,0 +1,8 @@
+.vs/
+*/Win32/
+*/x64/
+
+*.vcxproj.user
+
+*.lua
+*.img

--- a/msvc/README.md
+++ b/msvc/README.md
@@ -1,0 +1,30 @@
+These are MSVC (Visual Studio 2017) project files for the host-side tools,
+namely 'luac.cross' and 'spiffsimg'.  Some may find these convenient if they
+already have MSVC instead of, say, setting up a Cygwin or MingW build
+system.
+
+To build 'luac.cross', you must first edit app/include/user_config.h to make
+some choices about the kind of cross-compiler you are generating.
+
+In particular, the definition of
+    LUA_FLASH_STORE
+should be enabled if you are creating a cross-compiler for generating images
+for the Lua File Storage (LFS).  The specific value of this define is not
+critical for luac.cross, but it's existence is if you want to be able to
+generate appropriate code for LFS.
+
+Be aware that the codebase, as checked in, has LUA_FLASH_STORE undefined.
+Since it is expected that most folks wanting a host-side luac.cross is
+for LFS use, you will want to first make sure that is changed to be
+defined.
+
+Secondly, if you are wanting to generate code that is appropriate for an
+integer-only build, you should ensure that
+    LUA_NUMBER_INTEGRAL
+is defined.
+
+After altering those settings, you can build using the hosttools.sln file in
+the Visual Studio UI, or directly on the command line.  x86 and x64 targets
+are provisioned, though there isn't anything to be gained with the 64-bit
+build.
+

--- a/msvc/hosttools.sln
+++ b/msvc/hosttools.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.168
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "luac-cross", "luac-cross\luac-cross.vcxproj", "{78A3411A-A18F-41A4-B4A7-D76B273F0E44}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{78A3411A-A18F-41A4-B4A7-D76B273F0E44}.Debug|x64.ActiveCfg = Debug|x64
+		{78A3411A-A18F-41A4-B4A7-D76B273F0E44}.Debug|x64.Build.0 = Debug|x64
+		{78A3411A-A18F-41A4-B4A7-D76B273F0E44}.Debug|x86.ActiveCfg = Debug|Win32
+		{78A3411A-A18F-41A4-B4A7-D76B273F0E44}.Debug|x86.Build.0 = Debug|Win32
+		{78A3411A-A18F-41A4-B4A7-D76B273F0E44}.Release|x64.ActiveCfg = Release|x64
+		{78A3411A-A18F-41A4-B4A7-D76B273F0E44}.Release|x64.Build.0 = Release|x64
+		{78A3411A-A18F-41A4-B4A7-D76B273F0E44}.Release|x86.ActiveCfg = Release|Win32
+		{78A3411A-A18F-41A4-B4A7-D76B273F0E44}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {FC69D912-B682-4325-8FBC-1A887364B511}
+	EndGlobalSection
+EndGlobal

--- a/msvc/luac-cross/luac-cross.vcxproj
+++ b/msvc/luac-cross/luac-cross.vcxproj
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{78A3411A-A18F-41A4-B4A7-D76B273F0E44}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>luaccross</RootNamespace>
+    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141_xp</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>luac.cross</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>luac.cross</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>luac.cross</TargetName>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(ProjectDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)$(Platform)\$(Configuration)\</IntDir>
+    <TargetName>luac.cross</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>LUA_CROSS_COMPILER;LUA_OPTIMIZE_MEMORY=2;_CRT_SECURE_NO_WARNINGS;_CONSOLE;LUA_DEBUG_BUILD;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\app\lua;$(ProjectDir)\..\..\app\libc;$(ProjectDir)\..\..\app\include;$(ProjectDir)\..\..\app\uzlib</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateMapFile>true</GenerateMapFile>
+      <AdditionalDependencies>setargv.obj;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>LUA_CROSS_COMPILER;LUA_OPTIMIZE_MEMORY=2;_CRT_SECURE_NO_WARNINGS;_CONSOLE;LUA_DEBUG_BUILD;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\app\lua;$(ProjectDir)\..\..\app\libc;$(ProjectDir)\..\..\app\include;$(ProjectDir)\..\..\app\uzlib</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateMapFile>true</GenerateMapFile>
+      <AdditionalDependencies>setargv.obj;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>LUA_CROSS_COMPILER;LUA_OPTIMIZE_MEMORY=2;_CRT_SECURE_NO_WARNINGS;_CONSOLE;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\app\lua;$(ProjectDir)\..\..\app\libc;$(ProjectDir)\..\..\app\include;$(ProjectDir)\..\..\app\uzlib</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateMapFile>true</GenerateMapFile>
+      <AdditionalDependencies>setargv.obj;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>LUA_CROSS_COMPILER;LUA_OPTIMIZE_MEMORY=2;_CRT_SECURE_NO_WARNINGS;_CONSOLE;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\..\app\lua;$(ProjectDir)\..\..\app\libc;$(ProjectDir)\..\..\app\include;$(ProjectDir)\..\..\app\uzlib</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateMapFile>true</GenerateMapFile>
+      <AdditionalDependencies>setargv.obj;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\app\lua\lapi.c" />
+    <ClCompile Include="..\..\app\lua\lauxlib.c" />
+    <ClCompile Include="..\..\app\lua\lbaselib.c" />
+    <ClCompile Include="..\..\app\lua\lcode.c" />
+    <ClCompile Include="..\..\app\lua\ldblib.c" />
+    <ClCompile Include="..\..\app\lua\ldebug.c" />
+    <ClCompile Include="..\..\app\lua\ldo.c" />
+    <ClCompile Include="..\..\app\lua\ldump.c" />
+    <ClCompile Include="..\..\app\lua\lfunc.c" />
+    <ClCompile Include="..\..\app\lua\lgc.c" />
+    <ClCompile Include="..\..\app\lua\linit.c" />
+    <ClCompile Include="..\..\app\lua\llex.c" />
+    <ClCompile Include="..\..\app\lua\lmathlib.c" />
+    <ClCompile Include="..\..\app\lua\lmem.c" />
+    <ClCompile Include="..\..\app\lua\loadlib.c" />
+    <ClCompile Include="..\..\app\lua\lobject.c" />
+    <ClCompile Include="..\..\app\lua\lopcodes.c" />
+    <ClCompile Include="..\..\app\lua\lparser.c" />
+    <ClCompile Include="..\..\app\lua\lrotable.c" />
+    <ClCompile Include="..\..\app\lua\lstate.c" />
+    <ClCompile Include="..\..\app\lua\lstring.c" />
+    <ClCompile Include="..\..\app\lua\lstrlib.c" />
+    <ClCompile Include="..\..\app\lua\ltable.c" />
+    <ClCompile Include="..\..\app\lua\ltablib.c" />
+    <ClCompile Include="..\..\app\lua\ltm.c" />
+    <ClCompile Include="..\..\app\lua\luac_cross\lflashimg.c" />
+    <ClCompile Include="..\..\app\lua\luac_cross\liolib.c" />
+    <ClCompile Include="..\..\app\lua\luac_cross\loslib.c" />
+    <ClCompile Include="..\..\app\lua\luac_cross\luac.c" />
+    <ClCompile Include="..\..\app\lua\luac_cross\print.c" />
+    <ClCompile Include="..\..\app\lua\lundump.c" />
+    <ClCompile Include="..\..\app\lua\lvm.c" />
+    <ClCompile Include="..\..\app\lua\lzio.c" />
+    <ClCompile Include="..\..\app\uzlib\crc32.c" />
+    <ClCompile Include="..\..\app\uzlib\uzlib_deflate.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\app\include\module.h" />
+    <ClInclude Include="..\..\app\include\user_config.h" />
+    <ClInclude Include="..\..\app\include\user_modules.h" />
+    <ClInclude Include="..\..\app\lua\lapi.h" />
+    <ClInclude Include="..\..\app\lua\lauxlib.h" />
+    <ClInclude Include="..\..\app\lua\lcode.h" />
+    <ClInclude Include="..\..\app\lua\ldebug.h" />
+    <ClInclude Include="..\..\app\lua\ldo.h" />
+    <ClInclude Include="..\..\app\lua\legc.h" />
+    <ClInclude Include="..\..\app\lua\lflash.h" />
+    <ClInclude Include="..\..\app\lua\lfunc.h" />
+    <ClInclude Include="..\..\app\lua\lgc.h" />
+    <ClInclude Include="..\..\app\lua\llex.h" />
+    <ClInclude Include="..\..\app\lua\llimits.h" />
+    <ClInclude Include="..\..\app\lua\lmem.h" />
+    <ClInclude Include="..\..\app\lua\lobject.h" />
+    <ClInclude Include="..\..\app\lua\lopcodes.h" />
+    <ClInclude Include="..\..\app\lua\lparser.h" />
+    <ClInclude Include="..\..\app\lua\lrodefs.h" />
+    <ClInclude Include="..\..\app\lua\lrotable.h" />
+    <ClInclude Include="..\..\app\lua\lstate.h" />
+    <ClInclude Include="..\..\app\lua\lstring.h" />
+    <ClInclude Include="..\..\app\lua\ltable.h" />
+    <ClInclude Include="..\..\app\lua\ltm.h" />
+    <ClInclude Include="..\..\app\lua\lua.h" />
+    <ClInclude Include="..\..\app\lua\luaconf.h" />
+    <ClInclude Include="..\..\app\lua\luac_cross.h" />
+    <ClInclude Include="..\..\app\lua\lualib.h" />
+    <ClInclude Include="..\..\app\lua\lundump.h" />
+    <ClInclude Include="..\..\app\lua\lvm.h" />
+    <ClInclude Include="..\..\app\lua\lzio.h" />
+    <ClInclude Include="..\..\app\uzlib\uzlib.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/msvc/luac-cross/luac-cross.vcxproj.filters
+++ b/msvc/luac-cross/luac-cross.vcxproj.filters
@@ -1,0 +1,237 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="app">
+      <UniqueIdentifier>{4d57c826-be1b-40a4-afb4-e4bd4a62ef06}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="app\lua">
+      <UniqueIdentifier>{4a6a3fe9-6e73-4ac0-a7c8-eb7cff0094cf}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="app\uzlib">
+      <UniqueIdentifier>{df9c7976-ea6e-497b-aa10-c94220b331ac}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="app\lua\luac_cross">
+      <UniqueIdentifier>{016730a9-1aa4-4f7b-a5cf-3e566e37f2b6}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="app\include">
+      <UniqueIdentifier>{439d70e8-0091-42d2-919f-7e710de3867c}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\app\uzlib\crc32.c">
+      <Filter>app\uzlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\uzlib\uzlib_deflate.c">
+      <Filter>app\uzlib</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\luac_cross\lflashimg.c">
+      <Filter>app\lua\luac_cross</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\luac_cross\liolib.c">
+      <Filter>app\lua\luac_cross</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\luac_cross\loslib.c">
+      <Filter>app\lua\luac_cross</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\luac_cross\luac.c">
+      <Filter>app\lua\luac_cross</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\luac_cross\print.c">
+      <Filter>app\lua\luac_cross</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lapi.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lauxlib.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lbaselib.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lcode.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\ldblib.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\ldebug.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\ldo.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\ldump.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lfunc.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lgc.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\linit.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\llex.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lmathlib.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lmem.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\loadlib.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lobject.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lopcodes.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lparser.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lrotable.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lstate.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lstring.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lstrlib.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\ltable.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\ltablib.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\ltm.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lundump.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lvm.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\app\lua\lzio.c">
+      <Filter>app\lua</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\app\uzlib\uzlib.h">
+      <Filter>app\uzlib</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lapi.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lauxlib.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lcode.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\ldebug.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\ldo.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lfunc.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lgc.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\llex.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\llimits.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lmem.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lobject.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lopcodes.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lparser.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lrodefs.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lrotable.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lstate.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lstring.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\ltable.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\ltm.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\luac_cross.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\luaconf.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lundump.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lvm.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lzio.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lua.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lualib.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\lflash.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\lua\legc.h">
+      <Filter>app\lua</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\include\module.h">
+      <Filter>app\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\include\user_config.h">
+      <Filter>app\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\app\include\user_modules.h">
+      <Filter>app\include</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
added MSVC project configuration for host-side tools.  modified code to also build with MSVC.  at present, only luac.cross.  later, spiffsimg.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`. ??? donde esta?

This minor enhancement provides support for building host-side tools with MSVC.  This is useful for folks who are on Windows, and who already have MSVC.  The host-side tools need to be native.  Most of the firmware build can be done via the online web service, but to use LFC, you must have luac.cross.

The major part of this change is just conditional compilation around toolchain-specific language extensions, such as __attribute() on gcc, and functional equivalents as __declspec() for MSVC.  There was a minor syntax error in luaconf.h that was masked by conditional compilation on gcc.  The rest are just adapting to a few peculiarities of the libc that comes with MSVC.

The spiffsimg tool is going to be more involved than I originally thought, and I feel that having luac.cross is sufficiently meritorious in itself to warrant considering accepting this PR's content independent of that.  Having a native luac.cross enables folks on Windows to enjoy the benefits of LFS -- even using the online build system since is has been extended to allow the creation of a LFS-enabled image.  (I'm not even sure why one needs spiffsimg at all, but I don't mind adapting it, too.  I will just do that as a separate exercise.)

Be aware that I made a couple arbitrary choices about this build configuration that may not meet your tastes:

1. I created a directory 'msvc' at the top-level of the source tree, and put all the msvc/devstudio specific stuff in there.  I don't mind moving it if you prefer it to be somewhere, but I had to put it somewhere for starters.

2. I let the output files be emitted to subdirectories of that project directory; 'Win32' for x86, and 'x64' for x64 builds, and Debug and Release under those.  This is in keeping with my personal practice, but if you would like the build target ('luac.cross.exe') to be emitted elsewhere, let me know.  I think the Linux build squirts it out in the root?

If you don't like these choices, let me know and I'll alter them accordingly.

Lastly, I suspect that there is little need to recompile luac.cross.  It might be useful to host the compiled binary for casually interested parties.  I have taken pains to ensure that the built binary is statically linked such that it will run as-is on everything XP and up -- no infernal runtime dll hell.  I don't know if nodemcu hosts built binaries.  Regardless, it will still be useful to have the build configuration in the repo so that folks can build themselves, or for maintenance reasons.

Cheers!