### PR TITLE
Support eth boards without power pin, extend docs

### DIFF
--- a/components/modules/eth.c
+++ b/components/modules/eth.c
@@ -26,7 +26,8 @@ typedef enum {
 
 static struct {
   const eth_config_t *eth_config;
-  gpio_num_t pin_power, pin_mdc, pin_mdio;
+  int pin_power;
+  gpio_num_t pin_mdc, pin_mdio;
 } module_config;
 
 

--- a/docs/modules/eth.md
+++ b/docs/modules/eth.md
@@ -119,6 +119,25 @@ Event information provided for each event is as follows:
     - `netmask`: the IP netmask
     - `gw`: the gateway ("0.0.0.0" if no gateway)
 
+#### Example
+```lua
+function ev(event, info)
+    print("event", event)
+    if event == "got_ip" then
+        print("ip:"..info.ip..", nm:"..info.netmask..", gw:"..info.gw)
+    elseif event == "connected" then
+        print("speed:", eth.get_speed())
+        print("mac:", eth.get_mac())
+    end
+end
+
+eth.on("connected", ev)
+eth.on("disconnected", ev)
+eth.on("start", ev)
+eth.on("stop", ev)
+eth.on("got_ip", ev)
+```
+
 
 ## eth.set_mac()
 Set MAC address.

--- a/docs/modules/eth.md
+++ b/docs/modules/eth.md
@@ -74,12 +74,20 @@ An error is thrown in case of invalid parameters or if the ethernet driver faile
 
 #### Example
 ```lua
+-- Initialize ESP32-GATEWAY
 eth.init({phy  = eth.PHY_LAN8720,
           addr = 0,
           clock_mode = eth.CLOCK_GPIO17_OUT,
           power = 5,
           mdc   = 23,
           mdio  = 18})
+
+-- Initialize wESP32
+eth.init({phy  = eth.PHY_LAN8720,
+          addr = 0,
+          clock_mode = eth.CLOCK_GPIO0_IN,
+          mdc   = 16,
+          mdio  = 17})
 ```
 
 


### PR DESCRIPTION
Follow-up to #2820.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This PR fixes the handling for optional power pin during `eth.init()`. Detected when running the code on a wESP32 board.
Init example for this board is added to the docs and general improvement for `eth.on()`.
