### PR TITLE
Fix enduser_setup default POST request

### DIFF
--- a/app/modules/enduser_setup.c
+++ b/app/modules/enduser_setup.c
@@ -397,14 +397,20 @@ static err_t close_once_sent (void *arg, struct tcp_pcb *pcb, u16_t len)
 /* ------------------------------------------------------------------------- */
 
 /**
- * Get length of param
+ * Get length of param value
+ * 
+ * This is being called with a fragment of the parameters passed in the 
+ * URL for GET requests or part of the body of a POST request.
+ * The string will look like one of these
+ * "SecretPassword HTTP/1.1"
+ * "SecretPassword&wifi_ssid=..."
+ * "SecretPassword"
+ * The string is searched for the first occurence of deliemiter '&' or ' '.
+ * If found return the length up to that position.
+ * If not found return the length of the string.
  *
- * Search string for first occurence of deliemiter '&' or ' '.
- * if found that terminates the param, if not end of string does.
- *
- * @return -1 if no occurence of char was found.
  */
-static int enduser_setup_get_len(const char *str)
+static int enduser_setup_get_lenth_of_param_value(const char *str)
 {
   char *found = strpbrk (str, "& ");
   if (!found)
@@ -820,8 +826,8 @@ static int enduser_setup_http_handle_credentials(char *data, unsigned short data
   char *name_str_start = name_str + name_field_len;
   char *pwd_str_start = pwd_str + pwd_field_len;
 
-  int name_str_len = enduser_setup_get_len(name_str_start);
-  int pwd_str_len = enduser_setup_get_len(pwd_str_start);
+  int name_str_len = enduser_setup_get_lenth_of_param_value(name_str_start);
+  int pwd_str_len = enduser_setup_get_lenth_of_param_value(pwd_str_start);
 
 
   struct station_config *cnf = luaM_malloc(lua_getstate(), sizeof(struct station_config));

--- a/app/modules/enduser_setup.c
+++ b/app/modules/enduser_setup.c
@@ -408,7 +408,7 @@ static int enduser_setup_srch_str(const char *str, const char *srch_str)
   char *found = strpbrk (str, srch_str);
   if (!found)
   {
-    return -1;
+    return strlen(str);
   }
   else
   {


### PR DESCRIPTION
partially fixes #2847.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

**Rational**
the out of the box enduser_setup does not work as the param parsing fails.
It assumes to have a ' ' or '&' to terminate the params.
While this is true for the GET request (where the params are part of the URL which is followed by "&nbsp;HTTP/1.1" it does not hold for POST requests, where the message ends with the last char of the params.
```http
GET /url?wifi_ssid=ssid&wifi_password=pass HTTP/1.1
```
This fix returns a false positive if the request is malformed and does not have a space to terminate the URL.
But since message parsing is not very strict anyhow that should be OK (for now)
