### PR TITLE
add build_date to build info

### DIFF
--- a/app/include/user_version.h
+++ b/app/include/user_version.h
@@ -17,7 +17,7 @@
 // Can be removed when the script is adapted
 
 #ifndef BUILD_DATE
-#define BUILD_DATE		"unspecified"
+#define BUILD_DATE		BUILDINFO_BUILD_DATE
 #endif
 
 extern char SDK_VERSION[];

--- a/tools/update_buildinfo.sh
+++ b/tools/update_buildinfo.sh
@@ -6,6 +6,7 @@ COMMIT_ID="$(git rev-parse HEAD)"
 BRANCH="$(git rev-parse --abbrev-ref HEAD | sed -E 's/[\/\\]+/_/g')"
 RELEASE="$(git describe --tags --long | sed -E 's/(.*)-(.*)-.*/\1 +\2/g' | sed 's/ +0$//')"
 RELEASE_DTS=$(TZ=UTC git show --quiet --date=format-local:"%Y%m%d%H%M" --format="%cd" HEAD)
+BUILD_DATE="$(date "+%Y-%m-%d %H:%M")"
 
 MODULES=$(awk '/^[ \t]*#define LUA_USE_MODULES/{modules=modules sep tolower(substr($2,17));sep=","}END{if(length(modules)==0)modules="-";print modules}' $USER_MODULES_H | tr -d '\r')
 
@@ -46,6 +47,7 @@ cat > $TEMPFILE << EndOfMessage
 #define BUILDINFO_RELEASE "$RELEASE"
 #define BUILDINFO_RELEASE_DTS "$RELEASE_DTS"
 #define BUILDINFO_MODULES "$MODULES"
+#define BUILDINFO_BUILD_DATE "$BUILD_DATE"
 
 #define NODE_VERSION_LONG \\
   USER_PROLOG "\n" \\


### PR DESCRIPTION
Fixes https://github.com/nodemcu/nodemcu-firmware/pull/2830#discussion_r312716630.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

Add automatic BUILD_DATE to Build Info