### PR TITLE
LFS: add ressources to LFS image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ sdk/
 cache/
 .ccache/
 local/
+luac.cross
+luac.cross.int
 user_config.h
 server-ca.crt
 luac.cross
@@ -14,3 +16,6 @@ tools/toolchains/
 .cproject
 .project
 .settings/
+
+#ignore VisualStudio files
+.vs/

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -753,6 +753,15 @@ typedef struct LoadR {
  int readstatus;
 } LoadR;
 
+static const char* basename(const char* filename)
+{
+ filename++;	// skip the @
+ const char *s = strrchr(filename, '/');
+ if (!s) s = strrchr(filename, '\\');
+ s = s ? s + 1 : filename;
+ while (*s == '.') s++;
+ return s;
+}
 
 static const char *getR(lua_State *L, void *ud, size_t *size) {
  LoadR *lf = (LoadR *)ud;
@@ -766,7 +775,7 @@ static const char *getR(lua_State *L, void *ud, size_t *size) {
   lf->filename = IS(lf->argv[lf->i], "-") ? NULL : lf->argv[lf->i];
 
   if (lf->filename == NULL) {
-   lua_pushliteral(L, "=stdin");
+   lf->filename = "=stdin";
    lf->f = c_stdin;
   }
   else {
@@ -790,7 +799,7 @@ static const char *getR(lua_State *L, void *ud, size_t *size) {
  if (lf->state == 11)
  {
   lf->state++;
-  char* pre = lf->filename;
+  char* pre = basename(lf->filename);
   *size = strlen(pre);
   return pre;
  }

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -44,7 +44,7 @@
 
 /* convert a stack index to positive */
 #define abs_index(L, i)		((i) > 0 || (i) <= LUA_REGISTRYINDEX ? (i) : \
-					lua_gettop(L) + (i) + 1)
+     lua_gettop(L) + (i) + 1)
 
 // Parameters for luaI_openlib
 #define LUA_USECCLOSURES          0
@@ -719,6 +719,8 @@ LUALIB_API void luaL_unref (lua_State *L, int t, int ref) {
 
 #ifdef LUA_CROSS_COMPILER
 
+#define IS(s,p) (strcmp(s,p)==0)
+
 typedef struct LoadF {
   int extraline;
   FILE *f;
@@ -727,58 +729,118 @@ typedef struct LoadF {
 
 
 static const char *getF(lua_State *L, void *ud, size_t *size) {
-	LoadF *lf = (LoadF *)ud;
-	(void)L;
-	if (lf->extraline) {
-		lf->extraline = 0;
-		*size = 1;
-		return "\n";
-	}
-	if (c_feof(lf->f)) return NULL;
-	*size = c_fread(lf->buff, 1, sizeof(lf->buff), lf->f);
-	return (*size > 0) ? lf->buff : NULL;
+ LoadF *lf = (LoadF *)ud;
+ (void)L;
+ if (lf->extraline) {
+  lf->extraline = 0;
+  *size = 1;
+  return "\n";
+ }
+ if (c_feof(lf->f)) return NULL;
+ *size = c_fread(lf->buff, 1, sizeof(lf->buff), lf->f);
+ return (*size > 0) ? lf->buff : NULL;
 }
 
 typedef struct LoadR {
-	FILE *f;
-	char buff[LUAL_BUFFERSIZE];
-	int state;
+ FILE *f;
+ char buff[LUAL_BUFFERSIZE];
+ int state;
+ int argc;
+ char** argv;
+ int i;
+ char* filename;
+ char* fileErrorMsg;
+ int readstatus;
 } LoadR;
 
 
 static const char *getR(lua_State *L, void *ud, size_t *size) {
-	LoadR *lf = (LoadR *)ud;
-	(void)L;
-	if (lf->state == 0)
-	{
-		lf->state++;
-		char* pre = "return [=====[";
-		*size = strlen(pre);
-		return pre;
-	}
+ LoadR *lf = (LoadR *)ud;
+ (void)L;
 
-	if (lf->state == 1)
-	{
-		if (!c_feof(lf->f))
-		{
-			*size = c_fread(lf->buff, 1, sizeof(lf->buff), lf->f);
-			if (*size > 0)
-			{
-				return lf->buff;
-			}
-		}
-		lf->state++;
-	}
+ if (lf->state == 0)
+ {
+  if (lf->i >= lf->argc)
+   return NULL;
 
-	if (lf->state == 2)
-	{
-		lf->state++;
-		char* post = "]=====]";
-		*size = strlen(post);
-		return post;
-	}
+  lf->filename = IS(lf->argv[lf->i], "-") ? NULL : lf->argv[lf->i];
 
-	return NULL;
+  if (lf->filename == NULL) {
+   lua_pushliteral(L, "=stdin");
+   lf->f = c_stdin;
+  }
+  else {
+   lf->f = c_fopen(lf->filename, "rb");
+   if (lf->f == NULL) {
+    lf->fileErrorMsg = "open";
+    return NULL; // abort parser
+   }
+  }
+  lf->state++;
+ }
+
+ if (lf->state == 1)
+ {
+  lf->state = 11;
+  char* pre = "if \"";
+  *size = strlen(pre);
+  return pre;
+ }
+
+ if (lf->state == 11)
+ {
+  lf->state++;
+  char* pre = lf->filename;
+  *size = strlen(pre);
+  return pre;
+ }
+
+ if (lf->state == 12)
+ {
+  lf->state = 2;
+  char* pre = "\"==... then return [=====[";
+  *size = strlen(pre);
+  return pre;
+ }
+
+ if (lf->state == 2)
+ {
+  if (!c_feof(lf->f))
+  {
+   *size = c_fread(lf->buff, 1, sizeof(lf->buff), lf->f);
+   if (*size > 0)
+   {
+    return lf->buff;
+   }
+  }
+  lf->state++;
+ }
+
+ if (lf->state == 3)
+ {
+  lf->state++;
+  char* post = "]=====] end ";
+  *size = strlen(post);
+  return post;
+ }
+
+
+ if (lf->state == 4)
+ {
+  int readstatus = c_ferror(lf->f);
+  if (lf->filename) c_fclose(lf->f);  /* close file (even in case of errors) */
+  if (readstatus) {
+   lf->fileErrorMsg = "read";
+   return NULL; // abort parser
+  }
+
+  lf->state = 0;
+  lf->i++;
+  *size = 1;
+  return " ";
+ }
+
+ return NULL;
 }
 
 
@@ -792,70 +854,69 @@ static int errfile (lua_State *L, const char *what, int fnameindex) {
 
 
 LUALIB_API int luaL_loadfile(lua_State *L, const char *filename) {
-	LoadF lf;
-	int status, readstatus;
-	int c;
-	int fnameindex = lua_gettop(L) + 1;  /* index of filename on the stack */
-	lf.extraline = 0;
-	if (filename == NULL) {
-		lua_pushliteral(L, "=stdin");
-		lf.f = c_stdin;
-	}
-	else {
-		lua_pushfstring(L, "@%s", filename);
-		lf.f = c_fopen(filename, "r");
-		if (lf.f == NULL) return errfile(L, "open", fnameindex);
-	}
-	c = c_getc(lf.f);
-	if (c == '#') {  /* Unix exec. file? */
-		lf.extraline = 1;
-		while ((c = c_getc(lf.f)) != EOF && c != '\n');  /* skip first line */
-		if (c == '\n') c = c_getc(lf.f);
-	}
-	if (c == LUA_SIGNATURE[0] && filename) {  /* binary file? */
-		lf.f = c_freopen(filename, "rb", lf.f);  /* reopen in binary mode */
-		if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
-		/* skip eventual `#!...' */
-		while ((c = c_getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) {}
+ LoadF lf;
+ int status, readstatus;
+ int c;
+ int fnameindex = lua_gettop(L) + 1;  /* index of filename on the stack */
+ lf.extraline = 0;
+ if (filename == NULL) {
+  lua_pushliteral(L, "=stdin");
+  lf.f = c_stdin;
+ }
+ else {
+  lua_pushfstring(L, "@%s", filename);
+  lf.f = c_fopen(filename, "r");
+  if (lf.f == NULL) return errfile(L, "open", fnameindex);
+ }
+ c = c_getc(lf.f);
+ if (c == '#') {  /* Unix exec. file? */
+  lf.extraline = 1;
+  while ((c = c_getc(lf.f)) != EOF && c != '\n');  /* skip first line */
+  if (c == '\n') c = c_getc(lf.f);
+ }
+ if (c == LUA_SIGNATURE[0] && filename) {  /* binary file? */
+  lf.f = c_freopen(filename, "rb", lf.f);  /* reopen in binary mode */
+  if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
+  /* skip eventual `#!...' */
+  while ((c = c_getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) {}
 
-		lf.extraline = 0;
-	}
-	c_ungetc(c, lf.f);
-	status = lua_load(L, getF, &lf, lua_tostring(L, -1));
-	readstatus = c_ferror(lf.f);
-	if (filename) c_fclose(lf.f);  /* close file (even in case of errors) */
-	if (readstatus) {
-		lua_settop(L, fnameindex);  /* ignore results from `lua_load' */
-		return errfile(L, "read", fnameindex);
-	}
-	lua_remove(L, fnameindex);
-	return status;
+  lf.extraline = 0;
+ }
+ c_ungetc(c, lf.f);
+ status = lua_load(L, getF, &lf, lua_tostring(L, -1));
+ readstatus = c_ferror(lf.f);
+ if (filename) c_fclose(lf.f);  /* close file (even in case of errors) */
+ if (readstatus) {
+  lua_settop(L, fnameindex);  /* ignore results from `lua_load' */
+  return errfile(L, "read", fnameindex);
+ }
+ lua_remove(L, fnameindex);
+ return status;
 }
 
 
-LUALIB_API int luaL_loadressourcefile(lua_State *L, const char *filename) {
-	LoadR lf;
-	int status, readstatus;
-	int fnameindex = lua_gettop(L) + 1;  /* index of filename on the stack */
-	if (filename == NULL) {
-		lua_pushliteral(L, "=stdin");
-		lf.f = c_stdin;
-	}
-	else {
-		lua_pushfstring(L, "@%s", filename);
-		lf.f = c_fopen(filename, "rb");
-		if (lf.f == NULL) return errfile(L, "open", fnameindex);
-	}
-	lf.state = 0;
-	status = lua_load(L, getR, &lf, lua_tostring(L, -1));
-	readstatus = c_ferror(lf.f);
-	if (filename) c_fclose(lf.f);  /* close file (even in case of errors) */
-	if (readstatus) {
-		lua_settop(L, fnameindex);  /* ignore results from `lua_load' */
-		return errfile(L, "read", fnameindex);
-	}
-	lua_remove(L, fnameindex);
-	return status;
+LUALIB_API int luaL_loadresourcefiles(lua_State *L, const int argc, const char** argv)
+{
+ LoadR lf;
+ lf.state = 0;
+ lf.i = 0;
+ lf.argc = argc;
+ lf.argv = argv;
+ lf.filename = NULL;
+ lf.fileErrorMsg = NULL;
+
+ int status;
+ int stackindex = lua_gettop(L);
+ lua_pushliteral(L, "@getresource");
+ status = lua_load(L, getR, &lf, lua_tostring(L, -1));
+
+ if (lf.fileErrorMsg != NULL) {
+  lua_settop(L, stackindex);  /* ignore results from `lua_load' */
+  lua_pushfstring(L, "@%s", lf.filename);
+  return errfile(L, lf.fileErrorMsg, stackindex +1);
+ }
+ lua_remove(L, stackindex+1);
+ return status;
 }
 
 #else

--- a/app/lua/luac_cross/lflashimg.c
+++ b/app/lua/luac_cross/lflashimg.c
@@ -125,7 +125,7 @@ extern void __attribute__((noreturn)) luac_fatal(const char* message);
 #endif
 
 /*
- *  Serial allocator.  Throw a luac-style out of memory error is allocaiton fails.
+ *  Serial allocator.  Throw a luac-style out of memory error if allocaiton fails.
  */
 static void *flashAlloc(lua_State* L, size_t n) {
   void *p = (void *)(flashImage + curOffset);

--- a/app/lua/luac_cross/luac.c
+++ b/app/lua/luac_cross/luac.c
@@ -286,6 +286,7 @@ static int pmain(lua_State* L)
  int argc=s->argc;
  char** argv=s->argv;
  const Proto* f;
+ int resourcecount = 0;
  int i;
  if (!lua_checkstack(L,argc)) fatal("too many input files");
  if (execute)
@@ -303,10 +304,24 @@ static int pmain(lua_State* L)
  }
  for (i=0; i<argc; i++)
  {
-  const char* filename=IS("-") ? NULL : argv[i];
-  if (luaL_loadfile(L,filename)!=0) fatal(lua_tostring(L,-1));
+  const char* filename = IS("-") ? NULL : argv[i];
+
+  if (IS("-r"))
+  {
+	  resourcecount++;
+  }
+  else
+  {
+	  if (resourcecount)
+	  {
+		  if (luaL_loadressourcefile(L, filename) != 0) fatal(lua_tostring(L, -1));
+	  }
+	  else {
+		  if (luaL_loadfile(L, filename) != 0) fatal(lua_tostring(L, -1));
+	  }
+  }
  }
- f=combine(L,argc + (execute ? 1: 0), lookup);
+ f=combine(L,argc - resourcecount + (execute ? 1: 0), lookup);
  if (listing) luaU_print(f,listing>1);
  if (dumping)
  {


### PR DESCRIPTION
Fixes #2691.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/en/*`.

This PR adds the possibility to store entire files as resources in LFS images

Added a switch -r which declares all files after it to be stored as resources
Use luac.cross like this
``luac.cross -f  start.lua -r res1.txt``

Access it like this:

``` lua
print(LFS.getresource("res1.txt"))
print(loadfile("getresource.lua")("res1.txt"))
```
