### PR TITLE
ESP32: use xenial distribution for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
-sudo: required # due to manual install of make 4.1
-dist: trusty # due to the make 4.1 not installable on precise
+dist: xenial
 language: cpp
-# we need at least GNU Make 4.0, which isn't available in trusty, so grab it
-# manually from xenial
-before_install:
-- wget http://mirrors.kernel.org/ubuntu/pool/main/m/make-dfsg/make_4.1-6_amd64.deb
-- sudo dpkg -i make_4.1-6_amd64.deb
 addons:
   apt:
     packages:


### PR DESCRIPTION
Fixes upcoming travis switch to xenial.

- [x] This PR is for the `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

Adapted travis.yml file to use xenial.
Compared the travis logs before and after the change and found no relevant differences.
