### PR TITLE
hotfix: fix Makefile BAUDRATE default value for non-Windows OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ export summary := @echo
 MAKEFLAGS += --silent -w
 endif  # $(V)==1
 
+ifndef BAUDRATE
+	BAUDRATE=115200
+endif
 
 #############################################################
 # Select compile
@@ -81,9 +84,6 @@ ifeq ($(OS),Windows_NT)
 		ESPPORT = com1
 	else
 		ESPPORT = $(COMPORT)
-	endif
-	ifndef BAUDRATE
-		BAUDRATE=115200
 	endif
     ifeq ($(PROCESSOR_ARCHITECTURE),AMD64)
 # ->AMD64


### PR DESCRIPTION
This hotfix moves the new `BAUDRATE` variable in the Makefile to a common section of the Makefile so it is used by any OS.

`make flash` won't work in non-Windows until this is applied, unless `BAUDRATE` is defined.