### PR TITLE
Replaced obsolete static timers in lfs_fragments.lua (nodemcu #2764)

### DIFF
--- a/lua_examples/lfs/lfs_fragments.lua
+++ b/lua_examples/lfs/lfs_fragments.lua
@@ -56,8 +56,11 @@ if node.flashindex() == nil then
   node.flashreload('flash.img')
 end
 
-tmr.alarm(0, 1000, tmr.ALARM_SINGLE,
-  function()
-    local fi=node.flashindex; return pcall(fi and fi'_init')
-  end)
+local initTimer = tmr.create()
+initTimer:register(1000, tmr.ALARM_SINGLE,
+    function()
+        local fi=node.flashindex; return pcall(fi and fi'_init')
+    end
+    )
+initTimer:start()
 


### PR DESCRIPTION
Fixes #2764.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Replaces the obsolete static timers with dynamic ones.
