### PR TITLE
Minor esp32 fixes

### DIFF
--- a/components/base_nodemcu/uart.c
+++ b/components/base_nodemcu/uart.c
@@ -20,9 +20,11 @@ bool uart_on_data_cb(unsigned id, const char *buf, size_t len){
   if(!gL)
     return false;
 
+  int top = lua_gettop(gL);
   lua_rawgeti(gL, LUA_REGISTRYINDEX, uart_status[id].receive_rf);
   lua_pushlstring(gL, buf, len);
   lua_pcall(gL, 1, 0, 0);
+  lua_settop(gL, top);
   return !run_input;
 }
 
@@ -34,9 +36,11 @@ bool uart_on_error_cb(unsigned id, const char *buf, size_t len){
   if(!gL)
     return false;
 
+  int top = lua_gettop(gL);
   lua_rawgeti(gL, LUA_REGISTRYINDEX, uart_status[id].error_rf);
   lua_pushlstring(gL, buf, len);
   lua_pcall(gL, 1, 0, 0);
+  lua_settop(gL, top);
   return true;
 }
 

--- a/components/task/task.c
+++ b/components/task/task.c
@@ -55,7 +55,7 @@ task_handle_t task_get_id(task_callback_t t) {
 }
 
 
-bool task_post (task_prio_t priority, task_handle_t handle, task_param_t param)
+bool IRAM_ATTR task_post (task_prio_t priority, task_handle_t handle, task_param_t param)
 {
   if (priority >= TASK_PRIORITY_COUNT ||
       (handle & TASK_HANDLE_MASK) != TASK_HANDLE_MONIKER)


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

Part A fixes the issue where a failed uart callback leaves an error message behind on the stack, which interferes with the interactive shell (and uses up a stack slot). This is a temporary fix and I expect it to be replaced by `luaN_call()` down the line once that's in-tree (assuming it does not keep the `lua_pcall()` mechanics, in which case this fix needs to stay).

Part B is simply moving the task_post() function into IRAM, which is where I meant it to have been all along (since it can be used by ISRs just fine).

Hardly worth requesting a review for, but...