### PR TITLE
mqtt: print deprecation message regardless of autoreconnect value

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -1328,10 +1328,8 @@ static int mqtt_socket_connect( lua_State* L )
 
   if ( (stack<=top) && lua_isnumber(L, stack) )
   {
+    platform_print_deprecation_note("autoreconnect is deprecated", "in the next version");
     auto_reconnect = lua_tointeger(L, stack);
-    if ( auto_reconnect == RECONNECT_POSSIBLE ) {
-      platform_print_deprecation_note("autoreconnect == 1 is deprecated", "in the next version");
-    }
     stack++;
     if ( auto_reconnect != RECONNECT_OFF && auto_reconnect != RECONNECT_POSSIBLE ){
       auto_reconnect = RECONNECT_OFF; // default to 0


### PR DESCRIPTION
Step 1 of #2662.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

Print deprecation message when `autoreconnect` is provided regardless of its value.
