### PR TITLE
Minor cleanup: removal of c_types.h, other c_prefix tidy-up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,9 @@ SDK_DIR          := $(TOP_DIR)/$(SDK_REL_DIR)
 ESPTOOL_VER := 2.6
 
 # Ensure that the Espresif SDK is searched before the tool-chain's SDK (if any)
-CCFLAGS:= -I$(TOP_DIR)/sdk-overrides/include -I$(TOP_DIR)/app/include/lwip/app -I$(SDK_DIR)/include
+# Also, prevent the SDK's c_types.h from being included from anywhere, by
+# predefining its include-guard.
+CCFLAGS:= -I$(TOP_DIR)/sdk-overrides/include -I$(TOP_DIR)/app/include/lwip/app -I$(SDK_DIR)/include -D_C_TYPES_H_
 LDFLAGS:= -L$(SDK_DIR)/lib -L$(SDK_DIR)/ld $(LDFLAGS)
 
 ifdef DEBUG

--- a/app/coap/coap_client.c
+++ b/app/coap/coap_client.c
@@ -1,5 +1,5 @@
 #include "user_config.h"
-#include "c_types.h"
+#include <stdint.h>
 
 #include "coap.h"
 #include "hash.h"

--- a/app/coap/coap_io.h
+++ b/app/coap/coap_io.h
@@ -5,7 +5,6 @@
 extern "C" {
 #endif
 
-#include "c_types.h"
 #include "lwip/ip_addr.h"
 #include "espconn.h"
 #include "pdu.h"

--- a/app/coap/coap_server.c
+++ b/app/coap/coap_server.c
@@ -1,5 +1,6 @@
 #include "user_config.h"
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
 #include <stdlib.h>
 
 #include "coap.h"

--- a/app/coap/str.c
+++ b/app/coap/str.c
@@ -7,7 +7,7 @@
  */
 
 #include <stdlib.h>
-#include "c_types.h"
+#include <stddef.h>
 
 #include "str.h"
 

--- a/app/crypto/digests.h
+++ b/app/crypto/digests.h
@@ -1,12 +1,13 @@
 #ifndef _CRYPTO_DIGESTS_H_
 #define _CRYPTO_DIGESTS_H_
 
-#include <c_types.h>
+#include <stdint.h>
+#include <stddef.h>
 
 typedef void (*create_ctx_fn)(void *ctx);
 typedef void (*update_ctx_fn)(void *ctx, const uint8_t *msg, int len);
 typedef void (*finalize_ctx_fn)(uint8_t *digest, void *ctx);
-typedef sint32_t ( *read_fn )(int fd, void *ptr, size_t len);
+typedef int32_t ( *read_fn )(int fd, void *ptr, size_t len);
 
 /**
  * Description of a message digest mechanism.

--- a/app/crypto/mech.h
+++ b/app/crypto/mech.h
@@ -1,7 +1,9 @@
 #ifndef _MECH_H_
 #define _MECH_H_
 
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
 
 typedef struct
 {

--- a/app/crypto/sha2.h
+++ b/app/crypto/sha2.h
@@ -1,7 +1,8 @@
 #ifndef __SHA2_H__
 #define __SHA2_H__
 
-#include <c_types.h>
+#include <stdint.h>
+#include <stddef.h>
 
 /**************************************************************************
  * SHA256/384/512 declarations

--- a/app/dht/dht.h
+++ b/app/dht/dht.h
@@ -17,7 +17,7 @@
 // #else
 // #include <Arduino.h>
 // #endif
-#include "c_types.h"
+#include <stdint.h>
 
 #define DHT_LIB_VERSION "0.1.14"
 

--- a/app/driver/pwm2.c
+++ b/app/driver/pwm2.c
@@ -5,8 +5,8 @@
  * Nikolay Fiykov
  */
 
-#include <stdlib.h>
-#include "c_types.h"
+#include <stddef.h>
+#include <stdint.h>
 #include "mem.h"
 #include "pin_map.h"
 #include "platform.h"

--- a/app/driver/readline.c
+++ b/app/driver/readline.c
@@ -2,7 +2,7 @@
 #include "os_type.h"
 #include "osapi.h"
 #include "driver/uart.h"
-#include "c_types.h"
+#include <stdint.h>
 
 LOCAL os_timer_t readline_timer;
 

--- a/app/driver/rotary.c
+++ b/app/driver/rotary.c
@@ -11,7 +11,7 @@
  */
 
 #include "platform.h"
-#include "c_types.h"
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include "driver/rotary.h"

--- a/app/driver/switec.c
+++ b/app/driver/switec.c
@@ -14,7 +14,8 @@
  */
 
 #include "platform.h"
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include "driver/switec.h"

--- a/app/esp-gdbstub/gdbstub.c
+++ b/app/esp-gdbstub/gdbstub.c
@@ -10,7 +10,6 @@
 #include "gdbstub.h"
 #include "ets_sys.h"
 #include "eagle_soc.h"
-#include "c_types.h"
 #include "gpio.h"
 #include "xtensa/corebits.h"
 #include "driver/uart.h"

--- a/app/include/arch/cc.h
+++ b/app/include/arch/cc.h
@@ -35,7 +35,7 @@
 #define __ARCH_CC_H__
 
 //#include <string.h>
-#include "c_types.h"
+#include <stdint.h>
 #include "ets_sys.h"
 #include "osapi.h"
 #define EFAULT 14

--- a/app/include/driver/onewire.h
+++ b/app/include/driver/onewire.h
@@ -1,7 +1,8 @@
 #ifndef __ONEWIRE_H__
 #define __ONEWIRE_H__
 
-#include "c_types.h"
+#include <stdint.h>
+#include <stdbool.h>
 
 // You can exclude certain features from OneWire.  In theory, this
 // might save some space.  In practice, the compiler automatically

--- a/app/include/driver/pwm2.h
+++ b/app/include/driver/pwm2.h
@@ -8,7 +8,7 @@
 #ifndef __PWM2_H__
 #define __PWM2_H__
 
-#include "c_types.h"
+#include <stdint.h>
 #include "pin_map.h"
 
 typedef struct {

--- a/app/include/driver/rotary.h
+++ b/app/include/driver/rotary.h
@@ -4,7 +4,7 @@
 #ifndef __ROTARY_H__
 #define __ROTARY_H__
 
-#include "c_types.h"
+#include <stdint.h>
 
 #define ROTARY_CHANNEL_COUNT	3
 

--- a/app/include/driver/switec.h
+++ b/app/include/driver/switec.h
@@ -4,7 +4,7 @@
 #ifndef __SWITEC_H__
 #define __SWITEC_H__
 
-#include "c_types.h"
+#include <stdint.h>
 
 #define SWITEC_CHANNEL_COUNT	3
 

--- a/app/include/driver/uart.h
+++ b/app/include/driver/uart.h
@@ -3,7 +3,7 @@
 
 #include "uart_register.h"
 #include "eagle_soc.h"
-#include "c_types.h"
+#include <stdint.h>
 #include "os_type.h"
 
 #define RX_BUFF_SIZE    0x100

--- a/app/include/lwip/app/espconn_buf.h
+++ b/app/include/lwip/app/espconn_buf.h
@@ -14,7 +14,8 @@
  *  Created on: Apr 22, 2016
  *      Author: liuhan
  */
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
 
 #include "ets_sys.h"
 #include "os_type.h"

--- a/app/include/pm/pmSleep.h
+++ b/app/include/pm/pmSleep.h
@@ -1,7 +1,7 @@
 #ifndef __FPM_SLEEP_H__
 #define __FPM_SLEEP_H__
 #include "user_interface.h"
-#include "c_types.h"
+#include <stdint.h>
 #include "lauxlib.h"
 #include "gpio.h"
 #include "platform.h"

--- a/app/include/rom.h
+++ b/app/include/rom.h
@@ -3,7 +3,7 @@
 #ifndef _ROM_H_
 #define _ROM_H_
 
-#include "c_types.h"
+#include <stdint.h>
 #include "ets_sys.h"
 
 // SHA1 is assumed to match the netbsd sha1.h headers

--- a/app/include/rtc/rtcaccess.h
+++ b/app/include/rtc/rtcaccess.h
@@ -1,7 +1,7 @@
 #ifndef RTC_ACCESS_H
 #define RTC_ACCESS_H
 
-#include <c_types.h>
+#include <stdint.h>
 
 #define RTC_MMIO_BASE 0x60000700
 #define RTC_USER_MEM_BASE 0x60001200

--- a/app/include/rtc/rtctime.h
+++ b/app/include/rtc/rtctime.h
@@ -38,7 +38,7 @@
  * relevant functions and expose these instead, through the rtctime.c module.
  */
 
-#include <c_types.h>
+#include <stdint.h>
 #include "sections.h"
 
 #ifndef _RTCTIME_INTERNAL_H_

--- a/app/include/user_mbedtls.h
+++ b/app/include/user_mbedtls.h
@@ -1,4 +1,5 @@
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
 
 #include "user_config.h"
 

--- a/app/libc/stdlib.c
+++ b/app/libc/stdlib.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
+#include <stdint.h>
 
 #ifdef LUA_CROSS_COMPILER
 #define ICACHE_RODATA_ATTR

--- a/app/lua/legc.c
+++ b/app/lua/legc.c
@@ -2,7 +2,6 @@
 
 #include "legc.h"
 #include "lstate.h"
-#include "c_types.h"
 
 void legc_set_mode(lua_State *L, int mode, int limit) {
    global_State *g = G(L);

--- a/app/lua/luac_cross.h
+++ b/app/lua/luac_cross.h
@@ -6,73 +6,14 @@
 #define luac_cross_h
 
 #ifdef LUA_CROSS_COMPILER
-
-#define C_HEADER_ASSERT <assert.h>
-#define C_HEADER_CTYPE <ctype.h>
-#define C_HEADER_ERRNO <errno.h>
-#define C_HEADER_FCNTL <fcntl.h>
-#define C_HEADER_LOCALE <locale.h>
-#define C_HEADER_MATH <math.h>
-#define C_HEADER_STDIO <stdio.h>
-#define C_HEADER_STDLIB <stdlib.h>
-#define C_HEADER_STRING <string.h>
-#define C_HEADER_TIME <time.h>
-
 #define ICACHE_RODATA_ATTR
 
-#define c_abs abs
-#define c_exit exit
-#define c_fclose fclose
-#define c_feof feof
-#define c_ferror ferror
-#define c_fopen fopen
-#define c_fread fread
-#define c_free free
-#define c_freopen freopen
-#define c_getc getc
-#define c_getenv getenv
-#define c_malloc malloc
-#define c_memcmp memcmp
-#define c_memcpy memcpy
-#define c_printf printf
-#define c_puts puts
-#define c_reader reader
-#define c_realloc realloc
-#define c_sprintf sprintf
 #define c_stderr stderr
 #define c_stdin stdin
 #define c_stdout stdout
-#define c_strcat strcat
-#define c_strchr strchr
-#define c_strcmp strcmp
-#define c_strcoll strcoll
-#define c_strcpy strcpy
-#define c_strcspn strcspn
-#define c_strerror strerror
-#define c_strlen strlen
-#define c_strncat strncat
-#define c_strncmp strncmp
-#define c_strncpy strncpy
-#define c_strpbrk strpbrk
-#define c_strrchr strrchr
-#define c_strstr strstr
-double	c_strtod(const char *__n, char **__end_PTR);
-#define c_ungetc ungetc
-#define c_strtol strtol
-#define c_strtoul strtoul
+
 #define dbg_printf printf
 #else
-
-#define C_HEADER_ASSERT "c_assert.h"
-#define C_HEADER_CTYPE "c_ctype.h"
-#define C_HEADER_ERRNO "c_errno.h"
-#define C_HEADER_FCNTL "c_fcntl.h"
-#define C_HEADER_LOCALE "c_locale.h"
-#define C_HEADER_MATH "c_math.h"
-#define C_HEADER_STDIO "c_stdio.h"
-#define C_HEADER_STDLIB "c_stdlib.h"
-#define C_HEADER_STRING "c_string.h"
-#define C_HEADER_TIME "c_time.h"
 
 #endif /* LUA_CROSS_COMPILER */
 #endif /* luac_cross_h */

--- a/app/lua/luac_cross/lflashimg.c
+++ b/app/lua/luac_cross/lflashimg.c
@@ -7,10 +7,10 @@
 #define LUAC_CROSS_FILE
 
 #include "luac_cross.h"
-#include C_HEADER_CTYPE
-#include C_HEADER_STDIO
-#include C_HEADER_STDLIB
-#include C_HEADER_STRING
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define lflashimg_c
 #define LUA_CORE

--- a/app/lua/luac_cross/loslib.c
+++ b/app/lua/luac_cross/loslib.c
@@ -7,11 +7,11 @@
 #define LUAC_CROSS_FILE
 
 #include "luac_cross.h"
-#include C_HEADER_ERRNO
-#include C_HEADER_LOCALE
-#include C_HEADER_STDLIB
-#include C_HEADER_STRING
-#include C_HEADER_TIME
+#include <errno.h>
+#include <locale.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #define loslib_c
 #define LUA_LIB
@@ -217,7 +217,7 @@ static int os_setlocale (lua_State *L) {
 
 
 static int os_exit (lua_State *L) {
-  c_exit(luaL_optint(L, 1, EXIT_SUCCESS));
+  exit(luaL_optint(L, 1, EXIT_SUCCESS));
 }
 
 LROT_PUBLIC_BEGIN(oslib)

--- a/app/lua/luac_cross/luac.c
+++ b/app/lua/luac_cross/luac.c
@@ -7,10 +7,10 @@
 #define LUAC_CROSS_FILE
 
 #include "luac_cross.h"
-#include C_HEADER_ERRNO
-#include C_HEADER_STDIO
-#include C_HEADER_STDLIB
-#include C_HEADER_STRING
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #define luac_c

--- a/app/lua/luac_cross/print.c
+++ b/app/lua/luac_cross/print.c
@@ -7,8 +7,8 @@
 #define LUAC_CROSS_FILE
 
 #include "luac_cross.h"
-#include C_HEADER_CTYPE
-#include C_HEADER_STDIO
+#include <ctype.h>
+#include <stdio.h>
 
 #define luac_c
 #define LUA_CORE

--- a/app/lwip/core/sys_arch.c
+++ b/app/lwip/core/sys_arch.c
@@ -2,7 +2,7 @@
  * copyright (c) 2010 - 2011 espressif system
  */
 
-#include "c_types.h"
+#include <stdint.h>
 #include "ets_sys.h"
 #include "osapi.h"
 #include "os_type.h"

--- a/app/mbedtls/app/Espconn_mem.c
+++ b/app/mbedtls/app/Espconn_mem.c
@@ -1,4 +1,4 @@
-#include "c_types.h"
+#include <stdint.h>
 #include "mem.h"
 #include "user_interface.h"
 

--- a/app/mbedtls/app/lwIPFile.c
+++ b/app/mbedtls/app/lwIPFile.c
@@ -22,7 +22,7 @@
  *
  */
 
-#include "c_types.h"
+#include <stdint.h>
 
 #include <stdio.h>
 //#include "os.h"

--- a/app/modules/adc.c
+++ b/app/modules/adc.c
@@ -4,7 +4,7 @@
 #include "lauxlib.h"
 #include "platform.h"
 
-#include "c_types.h"
+#include <stdint.h>
 #include "user_interface.h"
 
 // Lua: read(id) , return system adc

--- a/app/modules/bloom.c
+++ b/app/modules/bloom.c
@@ -7,7 +7,7 @@
 #include "module.h"
 #include "lauxlib.h"
 #include <string.h>
-#include "c_types.h"
+#include <stdint.h>
 #include "../crypto/sha2.h"
 
 #if defined(LUA_USE_MODULES_BLOOM) && !defined(SHA2_ENABLE)

--- a/app/modules/coap.c
+++ b/app/modules/coap.c
@@ -5,9 +5,9 @@
 #include "platform.h"
 
 #include <string.h>
-#include <stdlib.h>
+#include <stddef.h>
 
-#include "c_types.h"
+#include <stdint.h>
 #include "mem.h"
 #include "lwip/ip_addr.h"
 #include "espconn.h"

--- a/app/modules/cron.c
+++ b/app/modules/cron.c
@@ -4,12 +4,12 @@
 #include "lauxlib.h"
 #include "lmem.h"
 #include "user_interface.h"
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
 #include <string.h>
 #include "ets_sys.h"
 #include "time.h"
 #include "rtc/rtctime.h"
-#include "stdlib.h"
 #include "mem.h"
 
 struct cronent_desc {

--- a/app/modules/crypto.c
+++ b/app/modules/crypto.c
@@ -4,8 +4,8 @@
 #include "module.h"
 #include "lauxlib.h"
 #include "platform.h"
-#include "c_types.h"
-#include <stdlib.h>
+#include <stdint.h>
+#include <stddef.h>
 #include "vfs.h"
 #include "../crypto/digests.h"
 #include "../crypto/mech.h"

--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -5,7 +5,7 @@
 #include "lmem.h"
 #include "platform.h"
 
-#include "c_types.h"
+#include <stdint.h>
 #include "vfs.h"
 #include <string.h>
 

--- a/app/modules/gdbstub.c
+++ b/app/modules/gdbstub.c
@@ -17,7 +17,7 @@
 #include "module.h"
 #include "lauxlib.h"
 #include "platform.h"
-#include "c_types.h"
+#include <stdint.h>
 #include "user_interface.h"
 #include "../esp-gdbstub/gdbstub.h"
 

--- a/app/modules/gpio.c
+++ b/app/modules/gpio.c
@@ -6,7 +6,7 @@
 #include "lmem.h"
 #include "platform.h"
 #include "user_interface.h"
-#include "c_types.h"
+#include <stdint.h>
 #include <string.h>
 #include "gpio.h"
 #include "hw_timer.h"

--- a/app/modules/gpio_pulse.c
+++ b/app/modules/gpio_pulse.c
@@ -3,7 +3,7 @@
 #include "lmem.h"
 #include "platform.h"
 #include "user_interface.h"
-#include "c_types.h"
+#include <stdint.h>
 #include <string.h>
 #include "gpio.h"
 #include "hw_timer.h"

--- a/app/modules/mdns.c
+++ b/app/modules/mdns.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <alloca.h>
 
-#include "c_types.h"
+#include <stdint.h>
 #include "lwip/ip_addr.h"
 #include "nodemcu_mdns.h"
 #include "user_interface.h"

--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -5,9 +5,9 @@
 #include "platform.h"
 
 #include <string.h>
-#include <stdlib.h>
+#include <stddef.h>
 
-#include "c_types.h"
+#include <stdint.h>
 #include "mem.h"
 #include "lwip/ip_addr.h"
 #include "espconn.h"

--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -7,9 +7,9 @@
 
 #include <string.h>
 #include <strings.h>
-#include <stdlib.h>
+#include <stddef.h>
 
-#include "c_types.h"
+#include <stdint.h>
 #include "mem.h"
 #include "osapi.h"
 #include "lwip/err.h"

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -16,7 +16,7 @@
 
 #include "platform.h"
 #include "lflash.h"
-#include "c_types.h"
+#include <stdint.h>
 #include <string.h>
 #include "driver/uart.h"
 #include "user_interface.h"

--- a/app/modules/pwm.c
+++ b/app/modules/pwm.c
@@ -3,7 +3,7 @@
 #include "module.h"
 #include "lauxlib.h"
 #include "platform.h"
-#include "c_types.h"
+#include <stdint.h>
 
 // Lua: realfrequency = setup( id, frequency, duty )
 static int lpwm_setup( lua_State* L )

--- a/app/modules/pwm2.c
+++ b/app/modules/pwm2.c
@@ -7,7 +7,7 @@
 
 // Module for interfacing with PWM2 driver
 
-#include "c_types.h"
+#include <stdint.h>
 #include "lauxlib.h"
 #include "module.h"
 #include "driver/pwm2.h"

--- a/app/modules/rotary.c
+++ b/app/modules/rotary.c
@@ -9,10 +9,10 @@
 #include "module.h"
 #include "lauxlib.h"
 #include "platform.h"
-#include "c_types.h"
+#include <stdint.h>
+#include <stdlib.h>
 #include "user_interface.h"
 #include "driver/rotary.h"
-#include <stdlib.h>
 
 #define MASK(x)		(1 << ROTARY_ ## x ## _INDEX)
 

--- a/app/modules/somfy.c
+++ b/app/modules/somfy.c
@@ -11,6 +11,7 @@
 
 //#define NODE_DEBUG
 
+#include <stdint.h>
 #include "os_type.h"
 #include "osapi.h"
 #include "sections.h"

--- a/app/modules/sqlite3.c
+++ b/app/modules/sqlite3.c
@@ -30,7 +30,7 @@
 #define LSQLITE_OMIT_UPDATE_HOOK 1
 #define SQLITE_OMIT_PROGRESS_CALLBACK 1
 
-#include <c_stdlib.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 

--- a/app/modules/switec.c
+++ b/app/modules/switec.c
@@ -16,7 +16,7 @@
 #include "module.h"
 #include "lauxlib.h"
 #include "platform.h"
-#include "c_types.h"
+#include <stdint.h>
 #include "task/task.h"
 #include "driver/switec.h"
 

--- a/app/modules/tls.c
+++ b/app/modules/tls.c
@@ -9,9 +9,9 @@
 #include "lmem.h"
 
 #include <string.h>
-#include <stdlib.h>
+#include <stddef.h>
 
-#include "c_types.h"
+#include <stdint.h>
 #include "mem.h"
 #include "lwip/ip_addr.h"
 #include "espconn.h"

--- a/app/modules/tmr.c
+++ b/app/modules/tmr.c
@@ -51,7 +51,7 @@ tmr.softwd(int)
 #include "module.h"
 #include "lauxlib.h"
 #include "platform.h"
-#include "c_types.h"
+#include <stdint.h>
 #include "user_interface.h"
 #include "pm/swtimer.h"
 

--- a/app/modules/uart.c
+++ b/app/modules/uart.c
@@ -4,7 +4,7 @@
 #include "lauxlib.h"
 #include "platform.h"
 
-#include "c_types.h"
+#include <stdint.h>
 #include <string.h>
 #include "rom.h"
 

--- a/app/modules/websocket.c
+++ b/app/modules/websocket.c
@@ -13,9 +13,9 @@
 #include "platform.h"
 #include "module.h"
 
-#include "c_types.h"
+#include <stdint.h>
 #include <string.h>
-#include <stdlib.h>
+#include <stddef.h>
 
 #include "websocketclient.h"
 

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -7,10 +7,10 @@
 #include "platform.h"
 
 #include <string.h>
-#include <stdlib.h>
+#include <stddef.h>
 #include "ctype.h"
 
-#include "c_types.h"
+#include <stdint.h>
 #include "user_interface.h"
 #include "wifi_common.h"
 

--- a/app/modules/wifi_eventmon.c
+++ b/app/modules/wifi_eventmon.c
@@ -5,9 +5,9 @@
 #include "platform.h"
 
 #include <string.h>
-#include <stdlib.h>
+#include <stddef.h>
 
-#include "c_types.h"
+#include <stdint.h>
 #include "user_interface.h"
 #include "smart.h"
 #include "smartconfig.h"

--- a/app/modules/wifi_monitor.c
+++ b/app/modules/wifi_monitor.c
@@ -6,10 +6,10 @@
 #include "platform.h"
 
 #include <string.h>
-#include <stdlib.h>
+#include <stddef.h>
 #include "ctype.h"
 
-#include "c_types.h"
+#include <stdint.h>
 #include "user_interface.h"
 #include "wifi_common.h"
 #include "sys/network_80211.h"

--- a/app/mqtt/mqtt_msg.h
+++ b/app/mqtt/mqtt_msg.h
@@ -7,7 +7,7 @@
 
 #ifndef MQTT_MSG_H
 #define	MQTT_MSG_H
-#include "c_types.h"
+#include <stdint.h>
 #ifdef	__cplusplus
 extern "C" {
 #endif

--- a/app/platform/cpu_esp8266.h
+++ b/app/platform/cpu_esp8266.h
@@ -2,6 +2,9 @@
 #define __CPU_ESP8266_H__
 
 #ifndef NO_CPU_ESP8266_INCLUDE
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
 #include "os_type.h"
 #include "spi_flash.h"
 #include "pin_map.h"

--- a/app/platform/pin_map.h
+++ b/app/platform/pin_map.h
@@ -2,7 +2,7 @@
 #ifndef __PIN_MAP_H__
 #define __PIN_MAP_H__
 
-#include "c_types.h"
+#include <stdint.h>
 #include "user_config.h"
 #include "gpio.h"
 

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -3,9 +3,9 @@
 #ifndef __PLATFORM_H__
 #define __PLATFORM_H__
 
+#include <stdint.h>
 #include "cpu_esp8266.h"
 
-#include "c_types.h"
 #include "driver/pwm.h"
 #include "driver/uart.h"
 #include "task/task.h"

--- a/app/platform/sdcard.c
+++ b/app/platform/sdcard.c
@@ -1,6 +1,6 @@
 #include "platform.h"
 #include "driver/spi.h"
-#include "c_types.h"
+#include <stdint.h>
 
 #include "sdcard.h"
 

--- a/app/platform/sdcard.h
+++ b/app/platform/sdcard.h
@@ -1,7 +1,8 @@
 #ifndef _SDCARD_H
 #define _SDCARD_H
 
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
 
 int platform_sdcard_init( uint8_t spi_no, uint8_t ss_pin );
 int platform_sdcard_status( void );

--- a/app/pm/swtimer.c
+++ b/app/pm/swtimer.c
@@ -48,8 +48,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
-
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
 
 //#define SWTMR_DEBUG
 #if !defined(SWTMR_DBG) && defined(LUA_USE_MODULES_SWTMR_DBG)

--- a/app/sjson/memcompat.h
+++ b/app/sjson/memcompat.h
@@ -1,7 +1,7 @@
 #ifndef __MEMCOMPAT_H__
 #define __MEMCOMPAT_H__
 
-#include "c_types.h"
+#include <stdint.h>
 #include "mem.h"
 
 #endif

--- a/app/sqlite3/esp8266.c
+++ b/app/sqlite3/esp8266.c
@@ -8,9 +8,9 @@
 **/
 
 #include <stdio.h>
-#include <stdlib.h>
+#include <stddef.h>
 #include <string.h>
-#include "c_types.h"
+#include <stdint.h>
 #include <osapi.h>
 #include <vfs.h>
 #include <time.h>

--- a/app/tsl2561/tsl2561.h
+++ b/app/tsl2561/tsl2561.h
@@ -33,7 +33,7 @@
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 /**************************************************************************/
-#include "c_types.h"
+#include <stdint.h>
 
 #ifndef _TSL2561_H_
 #define _TSL2561_H_

--- a/app/websocket/websocketclient.c
+++ b/app/websocket/websocketclient.c
@@ -27,9 +27,8 @@
 #include "espconn.h"
 #include "mem.h"
 #include "limits.h"
-#include "stdlib.h"
-
-#include "c_types.h"
+#include <stdint.h>
+#include <stddef.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/sdk-overrides/include/c_types.h
+++ b/sdk-overrides/include/c_types.h
@@ -1,0 +1,6 @@
+#ifndef _SDKOVERRIDES_C_TYPES_H_
+#define _SDKOVERRIDES_C_TYPES_H_
+
+#error "Please do not use c_types.h, use <stdint.h> instead"
+
+#endif

--- a/sdk-overrides/include/ets_sys.h
+++ b/sdk-overrides/include/ets_sys.h
@@ -1,6 +1,10 @@
 #ifndef SDK_OVERRIDES_INCLUDE_ETS_SYS_H_
 #define SDK_OVERRIDES_INCLUDE_ETS_SYS_H_
 
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
 #include_next "ets_sys.h"
 
 #include <stdarg.h>

--- a/sdk-overrides/include/osapi.h
+++ b/sdk-overrides/include/osapi.h
@@ -1,9 +1,12 @@
 #ifndef _SDK_OVERRIDE_OSAPI_H_
 #define _SDK_OVERRIDE_OSAPI_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
 #include_next "osapi.h"
 
-#include <stddef.h>
 #include "rom.h"
 
 unsigned int uart_baudrate_detect(unsigned int uart_no, unsigned int async);

--- a/sdk-overrides/include/stdbool.h
+++ b/sdk-overrides/include/stdbool.h
@@ -2,6 +2,11 @@
 #define __stdbool_h__
 
 // For compatibility with SDK. Boo.
-#include_next "c_types.h"
+typedef unsigned char   bool;
+#define BOOL            bool
+#define true            (1)
+#define false           (0)
+#define TRUE            true
+#define FALSE           false
 
 #endif

--- a/sdk-overrides/include/stdint.h
+++ b/sdk-overrides/include/stdint.h
@@ -1,0 +1,65 @@
+#ifndef _SDKOVERRIDES_STDINT_H_
+#define _SDKOVERRIDES_STDINT_H_
+
+#include_next "stdint.h"
+
+// Compatibility cruft from c_types.h, ideally we should get rid of this!
+typedef signed char         sint8_t;
+typedef signed short        sint16_t;
+typedef signed int          sint32_t;
+typedef signed long long    sint64_t;
+typedef unsigned long long  u_int64_t;
+typedef float               real32_t;
+typedef double              real64_t;
+
+typedef unsigned char       uint8;
+typedef unsigned char       u8;
+typedef signed char         sint8;
+typedef signed char         int8;
+typedef signed char         s8;
+typedef unsigned short      uint16;
+typedef unsigned short      u16;
+typedef signed short        sint16;
+typedef signed short        s16;
+typedef unsigned int        uint32;
+typedef unsigned int        u_int;
+typedef unsigned int        u32;
+typedef signed int          sint32;
+typedef signed int          s32;
+typedef int                 int32;
+typedef signed long long    sint64;
+typedef unsigned long long  uint64;
+typedef unsigned long long  u64;
+typedef float               real32;
+typedef double              real64;
+
+#define __le16      u16
+
+// And this stuff really doesn't belong in a types file in the first place...
+#ifndef __packed
+#define __packed        __attribute__((packed))
+#endif
+
+#define LOCAL       static
+
+typedef enum {
+    OK = 0,
+    FAIL,
+    PENDING,
+    BUSY,
+    CANCEL,
+} STATUS;
+
+#define BIT(nr)                 (1UL << (nr))
+
+#define REG_SET_BIT(_r, _b)  (*(volatile uint32_t*)(_r) |= (_b))
+#define REG_CLR_BIT(_r, _b)  (*(volatile uint32_t*)(_r) &= ~(_b))
+
+#define DMEM_ATTR __attribute__((section(".bss")))
+#define SHMEM_ATTR
+
+#define ICACHE_FLASH_ATTR __attribute__((section(".irom0.text")))
+#define ICACHE_RODATA_ATTR __attribute__((section(".irom.text")))
+#define STORE_ATTR __attribute__((aligned(4)))
+
+#endif

--- a/sdk-overrides/include/stdlib.h
+++ b/sdk-overrides/include/stdlib.h
@@ -2,7 +2,7 @@
 #define _OVERRIDE_STDLIB_H_
 
 #include_next "stdlib.h"
-
+#include <stdbool.h>
 #include "mem.h"
 
 #define free          os_free

--- a/sdk-overrides/include/user_interface.h
+++ b/sdk-overrides/include/user_interface.h
@@ -1,6 +1,10 @@
 #ifndef SDK_OVERRIDES_INCLUDE_USER_INTERFACE_H_
 #define SDK_OVERRIDES_INCLUDE_USER_INTERFACE_H_
 
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
 #include_next "user_interface.h"
 
 bool wifi_softap_deauth(uint8 mac[6]);


### PR DESCRIPTION
Alright, due to popular request (@galjonsfigur), here is a follow-up to #2838 that removes uses of `c_types.h` as well, and prevents it from going back in.

We're still left with inherited junk in our overridden `stdint.h`, but that can be whittled down over time hopefully. Some of that stuff should definitely be moved into some platform abstraction layer or other. Other bits yet should be search'n'replaced and removed in my opinion (e.g. a bunch of the integer type variations).

Also included is the tidy-up of a few missed other c_stdxxx replacements.

This is a far smaller cleanup than #2838, but I believe this now leaves us with being able to refer only to the standard headers within the NodeMCU code. A second sweep for `os_`prefixes should probably also be done though.