### PR TITLE
DHT11 read sometimes failed with checksum error

### DIFF
--- a/app/dht/dht.c
+++ b/app/dht/dht.c
@@ -151,12 +151,12 @@ int dht_read11(uint8_t pin)
     }
 
     // CONVERT AND STORE
-    dht_humidity    = dht_bytes[0];  // dht_bytes[1] == 0;
-    dht_temperature = dht_bytes[2];  // dht_bytes[3] == 0;
+    dht_humidity = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[0], dht_bytes[1]) / 256.0;
+    dht_temperature = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[2], dht_bytes[3]) / 256.0;
 
     // TEST CHECKSUM
     // dht_bytes[1] && dht_bytes[3] both 0
-    uint8_t sum = dht_bytes[0] + dht_bytes[2];
+    uint8_t sum = dht_bytes[0] + dht_bytes[1] + dht_bytes[2] + dht_bytes[3];
     if (dht_bytes[4] != sum) return DHTLIB_ERROR_CHECKSUM;
 
     return DHTLIB_OK;

--- a/app/dht/dht.c
+++ b/app/dht/dht.c
@@ -151,8 +151,8 @@ int dht_read11(uint8_t pin)
     }
 
     // CONVERT AND STORE
-    dht_humidity = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[0], dht_bytes[1]) / 256.0;
-    dht_temperature = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[2], dht_bytes[3]) / 256.0;
+    dht_humidity    = dht_bytes[0];  // dht_bytes[1] == 0;
+    dht_temperature = dht_bytes[2];  // dht_bytes[3] == 0;
 
     // TEST CHECKSUM
     // dht_bytes[1] && dht_bytes[3] both 0


### PR DESCRIPTION
Follow-up to #2557.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/en/*`.

Rebase related PR onto current `dev` with elimination of trailing white space.
I can't test due to lack of respective DHT11 hardware which triggers the CRC error.
