### PR TITLE
Fix 2749 + restore correct user_modules.h

### DIFF
--- a/app/include/user_modules.h
+++ b/app/include/user_modules.h
@@ -7,7 +7,7 @@
 // includes general purpose interface modules which require at most two GPIO pins.
 // See https://github.com/nodemcu/nodemcu-firmware/pull/1127 for discussions.
 // New modules should be disabled by default and added in alphabetical order.
-//#define LUA_USE_MODULES_ADC
+#define LUA_USE_MODULES_ADC
 //#define LUA_USE_MODULES_ADS1115
 //#define LUA_USE_MODULES_ADXL345
 //#define LUA_USE_MODULES_AM2320
@@ -21,22 +21,22 @@
 //#define LUA_USE_MODULES_COLOR_UTILS
 //#define LUA_USE_MODULES_CRON
 //#define LUA_USE_MODULES_CRYPTO
-//#define LUA_USE_MODULES_DHT
+#define LUA_USE_MODULES_DHT
 //#define LUA_USE_MODULES_ENCODER
 //#define LUA_USE_MODULES_ENDUSER_SETUP // USE_DNS in dhcpserver.h needs to be enabled for this module to work.
 #define LUA_USE_MODULES_FILE
-#define LUA_USE_MODULES_GDBSTUB
-//#define LUA_USE_MODULES_GPIO
+//#define LUA_USE_MODULES_GDBSTUB
+#define LUA_USE_MODULES_GPIO
 //#define LUA_USE_MODULES_GPIO_PULSE
 //#define LUA_USE_MODULES_HDC1080
 //#define LUA_USE_MODULES_HMC5883L
 //#define LUA_USE_MODULES_HTTP
 //#define LUA_USE_MODULES_HX711
-//#define LUA_USE_MODULES_I2C
+#define LUA_USE_MODULES_I2C
 //#define LUA_USE_MODULES_L3G4200D
 //#define LUA_USE_MODULES_MCP4725
 //#define LUA_USE_MODULES_MDNS
-//#define LUA_USE_MODULES_MQTT
+#define LUA_USE_MODULES_MQTT
 #define LUA_USE_MODULES_NET
 #define LUA_USE_MODULES_NODE
 #define LUA_USE_MODULES_OW
@@ -54,7 +54,7 @@
 //#define LUA_USE_MODULES_SJSON
 //#define LUA_USE_MODULES_SNTP
 //#define LUA_USE_MODULES_SOMFY
-//#define LUA_USE_MODULES_SPI
+#define LUA_USE_MODULES_SPI
 //#define LUA_USE_MODULES_SQLITE3
 //#define LUA_USE_MODULES_STRUCT
 //#define LUA_USE_MODULES_SWITEC

--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -431,7 +431,7 @@ static int file_g_read( lua_State* L, int n, int16_t end_char, int fd )
   luaL_buffinit(L, &b);
 
   for (j = 0; j < n; j += sizeof(p)) {
-    int nwanted = (j <= n - sizeof(p)) ? sizeof(p) : n - j;
+    int nwanted = (n - j >= sizeof(p)) ? sizeof(p) : n - j;
     int nread   = vfs_read(fd, p, nwanted);
 
     if (nread == VFS_RES_ERR || nread == 0) {
@@ -456,7 +456,7 @@ static int file_g_read( lua_State* L, int n, int16_t end_char, int fd )
 }
 
 // Lua: read()
-// file.read() will read FILE_READ_CHUNK bytes, or EOF is reached.
+// file.read() will read FILE _CHUNK bytes, or EOF is reached.
 // file.read(10) will read 10 byte from file, or EOF is reached.
 // file.read('q') will read until 'q' or EOF is reached.
 static int file_read( lua_State* L )


### PR DESCRIPTION
Fixes #2749

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.


One-line fix  to issue, plus backing out incorrect replacement of `app/include/user_modules.h`
