### PR TITLE
Be more assertive in the TLS documentation

### DIFF
--- a/docs/modules/http.md
+++ b/docs/modules/http.md
@@ -20,7 +20,10 @@ to make it easy to access. If there are multiple headers of the same name, then 
 
 **SSL/TLS support**
 
-Take note of constraints documented in the [net module](net.md).
+!!! attention
+
+    Secure (`https`) connections come with quite a few limitations.  Please see
+    the warnings in the [tls module](tls.md)'s documentation.
 
 ## http.delete()
 

--- a/docs/modules/mqtt.md
+++ b/docs/modules/mqtt.md
@@ -132,6 +132,11 @@ Connects to the broker specified by the given host, port, and secure options.
 - `function(client)` callback function for when the connection was established
 - `function(client, reason)` callback function for when the connection could not be established. No further callbacks should be called.
 
+!!! attention
+
+    Secure (`https`) connections come with quite a few limitations.  Please see
+    the warnings in the [tls module](tls.md)'s documentation.
+
 #### Returns
 `true` on success, `false` otherwise
 


### PR DESCRIPTION
Addresses #2873.

We just don't have the memory to be a real TLS client on the 8266.  Put
that in a big box and point at it from the http and mqtt modules; others
may also wish to give reference.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.
