### PR TITLE
Set missing DATABITS_8 property

### DIFF
--- a/lua_compat/spi_compat.lua
+++ b/lua_compat/spi_compat.lua
@@ -97,7 +97,8 @@ return function (pin_sclk, pin_mosi, pin_miso, pin_cs)
   M.CPHA_HIGH = 1
   M.HALFDUPLEX = 0
   M.FULLDUPLEX = 1
-
+  M.DATABITS_8 = 8
+  
   _pin_sclk = pin_sclk
   _pin_mosi = pin_mosi
   _pin_miso = pin_miso


### PR DESCRIPTION
Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

It is necessary to have this DATABITS_8 property on the spi compat for pre-esp32 compatibiltity in e.g. necessary for code at https://github.com/nodemcu/nodemcu-firmware/blob/11592951b90707cdcb6d751876170bf4da82850d/docs/en/modules/ucg.md
