### PR TITLE
Fix unaligned load/store exception in luaR_findentry

### DIFF
--- a/app/lua/lrotable.c
+++ b/app/lua/lrotable.c
@@ -86,6 +86,7 @@ const TValue* luaR_findentry(ROTable *rotable, TString *key, unsigned *ppos) {
   size_t      hash   = HASH(rotable, key);
   unsigned    i      = 0;
   int         j      = lookup_cache(hash, rotable);
+  unsigned    l      = key ? key->tsv.len : sizeof("__metatable")-1;
 
   if (pentry) {
     if (j >= 0){
@@ -101,9 +102,9 @@ const TValue* luaR_findentry(ROTable *rotable, TString *key, unsigned *ppos) {
      * aren't needed if there is a cache hit. Note that the termination null
      * is included so a "on\0" has a mask of 0xFFFFFF and "a\0" has 0xFFFF.
      */
-    unsigned name4 = *(unsigned *)strkey;
-    unsigned l     = key ? key->tsv.len : sizeof("__metatable")-1;
-    unsigned mask4 = l > 2 ? (~0u) : (~0u)>>((3-l)*8);
+    unsigned name4, mask4 = l > 2 ? (~0u) : (~0u)>>((3-l)*8);
+    c_memcpy(&name4, strkey, sizeof(name4));
+
     for(;pentry->key.type != LUA_TNIL; i++, pentry++) {
       if ((pentry->key.type == LUA_TSTRING) &&
           ((*(unsigned *)pentry->key.id.strkey ^ name4) & mask4) == 0 &&


### PR DESCRIPTION
Fixes #2701

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] No documentation changes required at `docs/en/*`.

Removes the possible unaligned fetch in `luaR_findentry()`

@marcelstoer, IMO we should add this to the current dev->master cut.