### PR TITLE
Fix issue with ADS1115 module

### DIFF
--- a/app/modules/ads1115.c
+++ b/app/modules/ads1115.c
@@ -585,7 +585,7 @@ LROT_BEGIN(ads1115_instance)
 #ifdef ADS1115_INCLUDE_TEST_FUNCTION
   LROT_FUNCENTRY( test_volt_conversion, test_volt_conversion )
 #endif
-  LROT_TABENTRY( "__index", ads1115_instance )
+  LROT_TABENTRY( __index, ads1115_instance )
   LROT_FUNCENTRY( __gc, ads1115_lua_delete )
 LROT_END(ads1115_instance, ads1115_instance, LROT_MASK_GC_INDEX )
 

--- a/docs/modules/ads1115.md
+++ b/docs/modules/ads1115.md
@@ -125,7 +125,7 @@ adc1:setting(ads1115.GAIN_6_144V, ads1115.DR_128SPS, ads1115.SINGLE_0, ads1115.C
 local function comparator(level, when)
 	-- read adc result with read() when threshold reached
 	gpio.trig(alert_pin)
-	volt, volt_dec, adc, sign = ads1:read()
+	volt, volt_dec, adc, sign = adc1:read()
 	print(volt, volt_dec, adc, sign)
 end
 gpio.mode(alert_pin, gpio.INT)


### PR DESCRIPTION
Fixes #2753

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.

I was searching for similar bug in other modules but didn't find any and I don't really know why only in this module only `__index` value was converted incorrectly. I don't have an ADS1115 chip, so any tests would be appreciated.

EDIT:
Also added a fix in documentation mentioned in #2753 - it's small enough to go to this PR. 