### PR TITLE
Fix the ug8 and ucg modules broken by eaac369.

### DIFF
--- a/components/modules/u8g2.c
+++ b/components/modules/u8g2.c
@@ -802,7 +802,7 @@ U8G2_DISPLAY_TABLE_SPI
 #undef U8G2_FONT_TABLE_ENTRY
 #undef U8G2_DISPLAY_TABLE_ENTRY
 #define U8G2_DISPLAY_TABLE_ENTRY(function, binding) \
-  LROT_FUNCENTRY( #binding, l ## binding )
+  LROT_FUNCENTRY( binding, l ## binding )
 
 LROT_BEGIN(lu8g2)
   U8G2_DISPLAY_TABLE_I2C
@@ -810,7 +810,7 @@ LROT_BEGIN(lu8g2)
   //
   // Register fonts
 #define U8G2_FONT_TABLE_ENTRY(font) \
-  LROT_LUDENTRY( #font,            (void *)(u8g2_ ## font) )
+  LROT_LUDENTRY( font,            (void *)(u8g2_ ## font) )
   U8G2_FONT_TABLE
   //
   LROT_NUMENTRY( DRAW_UPPER_RIGHT, U8G2_DRAW_UPPER_RIGHT )

--- a/components/modules/ucg.c
+++ b/components/modules/ucg.c
@@ -734,12 +734,12 @@ LROT_END(lucg_display, NULL, 0)
 
 LROT_BEGIN(lucg)
 #undef UCG_DISPLAY_TABLE_ENTRY
-#define UCG_DISPLAY_TABLE_ENTRY(binding, device, extension) LROT_FUNCENTRY( #binding, l ## binding )
+#define UCG_DISPLAY_TABLE_ENTRY(binding, device, extension) LROT_FUNCENTRY( binding, l ## binding )
   UCG_DISPLAY_TABLE
 
   // Register fonts
 #undef UCG_FONT_TABLE_ENTRY
-#define UCG_FONT_TABLE_ENTRY(font) LROT_LUDENTRY( #font, (void *)(ucg_ ## font) )
+#define UCG_FONT_TABLE_ENTRY(font) LROT_LUDENTRY( font, (void *)(ucg_ ## font) )
   UCG_FONT_TABLE
 
   // Font modes


### PR DESCRIPTION
Fixes #2926 

* [x] This PR is for the dev branch rather than for master.
* [x] This PR is compliant with the other contributing guidelines as well.
* [x] I have thoroughly tested my contribution.
* [x] The code changes are reflected in the documentation at docs/*.

https://github.com/nodemcu/nodemcu-firmware/commit/eaac369dece9ab74a736e8b42a21a4a655b3fe33 introduced changes to the way Lua ROM tables are built. Previously, lua function names were strings, now they are symbols (probably stringified by the macros).
But the ucg and ug8 modules use macro themselves to include the lcd drivers in the rom table, and they needed to stringify the driver names. This is not required anymore, but this fix was somewhat missed.

There may be other modules requiring that kind of fix, I did not check everywhere.