### PR TITLE
1st Tranch of SDK 3.0 follow up changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ else
   CCFLAGS += -O2
 endif
 
+
 # Handling of V=1/VERBOSE=1 flag
 #
 # if V=1, $(summary) does nothing
@@ -75,7 +76,16 @@ endif
 #  If any developers wish to develop, test and support alternative environments 
 #  then please raise a GitHub issue on this work.
 #
-ifeq (,$(findstring linux,$(MAKE_HOST)))
+
+ifndef $(OS)
+  ifneq (,$(findstring linux,$(MAKE_HOST)))
+    export OS := linux
+  else
+    export OS := windows
+  endif
+endif
+
+ifneq ($(OS),linux)
   #------------ BEGIN UNTESTED ------------ We are not under Linux, e.g.under windows.
 	ifeq ($(XTENSA_CORE),lx106)
 		# It is xcc
@@ -116,7 +126,7 @@ else
 
   UNAME_S := $(shell uname -s)
   UNAME_P := $(shell uname -p)
-  ifeq ($(MAKE_HOST),x86_64-pc-linux-gnu)
+  ifeq ($(OS),linux)
     ifndef TOOLCHAIN_ROOT
       TOOLCHAIN_VERSION = 20181106.0
       GCCTOOLCHAIN      = linux-x86_64-$(TOOLCHAIN_VERSION)
@@ -142,7 +152,6 @@ else
 	FIRMWAREDIR = ../bin/
   WGET = wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused
 endif
-#############################################################
 
 GITHUB_SDK       = https://github.com/espressif/ESP8266_NONOS_SDK
 GITHUB_ESPTOOL   = https://github.com/espressif/esptool
@@ -301,7 +310,6 @@ $(TOP_DIR)/cache/esptool/v$(ESPTOOL_VER).tar.gz:
 $(TOP_DIR)/sdk/.extracted-$(SDK_VER): $(TOP_DIR)/cache/$(SDK_FILE_VER).zip
 	mkdir -p "$(dir $@)"
 	$(summary) UNZIP $(patsubst $(TOP_DIR)/%,%,$<)
