### PR TITLE
Fix espconn.h override on Windows

### DIFF
--- a/sdk-overrides/include/espconn.h
+++ b/sdk-overrides/include/espconn.h
@@ -1,1 +1,5 @@
-../../app/include/lwip/app/espconn.h
+#ifndef _SDK_OVERRIDE_ESPCONN_H_
+#define _SDK_OVERRIDE_ESPCONN_H_
+// Pull in the correct lwIP header
+#include "../../app/include/lwip/app/espconn.h"
+#endif


### PR DESCRIPTION
Fixes #2853.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.
