### PR TITLE
net docs: clarify DNS callbacks

### DIFF
--- a/docs/modules/net.md
+++ b/docs/modules/net.md
@@ -236,6 +236,10 @@ Provides DNS resolution for a hostname.
 - `domain` domain name
 - `function(net.socket, ip)` callback function. The first parameter is the socket, the second parameter is the IP address as a string.
 
+If a callback `c` is provided, it is equivalent to having called `:on("dns",
+c)` on this socket; this callback will, hereafter, receive any pending
+resolution results recieved for this socket!
+
 #### Returns
 `nil`
 
@@ -579,6 +583,11 @@ Resolve a hostname to an IP address. Doesn't require a socket like [`net.socket.
 #### Parameters
 - `host` hostname to resolve
 - `function(sk, ip)` callback called when the name was resolved. `sk` is always `nil`
+
+There is at most one callback for all `net.dns.resolve()` requests at any time;
+all resolution results are sent to the most recent callback specified at time
+of receipt!  If multiple DNS callbacks are needed, associate them with separate
+sockets using [`net.socket:dns()`](#netsocketdns).
 
 #### Returns
 `nil`


### PR DESCRIPTION
Some very minor documentation change that might still be good to have in the next drop.