### PR TITLE
Added required libraries to build env setup instructions

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -17,6 +17,18 @@ Occasional NodeMCU firmware hackers don't need full control over the complete to
 ### Linux Build Environment
 NodeMCU firmware developers commit or contribute to the project on GitHub and might want to build their own full fledged build environment with the complete tool chain.
 
+#### Build environment dependencies, tools and libraries:
+
+#### Ubuntu:
+
+```bash
+sudo apt-get install -y gperf python-pip python-dev flex bison build-essential libssl-dev libffi-dev libncurses5-dev libncursesw5-dev libreadline-dev
+```
+
+
+
+#### Setting up the repository
+
 Run the following command for a new checkout from scratch. This will fetch the nodemcu repo, checkout the `dev-esp32` branch and finally pull all submodules:
 
 ```


### PR DESCRIPTION
Fixes#2843.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [X] This PR is for the `dev-esp32` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).

This PR updates docs to indicate required library dependencies to build the dev-esp32 branch.