### PR TITLE
add serial method to table

### DIFF
--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -662,6 +662,22 @@ LUALIB_API void luaL_addvalue (luaL_Buffer *B) {
   }
 }
 
+LUALIB_API void luaL_addrawvalue (luaL_Buffer *B) {
+  lua_State *L = B->L;
+  unsigned char bytes = lua_tonumber(L, -1);
+
+  if (1 <= bufffree(B)) {  /* fit into buffer? */
+    *(B->p) = bytes & 0xff;
+    B->p ++;
+    lua_pop(L, 1);  /* remove from stack */
+  }
+  else {
+    if (emptybuffer(B))
+      lua_insert(L, -2);  /* put buffer before new value */
+    B->lvl++;  /* add new value into B stack */
+    adjuststack(B);
+  }
+}
 
 LUALIB_API void luaL_buffinit (lua_State *L, luaL_Buffer *B) {
   B->L = L;

--- a/app/lua/lauxlib.h
+++ b/app/lua/lauxlib.h
@@ -164,6 +164,7 @@ LUALIB_API char *(luaL_prepbuffer) (luaL_Buffer *B);
 LUALIB_API void (luaL_addlstring) (luaL_Buffer *B, const char *s, size_t l);
 LUALIB_API void (luaL_addstring) (luaL_Buffer *B, const char *s);
 LUALIB_API void (luaL_addvalue) (luaL_Buffer *B);
+LUALIB_API void (luaL_addrawvalue) (luaL_Buffer *B);
 LUALIB_API void (luaL_pushresult) (luaL_Buffer *B);
 
 


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

\<Description of and rationale behind this PR\>

I use lua function like this.
```
function ByteTableToString(t)
    local tt = {}
    for _,v in pairs(t) do 
        tt[#tt + 1] = string.char(v)
    end
    return table.concat(tt)
end
```
but it's too slow.
so I make a c one.
eg:
```
table.serial({0x41,0x42,0x43,0x44,"Hello",0x45})
ABCDHelloE
```
