### PR TITLE
ESP32 precompiled toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ sdkconfig.old*
 build/
 app/
 components/*/.output/
+tools/toolchains
 
 #ignore Eclipse project files
 .cproject

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "toolchains"]
-	path = tools/toolchains
-	url = https://github.com/jmattsson/nodemcu-prebuilt-toolchains.git
 [submodule "sdk/esp32-esp-idf"]
 	path = sdk/esp32-esp-idf
 	url = https://github.com/espressif/esp-idf.git

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: | $(ESP32_GCC)
 %: | $(ESP32_GCC)
 	@echo Setting IDF_PATH and re-invoking...
 	@env IDF_PATH=$(IDF_PATH) PATH=$(PATH):$(ESP32_BIN) $(MAKE) -f $(THIS_MK_FILE) $@
-	@if [[ "$@" == "clean" ]]; then rm -rf $(THIS_DIR)/tools/toolchains/esp32-*; fi
+	@if test "$@" = "clean"; then rm -rf $(THIS_DIR)/tools/toolchains/esp32-*; fi
 
 $(ESP32_GCC): $(ESP32_TOOLCHAIN_DL)
 	@echo Uncompressing toolchain

--- a/Makefile
+++ b/Makefile
@@ -9,21 +9,26 @@ IDF_PATH=$(THIS_DIR)/sdk/esp32-esp-idf
 TOOLCHAIN_VERSION:=20181106.0
 PLATFORM:=linux-x86_64
 
-all: toolchain
-%: toolchain
+ESP32_BIN:=$(THIS_DIR)/tools/toolchains/esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION)/bin
+ESP32_GCC:=$(ESP32_BIN)/xtensa-esp32-elf-gcc
+ESP32_TOOLCHAIN_DL:=$(THIS_DIR)/cache/toolchain-esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz
+
+all: | $(ESP32_GCC)
+%: | $(ESP32_GCC)
 	@echo Setting IDF_PATH and re-invoking...
-	@env IDF_PATH=$(IDF_PATH) PATH=$(PATH):$(THIS_DIR)/tools/toolchains/esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION)/bin $(MAKE) -f $(THIS_MK_FILE) $@
+	@env IDF_PATH=$(IDF_PATH) PATH=$(PATH):$(ESP32_BIN) $(MAKE) -f $(THIS_MK_FILE) $@
+	@if [[ "$@" == "clean" ]]; then rm -rf $(THIS_DIR)/tools/toolchains/esp32-*; fi
 
-toolchain: $(THIS_DIR)/tools/toolchains/esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION)/bin/xtensa-esp32-elf-gcc
-	@echo Checking pre-compiled toolchain
+$(ESP32_GCC): $(ESP32_TOOLCHAIN_DL)
+	@echo Uncompressing toolchain
+	@mkdir -p $(THIS_DIR)/tools/toolchains/
+	@tar -xJf $< -C $(THIS_DIR)/tools/toolchains/
+	# the archive contains ro files
+	@chmod -R u+w $(THIS_DIR)/tools/toolchains/esp32-*
+	@touch $@
 
-$(THIS_DIR)/tools/toolchains/esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION)/bin/xtensa-esp32-elf-gcc: $(THIS_DIR)/cache/toolchain-esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz
-	mkdir -p $(THIS_DIR)/tools/toolchains/
-	tar -xJf $< -C $(THIS_DIR)/tools/toolchains/
-	touch $@
-
-$(THIS_DIR)/cache/toolchain-esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz:
-	mkdir -p $(THIS_DIR)/cache
+$(ESP32_TOOLCHAIN_DL):
+	@mkdir -p $(THIS_DIR)/cache
 	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused https://github.com/jmattsson/esp-toolchains/releases/download/$(PLATFORM)-$(TOOLCHAIN_VERSION)/toolchain-esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz -O $@ || { rm -f "$@"; exit 1; }
 
 else


### PR DESCRIPTION
Follow up to #2545.

- [x] This PR is for the `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

This is a first shot at aligning the `dev-esp32` branch to `dev`.
* toolchain submodule removed
* download and uncompress of pre-compiled *.xz release for esp32

Not sure whether the build service needs teaks.
