### PR TITLE
fixes #2677  minor syntax issues with some dummy variables that brack…

### DIFF
--- a/app/lua/linit.c
+++ b/app/lua/linit.c
@@ -58,8 +58,8 @@ extern const luaR_entry  lua_rotable_base[];
 //magic is used; the section names are lexically sorted, so 'a' and 'z' are
 //important to keep the other sections lexically between these two dummy
 //variables.  Check your mapfile output if you need to fiddle with this stuff.
-const LOCK_IN_SECTION(A) int _ro_start = 0;
-const LOCK_IN_SECTION(zzzzzzzz) int _ro_end = 0;
+const LOCK_IN_SECTION(A) char _ro_start[1] = {0};
+const LOCK_IN_SECTION(zzzzzzzz) char _ro_end[1] = {0};
 #endif
 static const LOCK_IN_SECTION(libs) luaL_reg LUA_LIBS[] = {
   {"",              luaopen_base},

--- a/app/lua/lrotable.h
+++ b/app/lua/lrotable.h
@@ -66,7 +66,7 @@ int luaR_isrotable(void *p);
 
 #if defined(_MSC_VER)
 //msvc build uses these dummy vars to locate the beginning and ending addresses of the RO data
-extern cons char _ro_start[], _ro_end[];
+extern const char _ro_start[], _ro_end[];
 #define IN_RODATA_AREA(p) (((const char*)(p)) >= _ro_start && ((const char *)(p)) <= _ro_end)
 #else /* one of the POSIX variants */
 #if defined(__CYGWIN__)


### PR DESCRIPTION
Fixes #2677 .

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines]- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

some minor syntax and intialization errors were introduced in the recently merged MSVC-specific modifications to lrotable.h and linit.c for supporting building luac.  This fixes those!