-	$(summary) HOST $(MAKE_HOST)
 	(cd "$(dir $@)" && \
 	 rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK-* && \
 	 unzip $(TOP_DIR)/cache/$(SDK_FILE_VER).zip \

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ endif
 .PHONY: toolchain
 
 sdk_extracted: $(TOP_DIR)/sdk/.extracted-$(SDK_VER)
-sdk_pruned: sdk_extracted $(TOP_DIR)/sdk/.pruned-$(SDK_VER)
+sdk_pruned: sdk_extracted toolchain $(TOP_DIR)/sdk/.pruned-$(SDK_VER)
 
 ifdef GITHUB_TOOLCHAIN
         TOOLCHAIN_ROOT := $(TOP_DIR)/tools/toolchains/esp8266-linux-x86_64-$(TOOLCHAIN_VERSION)
@@ -287,12 +287,6 @@ $(TOP_DIR)/cache/toolchain-esp8266-$(GCCTOOLCHAIN).tar.xz:
 else
 toolchain: $(ESPTOOL)
 endif
-#      TOOLCHAIN_VERSION = 20181106.0
-#      GCCTOOLCHAIN      = linux-x86_64-$(TOOLCHAIN_VERSION)
-#      TOOLCHAIN_ROOT    = $(TOP_DIR)/tools/toolchains/$(GCCTOOLCHAIN)
-#      GITHUB_TOOLCHAIN  = https://github.com/jmattsson/esp-toolchains
-#https://github.com/jmattsson/esp-toolchains/releases/download/linux-x86_64-20181106.0/toolchain-esp8266-linux-x86_64-20181106.0.tar.xz
-#https://github.com/jmattsson/esp-toolchains/releases/download/esp8266-linux-x86_64-20181106.0/toolchain-esp8266-linux-x86_64-20181106.0.tar.xz
 
 $(ESPTOOL): $(TOP_DIR)/cache/esptool/v$(ESPTOOL_VER).tar.gz
 	mkdir -p $(TOP_DIR)/tools/toolchains/
@@ -318,7 +312,7 @@ $(TOP_DIR)/sdk/.extracted-$(SDK_VER): $(TOP_DIR)/cache/$(SDK_FILE_VER).zip
 	mv $(dir $@)/$(SDK_ZIP_ROOT) $(dir $@)/esp_iot_sdk_v$(SDK_VER)
 	touch $@
 
-$(TOP_DIR)/sdk/.pruned-$(SDK_VER): $(TOOLCHAIN_ROOT)/bin
+$(TOP_DIR)/sdk/.pruned-$(SDK_VER):
 	rm -f $(SDK_DIR)/lib/liblwip.a $(SDK_DIR)/lib/libssl.a $(SDK_DIR)/lib/libmbedtls.a
 	$(summary) PRUNE libmain.a libc.a
 	echo $(PATH)

--- a/Makefile
+++ b/Makefile
@@ -269,7 +269,7 @@ sdk_extracted: $(TOP_DIR)/sdk/.extracted-$(SDK_VER)
 sdk_pruned: sdk_extracted toolchain $(TOP_DIR)/sdk/.pruned-$(SDK_VER)
 
 ifdef GITHUB_TOOLCHAIN
-        TOOLCHAIN_ROOT := $(TOP_DIR)/tools/toolchains/esp8266-linux-x86_64-$(TOOLCHAIN_VERSION)
+  TOOLCHAIN_ROOT := $(TOP_DIR)/tools/toolchains/esp8266-linux-x86_64-$(TOOLCHAIN_VERSION)
 
 toolchain: $(TOOLCHAIN_ROOT)/bin $(ESPTOOL)
 
@@ -301,6 +301,7 @@ $(TOP_DIR)/cache/esptool/v$(ESPTOOL_VER).tar.gz:
 $(TOP_DIR)/sdk/.extracted-$(SDK_VER): $(TOP_DIR)/cache/$(SDK_FILE_VER).zip
 	mkdir -p "$(dir $@)"
 	$(summary) UNZIP $(patsubst $(TOP_DIR)/%,%,$<)
+	$(summary) HOST $(MAKE_HOST)
 	(cd "$(dir $@)" && \
 	 rm -fr esp_iot_sdk_v$(SDK_VER) ESP8266_NONOS_SDK-* && \
 	 unzip $(TOP_DIR)/cache/$(SDK_FILE_VER).zip \

--- a/Makefile
+++ b/Makefile
@@ -78,14 +78,15 @@ endif
 #
 
 ifndef $(OS)
-  ifneq (,$(findstring linux,$(MAKE_HOST)))
-    export OS := linux
+  # Assume Windows if MAKE_HOST contains "indows" and Linux otherwise
+  ifneq (,$(findstring indows,$(MAKE_HOST)))
+    OS := windows
   else
-    export OS := windows
+    OS := linux
   endif
 endif
 
-ifneq ($(OS),linux)
+ifneq (,$(findstring indows,$(OS)))
   #------------ BEGIN UNTESTED ------------ We are not under Linux, e.g.under windows.
 	ifeq ($(XTENSA_CORE),lx106)
 		# It is xcc

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,8 @@ else
   ifeq ($(MAKE_HOST),x86_64-pc-linux-gnu)
     ifndef TOOLCHAIN_ROOT
       TOOLCHAIN_VERSION = 20181106.0
-      GCCTOOLCHAIN      = esp8266-linux-x86_64-$(TOOLCHAIN_VERSION)
-      TOOLCHAIN_ROOT    = $(TOP_DIR)/tools/toolchains/$(GCCTOOLCHAIN)
+      GCCTOOLCHAIN      = linux-x86_64-$(TOOLCHAIN_VERSION)
+      TOOLCHAIN_ROOT    = $(TOP_DIR)/tools/toolchains/esp8266-$(GCCTOOLCHAIN)
       GITHUB_TOOLCHAIN  = https://github.com/jmattsson/esp-toolchains
       export PATH:=$(PATH):$(TOOLCHAIN_ROOT)/bin
   	endif
@@ -271,15 +271,15 @@ sdk_pruned: sdk_extracted $(TOP_DIR)/sdk/.pruned-$(SDK_VER)
 ifdef GITHUB_TOOLCHAIN
         TOOLCHAIN_ROOT := $(TOP_DIR)/tools/toolchains/esp8266-linux-x86_64-$(TOOLCHAIN_VERSION)
 
-toolchain: $(TOOLCHAIN_ROOT)/bin/xtensa-lx106-elf-gcc $(ESPTOOL)
+toolchain: $(TOOLCHAIN_ROOT)/bin $(ESPTOOL)
 
-$(TOOLCHAIN_ROOT)/bin/xtensa-lx106-elf-gcc: $(TOP_DIR)/cache/toolchain-$(GCCTOOLCHAIN).tar.xz
+$(TOOLCHAIN_ROOT)/bin: $(TOP_DIR)/cache/toolchain-esp8266-$(GCCTOOLCHAIN).tar.xz
 	mkdir -p $(TOP_DIR)/tools/toolchains/
 	$(summary) EXTRACT $(patsubst $(TOP_DIR)/%,%,$<)
 	tar -xJf $< -C $(TOP_DIR)/tools/toolchains/
 	touch $@
 
-$(TOP_DIR)/cache/toolchain-$(GCCTOOLCHAIN).tar.xz:
+$(TOP_DIR)/cache/toolchain-esp8266-$(GCCTOOLCHAIN).tar.xz:
 	mkdir -p $(TOP_DIR)/cache
 	$(summary) WGET $(patsubst $(TOP_DIR)/%,%,$@)
 	$(WGET) $(GITHUB_TOOLCHAIN)/releases/download/$(GCCTOOLCHAIN)/toolchain-esp8266-$(GCCTOOLCHAIN).tar.xz -O $@ \
@@ -287,6 +287,12 @@ $(TOP_DIR)/cache/toolchain-$(GCCTOOLCHAIN).tar.xz:
 else
 toolchain: $(ESPTOOL)
 endif
+#      TOOLCHAIN_VERSION = 20181106.0
+#      GCCTOOLCHAIN      = linux-x86_64-$(TOOLCHAIN_VERSION)
+#      TOOLCHAIN_ROOT    = $(TOP_DIR)/tools/toolchains/$(GCCTOOLCHAIN)
+#      GITHUB_TOOLCHAIN  = https://github.com/jmattsson/esp-toolchains
+#https://github.com/jmattsson/esp-toolchains/releases/download/linux-x86_64-20181106.0/toolchain-esp8266-linux-x86_64-20181106.0.tar.xz
+#https://github.com/jmattsson/esp-toolchains/releases/download/esp8266-linux-x86_64-20181106.0/toolchain-esp8266-linux-x86_64-20181106.0.tar.xz
 
 $(ESPTOOL): $(TOP_DIR)/cache/esptool/v$(ESPTOOL_VER).tar.gz
 	mkdir -p $(TOP_DIR)/tools/toolchains/
@@ -312,7 +318,7 @@ $(TOP_DIR)/sdk/.extracted-$(SDK_VER): $(TOP_DIR)/cache/$(SDK_FILE_VER).zip
 	mv $(dir $@)/$(SDK_ZIP_ROOT) $(dir $@)/esp_iot_sdk_v$(SDK_VER)
 	touch $@
 
-$(TOP_DIR)/sdk/.pruned-$(SDK_VER):
+$(TOP_DIR)/sdk/.pruned-$(SDK_VER): $(TOOLCHAIN_ROOT)/bin
 	rm -f $(SDK_DIR)/lib/liblwip.a $(SDK_DIR)/lib/libssl.a $(SDK_DIR)/lib/libmbedtls.a
 	$(summary) PRUNE libmain.a libc.a
 	echo $(PATH)

--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -41,9 +41,12 @@
 
 // The Lua Flash Store (LFS) allows you to store Lua code in Flash memory and
 // the Lua VMS will execute this code directly from flash without needing any
-// RAM overhead.  Note that you should now configure LFS directly in the 
-// System Partition Table and not at build time.
+// RAM overhead.  You can now configure LFS directly in the System Partition 
+// Table insted of at compile time. However for backwards compatibility setting
+// LUA_FLASH_STORE defines the default partition size if the NodeMCU partition
+// tool is not used.
 
+//#define LUA_FLASH_STORE                   0x10000
 
 // By default Lua executes the file init.lua at start up.  The following
 // define allows you to replace this with an alternative startup.  Warning:
@@ -68,11 +71,14 @@
 // general, limiting the size of the FS only to what your application needs
 // gives the fastest start-up and imaging times.
 
-// Note that you should now configure SPIFFS size and position directly in the 
-// System Partition Table and not at build time.
+// You can now configure SPIFFS size and position directly in the System 
+// Partition Table.  However backwards compatibility SPIFFS_MAX_FILESYSTEM_SIZE
+// can be set and this defines the default SPIFFS partition size if the NodeMCU
+// partition tool is not used. The value (~0x0) means the maximum size remaining.
 
 #define BUILD_SPIFFS
 #define SPIFFS_CACHE 1          // Enable if you use you SPIFFS in R/W mode
+//#define SPIFFS_MAX_FILESYSTEM_SIZE 0x20000
 #define SPIFFS_MAX_OPEN_FILES 4 // maximum number of open files for SPIFFS
 #define FS_OBJ_NAME_LEN 31      // maximum length of a filename
 
@@ -211,9 +217,14 @@
 #define NODEMCU_SPIFFS0_PARTITION         6
 #define NODEMCU_SPIFFS1_PARTITION         7
 
-#define LUA_FLASH_STORE                   0x0
+#ifndef LUA_FLASH_STORE
+#  define LUA_FLASH_STORE                 0x0
+#endif
+
 #define SPIFFS_FIXED_LOCATION             0x0
-#define SPIFFS_MAX_FILESYSTEM_SIZE        (~0x0)
+#ifndef SPIFFS_MAX_FILESYSTEM_SIZE
+#  define SPIFFS_MAX_FILESYSTEM_SIZE      0xFFFFFFFF
+#endif
 //#define SPIFFS_SIZE_1M_BOUNDARY
 
 #define LUA_TASK_PRIO             USER_TASK_PRIO_0

--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -41,7 +41,7 @@
 
 // The Lua Flash Store (LFS) allows you to store Lua code in Flash memory and
 // the Lua VMS will execute this code directly from flash without needing any
-// RAM overhead.  You can now configure LFS directly in the System Partition 
+// RAM overhead.  You can now configure LFS directly in the System Partition
 // Table insted of at compile time. However for backwards compatibility setting
 // LUA_FLASH_STORE defines the default partition size if the NodeMCU partition
 // tool is not used.
@@ -71,7 +71,7 @@
 // general, limiting the size of the FS only to what your application needs
 // gives the fastest start-up and imaging times.
 
-// You can now configure SPIFFS size and position directly in the System 
+// You can now configure SPIFFS size and position directly in the System
 // Partition Table.  However backwards compatibility SPIFFS_MAX_FILESYSTEM_SIZE
 // can be set and this defines the default SPIFFS partition size if the NodeMCU
 // partition tool is not used. The value (~0x0) means the maximum size remaining.

--- a/app/include/user_modules.h
+++ b/app/include/user_modules.h
@@ -7,7 +7,7 @@
 // includes general purpose interface modules which require at most two GPIO pins.
 // See https://github.com/nodemcu/nodemcu-firmware/pull/1127 for discussions.
 // New modules should be disabled by default and added in alphabetical order.
-#define LUA_USE_MODULES_ADC
+//#define LUA_USE_MODULES_ADC
 //#define LUA_USE_MODULES_ADS1115
 //#define LUA_USE_MODULES_ADXL345
 //#define LUA_USE_MODULES_AM2320
@@ -21,22 +21,22 @@
 //#define LUA_USE_MODULES_COLOR_UTILS
 //#define LUA_USE_MODULES_CRON
 //#define LUA_USE_MODULES_CRYPTO
-#define LUA_USE_MODULES_DHT
+//#define LUA_USE_MODULES_DHT
 //#define LUA_USE_MODULES_ENCODER
 //#define LUA_USE_MODULES_ENDUSER_SETUP // USE_DNS in dhcpserver.h needs to be enabled for this module to work.
 #define LUA_USE_MODULES_FILE
-//#define LUA_USE_MODULES_GDBSTUB
-#define LUA_USE_MODULES_GPIO
+#define LUA_USE_MODULES_GDBSTUB
+//#define LUA_USE_MODULES_GPIO
 //#define LUA_USE_MODULES_GPIO_PULSE
 //#define LUA_USE_MODULES_HDC1080
 //#define LUA_USE_MODULES_HMC5883L
 //#define LUA_USE_MODULES_HTTP
 //#define LUA_USE_MODULES_HX711
-#define LUA_USE_MODULES_I2C
+//#define LUA_USE_MODULES_I2C
 //#define LUA_USE_MODULES_L3G4200D
 //#define LUA_USE_MODULES_MCP4725
 //#define LUA_USE_MODULES_MDNS
-#define LUA_USE_MODULES_MQTT
+//#define LUA_USE_MODULES_MQTT
 #define LUA_USE_MODULES_NET
 #define LUA_USE_MODULES_NODE
 #define LUA_USE_MODULES_OW
@@ -54,7 +54,7 @@
 //#define LUA_USE_MODULES_SJSON
 //#define LUA_USE_MODULES_SNTP
 //#define LUA_USE_MODULES_SOMFY
-#define LUA_USE_MODULES_SPI
+//#define LUA_USE_MODULES_SPI
 //#define LUA_USE_MODULES_SQLITE3
 //#define LUA_USE_MODULES_STRUCT
 //#define LUA_USE_MODULES_SWITEC

--- a/app/libc/c_string.h
+++ b/app/libc/c_string.h
@@ -15,6 +15,7 @@
 
 #define c_memcmp os_memcmp
 #define c_memcpy os_memcpy
+#define c_memmove os_memmove
 #define c_memset os_memset
 
 #define c_strcat os_strcat

--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -435,7 +435,7 @@ static int file_g_read( lua_State* L, int n, int16_t end_char, int fd )
     int nread   = vfs_read(fd, p, nwanted);
 
     if (nread == VFS_RES_ERR || nread == 0) {
-      lua_pushnil(L);     
+      lua_pushnil(L);
       return 1;
     }
 
@@ -495,19 +495,19 @@ static int file_readline( lua_State* L )
 static int file_getfile( lua_State* L )
 {
   // Warning this code C calls other file_* routines to avoid duplication code.  These
-  // use Lua stack addressing of arguments, so this does Lua stack maniplation to 
+  // use Lua stack addressing of arguments, so this does Lua stack maniplation to
   // align these
   int ret_cnt = 0;
   lua_settop(L ,1);
   // Stack [1] = FD
-  file_open(L); 
+  file_open(L);
   // Stack [1] = filename; [2] = FD or nil
   if (!lua_isnil(L, -1)) {
     lua_remove(L, 1);  // dump filename, so [1] = FD
     file_fd_ud *ud = (file_fd_ud *)luaL_checkudata(L, 1, "file.obj");
-    ret_cnt = file_g_read(L, LUAI_MAXINT32, EOF, ud->fd); 
-    // Stack [1] = FD; [2] = contents if ret_cnt = 1; 
-    file_close(L);     // leaves Stack unchanged if [1] = FD 
+    ret_cnt = file_g_read(L, LUAI_MAXINT32, EOF, ud->fd);
+    // Stack [1] = FD; [2] = contents if ret_cnt = 1;
+    file_close(L);     // leaves Stack unchanged if [1] = FD
     lua_remove(L, 1);  // Dump FD leaving contents as [1] / ToS
   }
   return ret_cnt;
@@ -557,23 +557,23 @@ static int file_writeline( lua_State* L )
 static int file_putfile( lua_State* L )
 {
   // Warning this code C calls other file_* routines to avoid duplication code.  These
-  // use Lua stack addressing of arguments, so this does Lua stack maniplation to 
+  // use Lua stack addressing of arguments, so this does Lua stack maniplation to
   // align these
   int ret_cnt = 0;
   lua_settop(L, 2);
   lua_pushvalue(L, 2); //dup contents onto the ToS [3]
   lua_pushliteral(L, "w+");
   lua_replace(L, 2);
-  // Stack [1] = filename; [2] "w+" [3] contents; 
-  file_open(L); 
-  // Stack [1] = filename; [2] "w+" [3] contents; [4] FD or nil 
+  // Stack [1] = filename; [2] "w+" [3] contents;
+  file_open(L);
+  // Stack [1] = filename; [2] "w+" [3] contents; [4] FD or nil
 
   if (!lua_isnil(L, -1)) {
     lua_remove(L, 2);  //dump "w+" attribute literal
     lua_replace(L, 1);
-    // Stack [1] = FD; [2] contents 
+    // Stack [1] = FD; [2] contents
     file_write(L);
-    // Stack [1] = FD; [2] contents; [3] result status 
+    // Stack [1] = FD; [2] contents; [3] result status
     lua_remove(L, 2);  //dump contents
     file_close(L);
     lua_remove(L, 1); // Dump FD leaving status as ToS

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -572,7 +572,7 @@ static int node_random (lua_State *L) {
 }
 
 #ifdef DEVELOPMENT_TOOLS
-// Lua: rec = node.readrcr(id) 
+// Lua: rec = node.readrcr(id)
 static int node_readrcr (lua_State *L) {
   int id  = luaL_checkinteger(L, 1);
   char *data;
@@ -581,7 +581,7 @@ static int node_readrcr (lua_State *L) {
   lua_pushlstring(L, data, n);
   return 1;
 }
-// Lua: n = node.writercr(id,rec) 
+// Lua: n = node.writercr(id,rec)
 static int node_writercr (lua_State *L) {
   int id = luaL_checkinteger(L, 1),l;
   const char *data = lua_tolstring(L, 2, &l);
@@ -601,17 +601,17 @@ static const LUA_REG_TYPE pt_map[] = {
   { LNILKEY, LNILVAL }
 };
 
-// Lua: ptinfo = node.getpartitiontable() 
+// Lua: ptinfo = node.getpartitiontable()
 static int node_getpartitiontable (lua_State *L) {
   uint32_t param[max_pt] = {0};
   param[lfs_size]    = platform_flash_get_partition(NODEMCU_LFS0_PARTITION, param + lfs_addr);
   param[spiffs_size] = platform_flash_get_partition(NODEMCU_SPIFFS0_PARTITION, param + spiffs_addr);
 
   lua_settop(L, 0);
-  lua_createtable (L, 0, max_pt);                   /* at index 1 */ 
+  lua_createtable (L, 0, max_pt);                   /* at index 1 */
   lua_pushrotable(L, (void*)pt_map);                /* at index 2 */
   lua_pushnil(L);                                   /* first key at index 3 */
-  while (lua_next(L, 2) != 0) {                     /* key at index 3, and v at index 4 */     
+  while (lua_next(L, 2) != 0) {                     /* key at index 3, and v at index 4 */
     lua_pushvalue(L, 3);                            /* dup key to index 5 */
     lua_pushinteger(L, param[lua_tointeger(L, 4)]); /* param [v] at index 6 */
     lua_rawset(L, 1);
@@ -639,7 +639,7 @@ static void delete_partition(partition_item_t *p, int n) {
 #define LFS_PARTITION    (SYSTEM_PARTITION_CUSTOMER_BEGIN + NODEMCU_LFS0_PARTITION)
 #define SPIFFS_PARTITION (SYSTEM_PARTITION_CUSTOMER_BEGIN + NODEMCU_SPIFFS0_PARTITION)
 
-// Lua: node.setpartitiontable(pt_settings) 
+// Lua: node.setpartitiontable(pt_settings)
 static int node_setpartitiontable (lua_State *L) {
   partition_item_t *rcr_pt = NULL, *pt;
   uint32_t flash_size = flash_rom_get_size_byte();
@@ -650,7 +650,7 @@ static int node_setpartitiontable (lua_State *L) {
 
   luaL_argcheck(L, lua_istable(L, 1), 1, "must be table");
   lua_settop(L, 1);
-  /* convert input table into 4 option array */ 
+  /* convert input table into 4 option array */
   lua_pushrotable(L, (void*)pt_map);  /* at index 2 */
   lua_pushnil(L);                   /* first key at index 3 */
   while (lua_next(L, 1) != 0) {
@@ -659,7 +659,7 @@ static int node_setpartitiontable (lua_State *L) {
     lua_pushvalue(L, 3);  /* dup key to index 5 */
     lua_rawget(L, 2);     /* lookup in pt_map */
     luaL_argcheck(L, !lua_isnil(L, -1), 1, "invalid partition setting");
-    param[lua_tointeger(L, 5)] = lua_tointeger(L, 4); 
+    param[lua_tointeger(L, 5)] = lua_tointeger(L, 4);
     /* removes 'value'; keeps 'key' for next iteration */
     lua_pop(L, 2);  /* discard value and lookup */
   }
@@ -701,11 +701,11 @@ static int node_setpartitiontable (lua_State *L) {
       }
       if (param[spiffs_size] != SKIP) {
         // BOTCH: - at the moment the firmware doesn't boot if the SPIFFS partition
-        //          is deleted so the minimum SPIFFS size is 64Kb   
+        //          is deleted so the minimum SPIFFS size is 64Kb
         p->size = param[spiffs_size] > 0x10000 ? param[spiffs_size] : 0x10000;
-      } 
+      }
       if (p->size == SKIP) {
-        if (p->addr < 0) { 
+        if (p->addr < 0) {
           // This allocate all the remaining flash to SPIFFS
           p->addr = last;
           p->size = flash_size - last;
@@ -722,20 +722,20 @@ static int node_setpartitiontable (lua_State *L) {
 
     if (p->size == 0) {
       // Delete 0-sized partitions as the SDK barfs on these
-      delete_partition(p, n-i-1);    
+      delete_partition(p, n-i-1);
       n--; i--;
     } else {
-      // Do consistency tests on the partition       
+      // Do consistency tests on the partition
       if (p->addr & (INTERNAL_FLASH_SECTOR_SIZE - 1) ||
         p->size & (INTERNAL_FLASH_SECTOR_SIZE - 1) ||
-        p->addr < last || 
+        p->addr < last ||
         p->addr + p->size > flash_size) {
         luaL_error(L, "value out of range");
       }
     }
   }
-//  for (i = 0; i < n; i ++) 
-//    dbg_printf("Partition %d: %04x %06x %06x\n", i, pt[i].type, pt[i].addr, pt[i].size);   
+//  for (i = 0; i < n; i ++)
+//    dbg_printf("Partition %d: %04x %06x %06x\n", i, pt[i].type, pt[i].addr, pt[i].size);
     platform_rcr_write(PLATFORM_RCR_PT, pt, n*sizeof(partition_item_t));
     while(1); // Trigger WDT; the new PT will be loaded on reboot
 

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -1,5 +1,4 @@
 // Module for interfacing with system
-
 #include "module.h"
 #include "lauxlib.h"
 
@@ -571,6 +570,7 @@ static int node_random (lua_State *L) {
   lua_pushnumber(L, node_random_range(l, u));  /* int between `l' and `u' */
   return 1;
 }
+
 #ifdef DEVELOPMENT_TOOLS
 // Lua: rec = node.readrcr(id) 
 static int node_readrcr (lua_State *L) {
@@ -590,6 +590,158 @@ static int node_writercr (lua_State *L) {
   return 1;
 }
 #endif
+
+typedef enum pt_t { lfs_addr=0, lfs_size, spiffs_addr, spiffs_size, max_pt} pt_t;
+
+static const LUA_REG_TYPE pt_map[] = {
+  { LSTRKEY( "lfs_addr" ),    LNUMVAL( lfs_addr ) },
+  { LSTRKEY( "lfs_size" ),    LNUMVAL( lfs_size ) },
+  { LSTRKEY( "spiffs_addr" ), LNUMVAL( spiffs_addr ) },
+  { LSTRKEY( "spiffs_size" ), LNUMVAL( spiffs_size ) },
+  { LNILKEY, LNILVAL }
+};
+
+// Lua: ptinfo = node.getpartitiontable() 
+static int node_getpartitiontable (lua_State *L) {
+  uint32_t param[max_pt] = {0};
+  param[lfs_size]    = platform_flash_get_partition(NODEMCU_LFS0_PARTITION, param + lfs_addr);
+  param[spiffs_size] = platform_flash_get_partition(NODEMCU_SPIFFS0_PARTITION, param + spiffs_addr);
+
+  lua_settop(L, 0);
+  lua_createtable (L, 0, max_pt);                   /* at index 1 */ 
+  lua_pushrotable(L, (void*)pt_map);                /* at index 2 */
+  lua_pushnil(L);                                   /* first key at index 3 */
+  while (lua_next(L, 2) != 0) {                     /* key at index 3, and v at index 4 */     
+    lua_pushvalue(L, 3);                            /* dup key to index 5 */
+    lua_pushinteger(L, param[lua_tointeger(L, 4)]); /* param [v] at index 6 */
+    lua_rawset(L, 1);
+    lua_pop(L, 1);                                  /* discard v */
+  }
+  lua_pop(L, 1);                                    /* discard pt_map reference */
+  return 1;
+}
+
+static void insert_partition(partition_item_t *p, int n, uint32_t type, uint32_t addr) {
+  if (n>0)
+    c_memmove(p+1, p, n*sizeof(partition_item_t)); /* overlapped so must be move not cpy */
+  p->type = type;
+  p->addr = addr;
+  p->size = 0;
+}
+
+static void delete_partition(partition_item_t *p, int n) {
+  if (n>0)
+    c_memmove(p, p+1, n*sizeof(partition_item_t)); /* overlapped so must be move not cpy */
+}
+
+#define SKIP (~0)
+#define IROM0_PARTITION  (SYSTEM_PARTITION_CUSTOMER_BEGIN + NODEMCU_IROM0TEXT_PARTITION)
+#define LFS_PARTITION    (SYSTEM_PARTITION_CUSTOMER_BEGIN + NODEMCU_LFS0_PARTITION)
+#define SPIFFS_PARTITION (SYSTEM_PARTITION_CUSTOMER_BEGIN + NODEMCU_SPIFFS0_PARTITION)
+
+// Lua: node.setpartitiontable(pt_settings) 
+static int node_setpartitiontable (lua_State *L) {
+  partition_item_t *rcr_pt = NULL, *pt;
+  uint32_t flash_size = flash_rom_get_size_byte();
+  uint32_t i = platform_rcr_read(PLATFORM_RCR_PT, (void **) &rcr_pt);
+  uint32_t last = 0;
+  uint32_t n = i / sizeof(partition_item_t);
+  uint32_t param[max_pt] = {SKIP, SKIP, SKIP, SKIP};
+
+  luaL_argcheck(L, lua_istable(L, 1), 1, "must be table");
+  lua_settop(L, 1);
+  /* convert input table into 4 option array */ 
+  lua_pushrotable(L, (void*)pt_map);  /* at index 2 */
+  lua_pushnil(L);                   /* first key at index 3 */
+  while (lua_next(L, 1) != 0) {
+    /* 'key' (at index 3) and 'value' (at index 4) */
+    luaL_argcheck(L, lua_isstring(L, 3) && lua_isnumber(L, 4), 1, "invalid partition setting");
+    lua_pushvalue(L, 3);  /* dup key to index 5 */
+    lua_rawget(L, 2);     /* lookup in pt_map */
+    luaL_argcheck(L, !lua_isnil(L, -1), 1, "invalid partition setting");
+    param[lua_tointeger(L, 5)] = lua_tointeger(L, 4); 
+    /* removes 'value'; keeps 'key' for next iteration */
+    lua_pop(L, 2);  /* discard value and lookup */
+  }
+ /*
+  * Allocate a scratch Partition Table as userdata on the Lua stack, and copy the
+  * current Flash PT into this for manipulation
+  */
+  lua_newuserdata(L, (n+2)*sizeof(partition_item_t));
+  pt = lua_touserdata (L, -1);
+  c_memcpy(pt, rcr_pt, n*sizeof(partition_item_t));
+  pt[n].type = 0; pt[n+1].type = 0;
+
+  for (i = 0; i < n; i ++) {
+    partition_item_t *p = pt + i;
+
+    if (p->type == IROM0_PARTITION && p[1].type != LFS_PARTITION) {
+      // if the LFS partition is not following IROM0 then slot a blank one in
+      insert_partition(p + 1, n-i-1, LFS_PARTITION, p->addr + p->size);
+      n++;
+
+    } else if (p->type == LFS_PARTITION) {
+      if (p[1].type != SPIFFS_PARTITION) {
+        // if the SPIFFS partition is not following LFS then slot a blank one in
+        insert_partition(p + 1, n-i-1, SPIFFS_PARTITION, 0);
+        n++;
+      }
+      // update the LFS options if set
+      if (param[lfs_addr] != SKIP) {
+        p->addr = param[lfs_addr];
+      }
+      if (param[lfs_size] != SKIP) {
+        p->size = param[lfs_size];
+      }
+    } else if (p->type == SPIFFS_PARTITION) {
+      // update the SPIFFS options if set
+      if (param[spiffs_addr] != SKIP) {
+        p->addr = param[spiffs_addr];
+        p->size = SKIP;
+      }
+      if (param[spiffs_size] != SKIP) {
+        // BOTCH: - at the moment the firmware doesn't boot if the SPIFFS partition
+        //          is deleted so the minimum SPIFFS size is 64Kb   
+        p->size = param[spiffs_size] > 0x10000 ? param[spiffs_size] : 0x10000;
+      } 
+      if (p->size == SKIP) {
+        if (p->addr < 0) { 
+          // This allocate all the remaining flash to SPIFFS
+          p->addr = last;
+          p->size = flash_size - last;
+        } else {
+          p->size = flash_size - p->addr;
+        }
+      } else if (/* size is specified && */ p->addr == 0) {
+        // if the is addr not specified then start SPIFFS at 1Mb
+        // boundary if the size will fit otherwise make it consecutive
+        // to the previous partition.
+        p->addr = (p->size <= flash_size - 0x100000) ? 0x100000 : last;
+      }
+    }
+
+    if (p->size == 0) {
+      // Delete 0-sized partitions as the SDK barfs on these
+      delete_partition(p, n-i-1);    
+      n--; i--;
+    } else {
+      // Do consistency tests on the partition       
+      if (p->addr & (INTERNAL_FLASH_SECTOR_SIZE - 1) ||
+        p->size & (INTERNAL_FLASH_SECTOR_SIZE - 1) ||
+        p->addr < last || 
+        p->addr + p->size > flash_size) {
+        luaL_error(L, "value out of range");
+      }
+    }
+  }
+//  for (i = 0; i < n; i ++) 
+//    dbg_printf("Partition %d: %04x %06x %06x\n", i, pt[i].type, pt[i].addr, pt[i].size);   
+    platform_rcr_write(PLATFORM_RCR_PT, pt, n*sizeof(partition_item_t));
+    while(1); // Trigger WDT; the new PT will be loaded on reboot
+
+  return 0;
+}
+
 
 // Module function map
 
@@ -650,6 +802,8 @@ static const LUA_REG_TYPE node_map[] =
 #ifdef DEVELOPMENT_TOOLS
   { LSTRKEY( "osprint" ), LFUNCVAL( node_osprint ) },
 #endif
+  { LSTRKEY( "getpartitiontable" ), LFUNCVAL( node_getpartitiontable ) },
+  { LSTRKEY( "setpartitiontable" ), LFUNCVAL( node_setpartitiontable ) },
 
 // Combined to dsleep(us, option)
 // { LSTRKEY( "dsleepsetoption" ), LFUNCVAL( node_deepsleep_setoption) },

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -571,7 +571,25 @@ static int node_random (lua_State *L) {
   lua_pushnumber(L, node_random_range(l, u));  /* int between `l' and `u' */
   return 1;
 }
-
+#ifdef DEVELOPMENT_TOOLS
+// Lua: rec = node.readrcr(id) 
+static int node_readrcr (lua_State *L) {
+  int id  = luaL_checkinteger(L, 1);
+  char *data;
+  int n = platform_rcr_read(id, (void **)&data);
+  if (n == ~0) return 0;
+  lua_pushlstring(L, data, n);
+  return 1;
+}
+// Lua: n = node.writercr(id,rec) 
+static int node_writercr (lua_State *L) {
+  int id = luaL_checkinteger(L, 1),l;
+  const char *data = lua_tolstring(L, 2, &l);
+  int n = platform_rcr_write(id, data, l);
+  lua_pushinteger(L, n);
+  return 1;
+}
+#endif
 
 // Module function map
 
@@ -605,6 +623,10 @@ static const LUA_REG_TYPE node_map[] =
   { LSTRKEY( "sleep" ), LFUNCVAL( node_sleep ) },
 #ifdef PMSLEEP_ENABLE
   PMSLEEP_INT_MAP,
+#endif
+#ifdef DEVELOPMENT_TOOLS
+  { LSTRKEY( "readrcr" ), LFUNCVAL( node_readrcr ) },
+  { LSTRKEY( "writercr" ), LFUNCVAL( node_writercr ) },
 #endif
   { LSTRKEY( "chipid" ), LFUNCVAL( node_chipid ) },
   { LSTRKEY( "flashid" ), LFUNCVAL( node_flashid ) },

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -903,10 +903,10 @@ uint32_t platform_s_flash_read( void *to, uint32_t fromaddr, uint32_t size )
     r = flash_read(fromaddr, to2, size2);
     if(SPI_FLASH_RESULT_OK == r)
     {
-      os_memmove(to,to2,size2);
+      c_memmove(to,to2,size2);  // This is overlapped so must be memmove and not memcpy
       char back[ INTERNAL_FLASH_READ_UNIT_SIZE ] __attribute__ ((aligned(INTERNAL_FLASH_READ_UNIT_SIZE)));
       r=flash_read(fromaddr+size2,(uint32*)back,INTERNAL_FLASH_READ_UNIT_SIZE);
-      os_memcpy((uint8_t*)to+size2,back,INTERNAL_FLASH_READ_UNIT_SIZE);
+      c_memcpy((uint8_t*)to+size2,back,INTERNAL_FLASH_READ_UNIT_SIZE);
     }
   }
   else
@@ -936,7 +936,7 @@ static uint32_t flash_map_meg_offset (void) {
   return m0 + m1;
 }
 
-uint32_t platform_flash_mapped2phys (uint32_t mapped_addr)  {
+uint32_t platform_flash_mapped2phys (uint32_t mapped_addr) {
   uint32_t meg = flash_map_meg_offset();
   return (meg&1) ? -1 : mapped_addr - INTERNAL_FLASH_MAPPED_ADDRESS + meg ;
 }
@@ -946,13 +946,134 @@ uint32_t platform_flash_phys2mapped (uint32_t phys_addr) {
   return (meg&1) ? -1 : phys_addr + INTERNAL_FLASH_MAPPED_ADDRESS - meg;
 }
 
-uint32_t platform_flash_get_partition (uint32_t part_id, uint32_t *addr)  {
+uint32_t platform_flash_get_partition (uint32_t part_id, uint32_t *addr) {
   partition_item_t pt = {0,0,0};
   system_partition_get_item(SYSTEM_PARTITION_CUSTOMER_BEGIN + part_id, &pt);
   if (addr) {
     *addr = pt.addr;
   }
   return  pt.type == 0 ? 0 : pt.size;
+}
+/*
+ * The Reboot Config Records are stored in the 4K flash page at offset 0x10000 (in
+ * the linker section .irom0.ptable) and is used for configuration changes that
+ * persist across reboots. This page contains a sequence of records, each of which
+ * is word-aligned and comprises a header and body of length 0-64 words.  The 4-byte
+ * header comprises a length, a RCR id, and two zero fill bytes.  These are written
+ * using flash NAND writing rules, so any unused area (all 0xFF) can be overwritten
+ * by a new record without needing to erase the RCR page.  Ditto any existing
+ * record can be marked as deleted by over-writing the header with the id set to
+ * PLATFORM_RCR_DELETED (0x0).  Note that the last word is not used additions so a
+ * scan for PLATFORM_RCR_FREE will always terminate.
+ *
+ * The number of updates is extremely low, so it is unlikely (but possible) that
+ * the page might fill with the churn of new RCRs, so in this case the write function
+ * compacts the page by eliminating all deleted records.  This does require a flash
+ * sector erase.
+ *
+ * NOTE THAT THIS ALGO ISN'T 100% ROBUST, eg. a powerfail between the erase and the
+ * wite-back will leave the page unitialised; ditto a powerfail between the record
+ * appned and old deletion will leave two records.  However this is better than the
+ * general integrity of SPIFFS, for example and the vulnerable window is typically
+ * less than 1 mSec every configuration change.
+ */
+extern uint32_t _irom0_text_start[];
+#define RCR_WORD(i) (_irom0_text_start[i])
+#define WORDSIZE sizeof(uint32_t)
+#define FLASH_SECTOR_WORDS (INTERNAL_FLASH_SECTOR_SIZE/WORDSIZE)
+
+uint32_t platform_rcr_read (uint8_t rec_id, void **rec) {
+//DEBUG os_printf("platform_rcr_read(%d,%08x)\n",rec_id,rec);
+    platform_rcr_t *rcr = (platform_rcr_t *) &RCR_WORD(0);
+    uint32_t i = 0;
+   /*
+    * Chain down the RCR page looking for a record that matches the record
+    * ID. If found return the size of the record and optionally its address.
+    */
+   while (1) {
+        // copy RCR header into RAM to avoid unaligned exceptions
+        platform_rcr_t r = (platform_rcr_t) RCR_WORD(i);
+        if (r.id == rec_id) {
+            if (rec) *rec = &RCR_WORD(i+1);
+            return r.len * WORDSIZE;
+        } else if (r.id == PLATFORM_RCR_FREE) {
+            break;
+        }
+        i += 1 + r.len;
+    }
+    return ~0;
+}
+
+/*
+ * Chain down the RCR page and look for an existing record that matches the record
+ * ID and the first free record.  If there is enough room, then append the new
+ * record and mark any previous record as deleted.  If the page is full then GC,
+ * erase the page and rewrite with the GCed content.
+ */
+#define MAXREC 65
+uint32_t platform_rcr_write (uint8_t rec_id, const void *inrec, uint8_t n) {
+    uint32_t nwords = (n+WORDSIZE-1) / WORDSIZE;
+    uint32_t reclen = (nwords+1)*WORDSIZE;
+    uint32_t *prev=NULL, *new = NULL;
+
+    // make local stack copy of inrec including header and any trailing fill bytes
+    uint32_t rec[MAXREC];
+    if (nwords >= MAXREC)
+        return ~0;
+    rec[0] = 0; rec[nwords] = 0;
+    ((platform_rcr_t *) rec)->id = rec_id;
+    ((platform_rcr_t *) rec)->len = nwords;
+    c_memcpy(rec+1, inrec, n);  // let memcpy handle 0 and odd byte cases
+
+    // find previous copy if any and exit if the replacement is the same value
+    uint8_t np = platform_rcr_read (rec_id, (void **) &prev);
+    if (prev && !os_memcmp(prev-1, rec, reclen))
+        return n;
+
+    // find next free slot
+    platform_rcr_read (PLATFORM_RCR_FREE, (void **) &new);
+    uint32_t nfree = &RCR_WORD(FLASH_SECTOR_WORDS) - new;
+
+    // Is there enough room to fit the rec in the RCR page?
+    if (nwords < nfree) {  // Note inequality needed to leave at least one all set word
+        uint32_t addr = platform_flash_mapped2phys((uint32_t)&new[-1]);
+        platform_s_flash_write(rec, addr, reclen);
+
+        if (prev) { // If a previous exists, then overwrite the hdr as DELETED
+            platform_rcr_t rcr = {0};
+            addr = platform_flash_mapped2phys((uint32_t)&prev[-1]);
+            rcr.id = PLATFORM_RCR_DELETED; rcr.len = np/WORDSIZE;
+            platform_s_flash_write(&rcr, addr, WORDSIZE);
+        }
+
+    } else {
+        platform_rcr_t *rcr = (platform_rcr_t *) &RCR_WORD(0), newrcr = {0};
+        uint32_t flash_addr = platform_flash_mapped2phys((uint32_t)&RCR_WORD(0));
+        uint32_t *buf, i, l, pass;
+
+        for (pass = 1; pass <= 2; pass++)  {
+            for (i = 0, l = 0; i < FLASH_SECTOR_WORDS - nfree; ) {
+                platform_rcr_t r = rcr[i]; // again avoid unaligned exceptions
+                if (r.id == PLATFORM_RCR_FREE)
+                    break;
+                if (r.id != PLATFORM_RCR_DELETED && r.id != rec_id) {
+                    if (pass == 2) memcpy(buf + l, rcr + i, (r.len + 1)*WORDSIZE);
+                    l += r.len + 1;
+                }
+                i += r.len + 1;
+            }
+            if (pass == 2) memcpy(buf + l, rec, reclen);
+            l += nwords + 1;
+            if (pass == 1) buf = c_malloc(l * WORDSIZE);
+
+            if (l >= FLASH_SECTOR_WORDS || !buf)
+                return ~0;
+        }
+        platform_flash_erase_sector(flash_addr/INTERNAL_FLASH_SECTOR_SIZE);
+        platform_s_flash_write(buf, flash_addr, l*WORDSIZE);
+        c_free(buf);
+    }
+    return nwords*WORDSIZE;
 }
 
 void* platform_print_deprecation_note( const char *msg, const char *time_frame)

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -292,13 +292,6 @@ uint32_t platform_flash_phys2mapped (uint32_t phys_addr);
 uint32_t platform_flash_get_partition (uint32_t part_id, uint32_t *addr);
 
 // *****************************************************************************
-// Allocator support
-
-void* platform_get_first_free_ram( unsigned id );
-void* platform_get_last_free_ram( unsigned id );
-
-
-// *****************************************************************************
 // Other glue
 
 int platform_ow_exists( unsigned id );
@@ -323,5 +316,41 @@ void* platform_print_deprecation_note( const char *msg, const char *time_frame);
 #define MOD_CHECK_RES_ID( mod, id, resmod, resid )\
   if( !platform_ ## mod ## _check_ ## resmod ## _id( id, resid ) )\
     return luaL_error( L, #resmod" %d not valid with " #mod " %d", ( unsigned )resid, ( unsigned )id )
+
+// *****************************************************************************
+// Reboot config page
+/*
+ * The 4K flash page in the linker section .irom0.ptable (offset 0x10000) is used 
+ * for configuration changes that persist across reboots. This 4k page contains a
+ * sequence of records that are written using flash NAND writing rules.  See the
+ * header app/spiffs/spiffs_nucleus.h for a discussion of how SPIFFS uses these. A
+ * similar technique is used here.
+ *
+ * Each record is word aligned and the first two bytes of the record are its size 
+ * and record type. Type 0xFF means unused and type 0x00 means deleted.  New 
+ * records can be added by overwriting the first unused slot.  Records can be 
+ * replaced by adding the new version, then setting the type of the previous version
+ * to deleted.  This all works and can be implemented with platform_s_flash_write()
+ * upto the 4K limit.
+ *
+ * If a new record cannot fit into the page then the deleted records are GCed by 
+ * copying the active records into a RAM scratch pad, erasing the page and writing 
+ * them back.  Yes, this is powerfail unsafe for a few mSec, but this is no worse 
+ * than writing to SPIFFS and won't even occur in normal production use.   
+ */
+#define IROM_PTABLE_ATTR          __attribute__((section(".irom0.ptable")))
+#define PLATFORM_PARTITION(n)  (SYSTEM_PARTITION_CUSTOMER_BEGIN + n)
+#define PLATFORM_RCR_DELETED   0x0
+#define PLATFORM_RCR_PT        0x1
+#define PLATFORM_RCR_PHY_DATA  0x2   
+#define PLATFORM_RCR_REFLASH   0x3
+#define PLATFORM_RCR_FREE      0xFF
+typedef union {
+    uint32_t hdr;
+    struct { uint8_t len,id; };
+} platform_rcr_t;
+
+uint32_t platform_rcr_read (uint8_t rec_id, void **rec);
+uint32_t platform_rcr_write (uint8_t rec_id, const void *rec, uint8_t size);
 
 #endif

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -66,7 +66,7 @@ extern const char _irom0_text_start[], _irom0_text_end[], _flash_used_end[];
 #define PTABLE_SIZE    7   /** THIS MUST BE MATCHED TO NO OF PT ENTRIES BELOW **/
 struct defaultpt {
   platform_rcr_t hdr;
-  partition_item_t pt[PTABLE_SIZE+1]; // the +! is for the endmarker 
+  partition_item_t pt[PTABLE_SIZE+1]; // the +! is for the endmarker
   };
 #define PT_LEN (NUM_PARTITIONS*sizeof(partition_item_t))
 /*
@@ -126,7 +126,7 @@ void user_pre_init(void) {
   // is where the cpu clock actually gets bumped to 80MHz.
     rtctime_early_startup ();
 #endif
-    partition_item_t *rcr_pt = NULL, *pt; 
+    partition_item_t *rcr_pt = NULL, *pt;
     enum flash_size_map fs_size_code = system_get_flash_size_map();
 // Flash size lookup is SIZE_256K*2^N where N is as follows (see SDK/user_interface.h)
                                      /*   0   1   2   3   4   5   6   7   8   9  */
@@ -151,7 +151,7 @@ void user_pre_init(void) {
     }
     os_memcpy(pt, rcr_pt, i);
 
-    if (pt[n-1].type == 0) {  
+    if (pt[n-1].type == 0) {
         // If the last PT entry is a {0,XX,0} end marker, then we need first time setup
         n = first_time_setup(pt, n-1, flash_size); // return n because setup might shrink the PT
     }
@@ -208,7 +208,7 @@ static uint32_t first_time_setup(partition_item_t *pt, uint32_t n, uint32_t flas
     /*
     * Scan down the PT adjusting and 0 entries to sensible defaults.  Also delete any
     * zero-sized partitions (as the SDK barfs on these).
-    */ 
+    */
     for (i = 0, j = 0; i < n; i ++) {
         partition_item_t *p = pt + i;
         switch (p->type) {
@@ -231,7 +231,7 @@ static uint32_t first_time_setup(partition_item_t *pt, uint32_t n, uint32_t flas
             break;
 
           case NODEMCU_PARTITION_SPIFFS:
-            if (p->size == ~0x0 && p->addr == 0) { 
+            if (p->size == ~0x0 && p->addr == 0) {
                 // This allocate all the remaining flash to SPIFFS
                 p->addr = last;
                 p->size = flash_size - last;
@@ -249,10 +249,10 @@ static uint32_t first_time_setup(partition_item_t *pt, uint32_t n, uint32_t flas
             // Delete 0-sized partitions as the SDK barfs on these
             newn--;
         } else {
-            // Do consistency tests on the partition       
+            // Do consistency tests on the partition
             if (p->addr & (INTERNAL_FLASH_SECTOR_SIZE - 1) ||
                 p->size & (INTERNAL_FLASH_SECTOR_SIZE - 1) ||
-                p->addr < last || 
+                p->addr < last ||
                 p->addr + p->size > flash_size) {
                 os_printf("Partition %u invalid alignment\n", i);
                 while(1) {/*system_soft_wdt_feed ();*/}

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -33,43 +33,66 @@ static task_handle_t input_sig;
 static uint8 input_sig_flag = 0;
 
 /* Contents of esp_init_data_default.bin */
-extern const uint32_t init_data[];
-extern const uint32_t init_data_end[];
+extern const uint32_t init_data[], init_data_end[];
+#define INIT_DATA_SIZE (init_data_end - init_data)
 __asm__(
   ".align 4\n"
   "init_data: .incbin \"" ESP_INIT_DATA_DEFAULT "\"\n"
   "init_data_end:\n"
 );
-extern const char _irom0_text_start[], _irom0_text_end[],_flash_used_end[];
+extern const char _irom0_text_start[], _irom0_text_end[], _flash_used_end[];
 #define IROM0_SIZE (_irom0_text_end - _irom0_text_start)
 
-#define INIT_DATA_SIZE (init_data_end - init_data)
 
 #define PRE_INIT_TEXT_ATTR        __attribute__((section(".p3.pre_init")))
 #define IROM_PTABLE_ATTR          __attribute__((section(".irom0.ptable")))
+#define USED_ATTR                 __attribute__((used))
 
 #define PARTITION(n)  (SYSTEM_PARTITION_CUSTOMER_BEGIN + n)
 
 #define SIZE_256K       0x00040000
 #define SIZE_1024K      0x00100000
+#define PT_CHUNK        0x00002000
+#define PT_ALIGN(n) ((n + (PT_CHUNK-1)) & (~((PT_CHUNK-1))))
 #define FLASH_BASE_ADDR ((char *) 0x40200000)
 
-//TODO: map the TLS server and client certs into NODEMCU_TLSCERT_PARTITION
-const partition_item_t partition_init_table[] IROM_PTABLE_ATTR = {
-    { PARTITION(NODEMCU_EAGLEROM_PARTITION),     0x00000,     0x0B000},
-    { SYSTEM_PARTITION_RF_CAL,                   0x0B000,      0x1000},
-    { SYSTEM_PARTITION_PHY_DATA,                 0x0C000,      0x1000},
-    { SYSTEM_PARTITION_SYSTEM_PARAMETER,         0x0D000,      0x3000},
-    { PARTITION(NODEMCU_IROM0TEXT_PARTITION),    0x10000,      0x0000},
-    { PARTITION(NODEMCU_LFS0_PARTITION),             0x0, LUA_FLASH_STORE},
-    { PARTITION(NODEMCU_SPIFFS0_PARTITION),          0x0, SPIFFS_MAX_FILESYSTEM_SIZE},
+#define NODEMCU_PARTITION_EAGLEROM  PLATFORM_PARTITION(NODEMCU_EAGLEROM_PARTITION)
+#define NODEMCU_PARTITION_IROM0TEXT PLATFORM_PARTITION(NODEMCU_IROM0TEXT_PARTITION)
+#define NODEMCU_PARTITION_LFS       PLATFORM_PARTITION(NODEMCU_LFS0_PARTITION)
+#define NODEMCU_PARTITION_SPIFFS    PLATFORM_PARTITION(NODEMCU_SPIFFS0_PARTITION)
+
+#define MAX_PARTITIONS 20
+#define WORDSIZE       sizeof(uint32_t)
+#define PTABLE_SIZE    7   /** THIS MUST BE MATCHED TO NO OF PT ENTRIES BELOW **/
+struct defaultpt {
+  platform_rcr_t hdr;
+  partition_item_t pt[PTABLE_SIZE+1]; // the +! is for the endmarker 
+  };
+#define PT_LEN (NUM_PARTITIONS*sizeof(partition_item_t))
+/*
+ * See app/platform/platform.h for how the platform reboot config records are used
+ * and these records are allocated.  The first record is a default partition table
+ * and this is statically declared in compilation below.
+ */
+static const struct defaultpt rompt IROM_PTABLE_ATTR USED_ATTR  = {
+  .hdr = {.len = sizeof(struct defaultpt)/WORDSIZE - 1,
+          .id  = PLATFORM_RCR_PT},
+  .pt  = {
+    { NODEMCU_PARTITION_EAGLEROM,         0x00000,     0x0B000},
+    { SYSTEM_PARTITION_RF_CAL,            0x0B000,      0x1000},
+    { SYSTEM_PARTITION_PHY_DATA,          0x0C000,      0x1000},
+    { SYSTEM_PARTITION_SYSTEM_PARAMETER,  0x0D000,      0x3000},
+    { NODEMCU_PARTITION_IROM0TEXT,        0x10000,      0x0000},
+    { NODEMCU_PARTITION_LFS,              0x0,          LUA_FLASH_STORE},
+    { NODEMCU_PARTITION_SPIFFS,           0x0,          SPIFFS_MAX_FILESYSTEM_SIZE},
     {0,(uint32_t) &_irom0_text_end,0}
+  }
 };
-// The following enum must maintain the partition table order
-enum partition {iram0=0, rf_call, phy_data, sys_parm, irom0, lfs, spiffs};
-#define PTABLE_SIZE ((sizeof(partition_init_table)/sizeof(partition_item_t))-1)
-#define PT_CHUNK 0x8000
-#define PT_ALIGN(n) ((n + (PT_CHUNK-1)) & (~((PT_CHUNK-1))))
+//TODO: map the TLS server and client certs into NODEMCU_TLSCERT_PARTITION
+
+static uint32_t first_time_setup(partition_item_t *pt, uint32_t n, uint32_t flash_size);
+static void phy_data_setup (partition_item_t *pt, uint32_t n);
+
 /*
  * The non-OS SDK prolog has been fundamentally revised in V3.  See SDK EN document
  * Partition Table.md for further discussion. This version of user_main.c is a
@@ -77,118 +100,174 @@ enum partition {iram0=0, rf_call, phy_data, sys_parm, irom0, lfs, spiffs};
  *
  * SDK V3 significantly reduces the RAM footprint required by the SDK and introduces
  * the use of a partition table (PT) to control flash allocation. The NodeMCU uses
- * this PT for overall allocation of its flash resources.  A constant copy PT is
- * maintained at the start of IROM0 (flash offset 0x10000) -- see partition_init_table
- * declaration above -- to facilitate its modification either in the firmware binary
- * or in the flash itself. This is Flash PT used during startup to create the live PT
- * in RAM that is used by the SDK.
+ * this PT for overall allocation of its flash resources. The non_OS SDK calls the
+ * user_pre_init() entry to do all of this startup configuration.  Note that this
+ * runs with Icache enabled -- that is the IROM0 partition is already mapped the
+ * address space at 0x40210000 and so that most SDK services are available, such
+ * as system_get_flash_size_map() which returns the valid flash size (including the
+ * 8Mb and 16Mb variants).
  *
- * Note that user_pre_init() runs with Icache enabled -- that is the IROM0 partition
- * is already mapped the address space at 0x40210000 and so that most SDK services
- * are available, such as system_get_flash_size_map() which returns the valid flash
- * size (including the 8Mb and 16Mb variants).
+ * The first 4K page of IROM0 (flash offset 0x10000) is used to maintain a set of
+ * Resource Communication Records (RCR) for inter-boot configuration using a NAND
+ * write-once algo (see app/platform/platform.h).  One of the current records is the
+ * SDK3.0 PT. This build statically compiles in an initial version at the start of
+ * the PT, with a {0, _irom0_text_end,0} marker as the last record and some fields
+ * also that need to be recomputed at runtime. This version is either replaced
+ * by first boot processing after provisioning, or by a node.setpartitiontable()
+ * API call. These replacement PTs are complete and can be passed directly for use
+ * by the non-OS SDK.
  *
- * We will be separately releasing a host PC-base python tool to configure the PT,
- * etc.,  but the following code will initialise the PT to sensible defaults even if
- * this tool isn't used.
+ * Note that we have released a host PC-base python tool, nodemcu-partition.py, to
+ * configure the PT, etc during provisioning.
  */
-static int setup_partition_table(partition_item_t *pt, uint32_t *n) {
-
-// Flash size lookup is SIZE_256K*2^N where N is as follows (see SDK/user_interface.h)
-    static char flash_size_scaler[] =
-  /*   0   1   2   3   4   5   6   7   8   9  */
-  /*  ½M  ¼M  1M  2M  4M  2M  4M  4M  8M 16M  */
-   "\001\000\002\003\004\003\004\004\005\006";
-    enum flash_size_map fs_size_code = system_get_flash_size_map();
-    uint32_t flash_size = SIZE_256K << flash_size_scaler[fs_size_code];
-    uint32_t first_free_flash_addr = partition_init_table[PTABLE_SIZE].addr
-                                     - (uint32_t) FLASH_BASE_ADDR;
-    int i,j;
-
-    os_memcpy(pt, partition_init_table, PTABLE_SIZE * sizeof(*pt));
-
-
-    if (flash_size < SIZE_1024K) {
-        os_printf("Flash size (%u) too small to support NodeMCU\n", flash_size);
-        return -1;
-    } else {
-        os_printf("system SPI FI size:%u, Flash size: %u\n", fs_size_code, flash_size );
-    }
-
-// Calculate the runtime sized partitions
-// The iram0, rf_call, phy_data, sys_parm partitions are as-is.
-    if (pt[irom0].size == 0) {
-        pt[irom0].size = first_free_flash_addr - pt[irom0].addr;
-    }
-    if (pt[lfs].addr == 0) {
-        pt[lfs].addr = PT_ALIGN(pt[irom0].addr + pt[irom0].size);
-        os_printf("LFS base: %08X\n", pt[lfs].addr);
-    }
-    if (pt[lfs].size == 0) {
-        pt[lfs].size = 0x10000;
-        os_printf("LFS size: %08X\n", pt[lfs].size);
-    }
-    if (pt[spiffs].addr == 0) {
-        pt[spiffs].addr = PT_ALIGN(pt[lfs].addr + pt[lfs].size);
-        os_printf("SPIFFS base: %08X\n", pt[spiffs].addr);
-    }
-
-    if (pt[spiffs].size == SPIFFS_MAX_FILESYSTEM_SIZE) {
-      pt[spiffs].size = flash_size - pt[spiffs].addr;
-        os_printf("SPIFFS size: %08X\n", pt[spiffs].size);
-    }
-
-//  Check that the phys data partition has been initialised and if not then do this
-//  now to prevent the SDK halting on a "rf_cal[0] !=0x05,is 0xFF" error.
-    uint32_t init_data_hdr = 0xffffffff, data_addr = pt[phy_data].addr;
-    int status = spi_flash_read(data_addr, &init_data_hdr, sizeof (uint32_t));
-    if (status == SPI_FLASH_RESULT_OK && *(char *)&init_data_hdr != 0x05) {
-        uint32_t idata[INIT_DATA_SIZE];
-        os_printf("Writing Init Data to 0x%08x\n",data_addr);
-        spi_flash_erase_sector(data_addr/SPI_FLASH_SEC_SIZE);
-        os_memcpy(idata, init_data, sizeof(idata));
-        spi_flash_write(data_addr, idata, sizeof(idata));
-        os_delay_us(1000);
-    }
-
-// Check partitions are page aligned and remove and any zero-length partitions.
-// This must be done last as this might break the enum partition ordering.
-    for (i = 0, j = 0; i < PTABLE_SIZE; i++) {
-        const partition_item_t *p = pt + i;
-        if ((p->addr| p->size) & (SPI_FLASH_SEC_SIZE-1)) {
-            os_printf("Partitions must be flash page aligned\n");
-            return -1;
-        }
-        if (p->size == 0)
-          continue;
-        if (j < i) {
-          pt[j] = *p;
-          p = pt + j;
-        }
-        os_printf("%2u: %08x %08x %08x\n", j, p->type, p->addr, p->size);
-        j++;
-    }
-
-    *n = j;
-    return fs_size_code;
-}
-
 void user_pre_init(void) {
 #ifdef LUA_USE_MODULES_RTCTIME
   // Note: Keep this as close to call_user_start() as possible, since it
   // is where the cpu clock actually gets bumped to 80MHz.
     rtctime_early_startup ();
 #endif
-    static partition_item_t pt[PTABLE_SIZE];
+    partition_item_t *rcr_pt = NULL, *pt; 
+    enum flash_size_map fs_size_code = system_get_flash_size_map();
+// Flash size lookup is SIZE_256K*2^N where N is as follows (see SDK/user_interface.h)
+                                     /*   0   1   2   3   4   5   6   7   8   9  */
+                                     /*  ½M  ¼M  1M  2M  4M  2M  4M  4M  8M 16M  */
+    static char flash_size_scaler[] = "\001\000\002\003\004\003\004\004\005\006";
+    uint32_t flash_size = SIZE_256K << flash_size_scaler[fs_size_code];
 
-    uint32_t pt_size;
-    uint32_t fs_size_code = setup_partition_table(pt, &pt_size);
-    if( fs_size_code > 0 && system_partition_table_regist(pt, pt_size, fs_size_code)) {
+    uint32_t i = platform_rcr_read(PLATFORM_RCR_PT, (void **) &rcr_pt);
+    uint32_t n = i / sizeof(partition_item_t);
+
+    if (flash_size < SIZE_1024K) {
+        os_printf("Flash size (%u) too small to support NodeMCU\n", flash_size);
+        return;
+    } else {
+        os_printf("system SPI FI size:%u, Flash size: %u\n", fs_size_code, flash_size );
+    }
+
+    pt = os_malloc(i);  // We will work on and register a RAM copy of the PT
+    // Return if anything is amiss; The SDK will halt if the PT hasn't been registered
+    if ( !rcr_pt || !pt || n * sizeof(partition_item_t) != i) {
         return;
     }
-    os_printf("system_partition_table_regist fail (%u)\n", fs_size_code);
-    while(1);
+    os_memcpy(pt, rcr_pt, i);
 
+    if (pt[n-1].type == 0) {  
+        // If the last PT entry is a {0,XX,0} end marker, then we need first time setup
+        n = first_time_setup(pt, n-1, flash_size); // return n because setup might shrink the PT
+    }
+
+    if (platform_rcr_read(PLATFORM_RCR_PHY_DATA, NULL)!=0) {
+        phy_data_setup(pt, n);
+    }
+
+    // Now register the partition and return
+//  for (i=0;i<n;i++) 
+//      os_printf("P%d: %3d %06x %06x\n", i, pt[i].type, pt[i].addr, pt[i].size);
+    if( fs_size_code > 1 && system_partition_table_regist(pt, n, fs_size_code)) {
+        return;
+    }
+    os_printf("Invalid system partition table\n");
+    while(1); // Trigger WDT}
+}
+
+/*
+ * If the PLATFORM_RCR_PT record doesn't exist then the PHY_DATA partition might
+ * not have been initialised.  This must be set to the proper default init data
+ * otherwise the SDK will halt on the "rf_cal[0] !=0x05,is 0xFF" error.
+ */
+static void phy_data_setup (partition_item_t *pt, uint32_t n) {
+    uint8_t  header[sizeof(uint32_t)] = {0};
+    int i;
+
+    for (i = 0; i < n; i++) {
+        if (pt[i].type == SYSTEM_PARTITION_PHY_DATA) {
+            uint32_t addr = pt[i].addr;
+            platform_s_flash_read(header, addr, sizeof(header));
+            if (header[0] != 0x05) {
+                uint32_t sector = pt[i].addr/INTERNAL_FLASH_SECTOR_SIZE;
+                if (platform_flash_erase_sector(sector) == PLATFORM_OK) {
+                    os_printf("Writing Init Data to 0x%08x\n",addr);
+                    platform_s_flash_write(init_data, addr, INIT_DATA_SIZE);
+                }
+            }
+            // flag setup complete so we don't retry this every boot
+            platform_rcr_write(PLATFORM_RCR_PHY_DATA, &addr, 0);
+            return;
+        }
+    }
+    // If the PHY_DATA doesn't exist or the write fails then the
+    // SDK will raise the rf_cal error anyway, so just return.
+}
+
+/*
+ * First time setup does the one-off PT calculations and checks.  If these are OK,
+ * then writes back a new RCR for the updated PT and triggers a reboot. It returns
+ * on failure.
+ */
+static uint32_t first_time_setup(partition_item_t *pt, uint32_t n, uint32_t flash_size) {
+    int i, j, last = 0, newn = n;
+    /*
+    * Scan down the PT adjusting and 0 entries to sensible defaults.  Also delete any
+    * zero-sized partitions (as the SDK barfs on these).
+    */ 
+    for (i = 0, j = 0; i < n; i ++) {
+        partition_item_t *p = pt + i;
+        switch (p->type) {
+
+          case NODEMCU_PARTITION_IROM0TEXT:
+            // If the IROM0 partition size is 0 then compute from the IROM0_SIZE. Note
+            // that the size in the end-marker is used by the nodemcu-partition.py
+            // script and not here.
+            if (p->size == 0) {
+                p->size = PT_ALIGN(IROM0_SIZE);
+            }
+            break;
+
+          case NODEMCU_PARTITION_LFS:
+            // Properly align the LFS partition size and make it consecutive to
+            // the previous partition.
+            p->size = PT_ALIGN(p->size);
+            if (p->addr == 0)
+                p->addr = last;
+            break;
+
+          case NODEMCU_PARTITION_SPIFFS:
+            if (p->size == ~0x0 && p->addr == 0) { 
+                // This allocate all the remaining flash to SPIFFS
+                p->addr = last;
+                p->size = flash_size - last;
+            } else if (p->size == ~0x0) {
+                p->size = flash_size - p->addr;
+           }  else if (p->addr == 0) {
+                // if the is addr not specified then start SPIFFS at 1Mb
+                // boundary if the size will fit otherwise make it consecutive
+                // to the previous partition.
+                p->addr = (p->size <= flash_size - 0x100000) ? 0x100000 : last;
+            }
+        }
+
+        if (p->size == 0) {
+            // Delete 0-sized partitions as the SDK barfs on these
+            newn--;
+        } else {
+            // Do consistency tests on the partition       
+            if (p->addr & (INTERNAL_FLASH_SECTOR_SIZE - 1) ||
+                p->size & (INTERNAL_FLASH_SECTOR_SIZE - 1) ||
+                p->addr < last || 
+                p->addr + p->size > flash_size) {
+                os_printf("Partition %u invalid alignment\n", i);
+                while(1) {/*system_soft_wdt_feed ();*/}
+            }
+            if (j < i)   // shift the partition down if we have any deleted slots
+                pt[j] = *p;
+//os_printf("Partition %d: %04x %06x %06x\n", j, p->type, p->addr, p->size);
+            j++;
+            last = p->addr + p->size;
+        }
+    }
+
+    platform_rcr_write(PLATFORM_RCR_PT, pt, newn*sizeof(partition_item_t));
+    while(1); // Trigger WDT; the new PT will be loaded on reboot
 }
 
 uint32 ICACHE_RAM_ATTR user_iram_memory_is_enabled(void) {
@@ -277,18 +356,18 @@ void user_init(void)
 #endif
     system_init_done_cb(nodemcu_init);
 }
-
+#if 0
 /*
  * The SDK now establishes exception handlers for EXCCAUSE errors: ILLEGAL,
  * INSTR_ERROR, LOAD_STORE_ERROR, PRIVILEGED, UNALIGNED, LOAD_PROHIBITED,
  * STORE_PROHIBITED.  These handlers are established in SDK/app_main.c.
  * LOAD_STORE_ERROR is handled by SDK/user_exceptions.o:load_non_32_wide_handler()
  * which is a fork of our version. The remaining are handled by a static function
- * at SDK:app+main.c:offset 0x0348.
- *
+ * at SDK:app+main.c:offset 0x0348.  This wrappoer is only needed for debugging.
+ */
 void __real__xtos_set_exception_handler (uint32_t cause, exception_handler_fn fn);
 void __wrap__xtos_set_exception_handler (uint32_t cause, exception_handler_fn fn) {
     os_printf("Exception handler %x  %x\n", cause, fn);
     __real__xtos_set_exception_handler (cause, fn);
 }
- */
+#endif

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -34,7 +34,7 @@ static uint8 input_sig_flag = 0;
 
 /* Contents of esp_init_data_default.bin */
 extern const uint32_t init_data[], init_data_end[];
-#define INIT_DATA_SIZE (init_data_end - init_data)
+#define INIT_DATA_SIZE ((init_data_end - init_data)*sizeof(uint32_t))
 __asm__(
   ".align 4\n"
   "init_data: .incbin \"" ESP_INIT_DATA_DEFAULT "\"\n"
@@ -161,8 +161,7 @@ void user_pre_init(void) {
     }
 
     // Now register the partition and return
-//  for (i=0;i<n;i++) 
-//      os_printf("P%d: %3d %06x %06x\n", i, pt[i].type, pt[i].addr, pt[i].size);
+// for (i=0;i<n;i++) os_printf("P%d: %3d %06x %06x\n", i, pt[i].type, pt[i].addr, pt[i].size);
     if( fs_size_code > 1 && system_partition_table_regist(pt, n, fs_size_code)) {
         return;
     }

--- a/docs/modules/node.md
+++ b/docs/modules/node.md
@@ -239,6 +239,24 @@ do
 end
 ```
 
+## node.getpartitiontable()
+
+Get the current LFS and SPIFFS partition information.
+
+#### Syntax
+`node.getpartitiontable()`
+
+#### Parameters
+none
+
+#### Returns
+An array containing entries for `lfs_addr`, `lfs_size`, `spiffs_addr` and `spiffs_size`. The address values are offsets relative to the startof the Flash memory.
+
+#### Example
+```lua
+print("The LFS size is " .. node.getpartitiontable().lfs_size)
+```
+
 ## node.heap()
 
 Returns the current available heap size in bytes. Note that due to fragmentation, actual allocations of this size may not be possible.
@@ -405,6 +423,31 @@ target CPU frequency (number)
 #### Example
 ```lua
 node.setcpufreq(node.CPU80MHZ)
+```
+
+## node.setpartitiontable()
+
+Sets the current LFS and / or SPIFFS partition information.
+
+#### Syntax
+`node.setpartitiontable(partition_info)`
+
+!!! note
+	This function is typically only used once during initial provisioning after first flashing the firmware.  It does some consistency checks to validate the specified parameters, and it then reboots the ESP module to load the new partition table. If the LFS or SPIFFS regions have changed then you will need to reload LFS, reformat the SPIFSS and reload its contents.
+
+#### Parameters
+An array containing one or more of the following enties. The address values are byte offsets relative to the startof the Flash memory. The size values are in bytes. Note that these parameters must be a multiple of 8Kb to align to Flash page boundaries.
+-  `lfs_addr`.  The base address of the LFS region.
+-  `lfs_size`.  The size of the LFS region.
+-  `spiffs_addr`. The base address of the SPIFFS region.
+-  `spiffs_size`. The size of the SPIFFS region.
+
+#### Returns
+Not applicable.  The ESP module will be rebooted for a valid new set, or a Lua error will be thown if inconsistencies are detected.
+
+#### Example
+```lua
+node.setpartitiontable{lfs_size = 0x20000, spiffs_addr = 0x120000, spiffs_size = 0x20000}
 ```
 
 

--- a/ld/nodemcu.ld
+++ b/ld/nodemcu.ld
@@ -233,7 +233,7 @@ SECTIONS
   .irom0.text : ALIGN(0x1000)
   {
     _irom0_text_start = ABSOLUTE(.);
-    *(.irom0.ptable)
+    KEEP(*(.irom0.ptable))
     . = ALIGN(0x1000);
     *(.servercert.flash)
     *(.clientcert.flash)


### PR DESCRIPTION
Fixes #2689

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have ~~thoroughly~~ tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This is a fairly large change, with a summary of the details below 
-  **`app/platform/platform.c`**. Add support for R/W of Reboot Config Records (RCRs) to store configuration changes that persist across reboots using flash NAND writing rules.  See inline comments for documentation. Flash erase is only carried out when GC of the RCR is required.  <br>&#x1F4D9; _Note: IMO, it would be well worthwhile using this API to store the TLS certificates._  
-  **`app/platform/platform.h`**. Header changes to support the above.
-  **`app/user/user_main.c`**. This declares a static initial partition table RCR.  A fairly major rework of the `user_pre_init()` code; this reads the current PT RTR and if this is the compiled one does calculation to work out the actual PT in RAM for the SDK to use.  It then writes this updated RCR back for use on subsequent boots, so this calculation is one-time only.  <br>Note that this is designed to interoperate with the `tools/nodemcu-partition.py` utility and the `node` API so that you can configure the LFS or SPIFFS partitions at compile time, over UART configuration, or at runtime.   
-  **`app/include/user_config.h`**. Following review feedback, I have changed this so that you can still set the compile-time default partition sizes for LFS and SPIFFS here. 
-  **`tools/nodemcu-partition.py`**. Supports simple configuration of the LFS or SPIFFS partitions and downloading of LFS and SPIFFS images via this script.  For example the following commands download a firmware image, then sets the LFS partition to 128KB and loads it with an LFS image over the UART:
```bash
  esptool -p /dev/ttyUSB0 -b 460800 --after no_reset write_flash \
    -fs 4MB --flash_mode=dio 0x00000  bin/0x00000.bin 0x10000 bin/0x10000.bin
  nodemcu-partition.py -ls 128K -lf bin/lfs.img
```
-  **`app/modules/node.c`**. Addition of `node.readrcr()` and `node.writercr()` if the macro DEVELOPMENT_TOOLS is defined.  <br> &#x1F534; Not documented since these functions are only available for development. <br> &#x1F534; the extra functions to query and to update the PT need to be added. 
-  **`app/libc/c_string.h`**. Minor change to add `c_memmove` mapping to `ets_memmove`.
-  **`ld/nodemcu.ld`**. Force KEEP() on the RCR page.


