### PR TITLE
Fix unref default file descriptor while still in use

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -126,15 +126,16 @@ static int file_close( lua_State* L )
     ud = (file_fd_ud *)luaL_checkudata(L, 1, "file.obj");
   }
 
-  // unref default file descriptor
-  luaL_unref( L, LUA_REGISTRYINDEX, file_fd_ref );
-  file_fd_ref = LUA_NOREF;
-
   if(ud->fd){
       vfs_close(ud->fd);
       // mark as closed
       ud->fd = 0;
   }
+
+  // unref default file descriptor
+  luaL_unref( L, LUA_REGISTRYINDEX, file_fd_ref );
+  file_fd_ref = LUA_NOREF;
+
   return 0;
 }
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

When executing `file.close()` for the basic model, the default file descriptor object is unreferenced even though it is still in use. This is opens up a potential race condition.

I discovered this issue on esp32 where the race recently resulted in a heap corruption. I never observed this on esp8266 - probably due to strictly sequential execution of events. This PR prevents the race condition in any case.
