### PR TITLE
Fixes for `ws2812` and `ws2812_effects`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ tools/toolchains/
 .project
 .settings/
 .vscode
+.vs
 
 #ignore temp file for build infos
 buildinfo.h

--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -16,10 +16,6 @@
 #define MODE_DUAL    1
 
 
-
-
-
-
 // Init UART1 to be able to stream WS2812 data to GPIO2 pin
 // If DUAL mode is selected, init UART0 to stream to TXD0 as well
 // You HAVE to redirect LUA's output somewhere else
@@ -168,10 +164,10 @@ static int ws2812_write(lua_State* L) {
   return 0;
 }
 
-static ptrdiff_t posrelat (ptrdiff_t pos, size_t len) {
+static ptrdiff_t posrelat(ptrdiff_t pos, size_t len) {
   /* relative string position: negative means back from end */
   if (pos < 0) pos += (ptrdiff_t)len + 1;
-  return (pos >= 0) ? pos : 0;
+  return MIN(MAX(pos, 1), len);
 }
 
 static ws2812_buffer *allocate_buffer(lua_State *L, int leds, int colorsPerLed) {
@@ -245,17 +241,11 @@ static int ws2812_buffer_fill_lua(lua_State* L) {
   return 0;
 }
 
-static int ws2812_buffer_fade(lua_State* L) {
-  ws2812_buffer * buffer = (ws2812_buffer*)luaL_checkudata(L, 1, "ws2812.buffer");
-  const int fade = luaL_checkinteger(L, 2);
-  unsigned direction = luaL_optinteger( L, 3, FADE_OUT );
-
-  luaL_argcheck(L, fade > 0, 2, "fade value should be a strict positive number");
-
+void ws2812_buffer_fade(ws2812_buffer * buffer, int fade, unsigned direction) {
   uint8_t * p = &buffer->values[0];
   int val = 0;
   int i;
-  for(i = 0; i < buffer->size * buffer->colorsPerLed; i++)
+  for (i = 0; i < buffer->size * buffer->colorsPerLed; i++)
   {
     if (direction == FADE_OUT)
     {
@@ -269,23 +259,31 @@ static int ws2812_buffer_fade(lua_State* L) {
       *p++ = val;
     }
   }
+}
+
+static int ws2812_buffer_fade_lua(lua_State* L) {
+  ws2812_buffer * buffer = (ws2812_buffer*)luaL_checkudata(L, 1, "ws2812.buffer");
+  const int fade = luaL_checkinteger(L, 2);
+  unsigned direction = luaL_optinteger( L, 3, FADE_OUT );
+
+  luaL_argcheck(L, fade > 0, 2, "fade value should be a strict positive number");
+
+  ws2812_buffer_fade(buffer, fade, direction);
 
   return 0;
 }
 
 
-int ws2812_buffer_shift(ws2812_buffer * buffer, int shiftValue, unsigned shift_type, int pos_start, int pos_end) {
+int ws2812_buffer_shift(lua_State* L, ws2812_buffer * buffer, int shiftValue, unsigned shift_type, int pos_start, int pos_end) {
 
   ptrdiff_t start = posrelat(pos_start, buffer->size);
   ptrdiff_t end = posrelat(pos_end, buffer->size);
-  if (start < 1) start = 1;
-  if (end > (ptrdiff_t)buffer->size) end = (ptrdiff_t)buffer->size;
 
   start--;
   int size = end - start;
   size_t offset = start * buffer->colorsPerLed;
 
-  //luaL_argcheck(L, shiftValue > 0-size && shiftValue < size, 2, "shifting more elements than buffer size");
+  luaL_argcheck(L, shiftValue >= 0-size && shiftValue <= size, 2, "shifting more elements than buffer size");
 
   int shift = shiftValue >= 0 ? shiftValue : -shiftValue;
 
@@ -295,8 +293,7 @@ int ws2812_buffer_shift(ws2812_buffer * buffer, int shiftValue, unsigned shift_t
     return 0;
   }
 
-  uint8_t * tmp_pixels = malloc(buffer->colorsPerLed * sizeof(uint8_t) * shift);
-  int i,j;
+  uint8_t * tmp_pixels = luaM_malloc(L, buffer->colorsPerLed * sizeof(uint8_t) * shift);
   size_t shift_len, remaining_len;
   // calculate length of shift section and remaining section
   shift_len = shift*buffer->colorsPerLed;
@@ -335,11 +332,10 @@ int ws2812_buffer_shift(ws2812_buffer * buffer, int shiftValue, unsigned shift_t
     }
   }
   // Free memory
-  free(tmp_pixels);
+  luaM_free(L, tmp_pixels);
 
   return 0;
 }
-
 
 static int ws2812_buffer_shift_lua(lua_State* L) {
 
@@ -351,10 +347,9 @@ static int ws2812_buffer_shift_lua(lua_State* L) {
   const int pos_end = luaL_optinteger(L, 5, -1);
 
 
-  ws2812_buffer_shift(buffer, shiftValue, shift_type, pos_start, pos_end);
+  ws2812_buffer_shift(L, buffer, shiftValue, shift_type, pos_start, pos_end);
   return 0;
 }
-
 
 static int ws2812_buffer_dump(lua_State* L) {
   ws2812_buffer * buffer = (ws2812_buffer*)luaL_checkudata(L, 1, "ws2812.buffer");
@@ -366,8 +361,7 @@ static int ws2812_buffer_dump(lua_State* L) {
 
 static int ws2812_buffer_replace(lua_State* L) {
   ws2812_buffer * buffer = (ws2812_buffer*)luaL_checkudata(L, 1, "ws2812.buffer");
-  size_t l = buffer->size;
-  ptrdiff_t start = posrelat(luaL_optinteger(L, 3, 1), l);
+  ptrdiff_t start = posrelat(luaL_optinteger(L, 3, 1), buffer->size);
 
   uint8_t *src;
   size_t srcLen;
@@ -425,8 +419,8 @@ static int ws2812_buffer_mix(lua_State* L) {
       val += (int32_t)(source[src].values[i] * source[src].factor);
     }
 
-	val += 128;	// rounding istead of floor
-    val >>= 8;
+	  val += 128;	// rounding istead of floor
+    val /= 256; // do not use implemetation dependant right shift
 
     if (val < 0) {
       val = 0;
@@ -531,8 +525,6 @@ static int ws2812_buffer_sub(lua_State* L) {
   size_t l = lhs->size;
   ptrdiff_t start = posrelat(luaL_checkinteger(L, 2), l);
   ptrdiff_t end = posrelat(luaL_optinteger(L, 3, -1), l);
-  if (start < 1) start = 1;
-  if (end > (ptrdiff_t)l) end = (ptrdiff_t)l;
   if (start <= end) {
     ws2812_buffer *result = allocate_buffer(L, end - start + 1, lhs->colorsPerLed);
     memcpy(result->values, lhs->values + lhs->colorsPerLed * (start - 1), lhs->colorsPerLed * (end - start + 1));
@@ -591,10 +583,9 @@ static int ws2812_buffer_tostring(lua_State* L) {
   return 1;
 }
 
-
 LROT_BEGIN(ws2812_buffer)
   LROT_FUNCENTRY( dump, ws2812_buffer_dump )
-  LROT_FUNCENTRY( fade, ws2812_buffer_fade )
+  LROT_FUNCENTRY( fade, ws2812_buffer_fade_lua)
   LROT_FUNCENTRY( fill, ws2812_buffer_fill_lua )
   LROT_FUNCENTRY( get, ws2812_buffer_get )
   LROT_FUNCENTRY( replace, ws2812_buffer_replace )
@@ -609,8 +600,6 @@ LROT_BEGIN(ws2812_buffer)
   LROT_FUNCENTRY( __tostring, ws2812_buffer_tostring )
 LROT_END( ws2812_buffer, ws2812_buffer, LROT_MASK_INDEX )
 
-
-
 LROT_BEGIN(ws2812)
   LROT_FUNCENTRY( init, ws2812_init )
   LROT_FUNCENTRY( newBuffer, ws2812_new_buffer )
@@ -622,7 +611,6 @@ LROT_BEGIN(ws2812)
   LROT_NUMENTRY( SHIFT_LOGICAL, SHIFT_LOGICAL )
   LROT_NUMENTRY( SHIFT_CIRCULAR, SHIFT_CIRCULAR )
 LROT_END( ws2812, NULL, 0 )
-
 
 int luaopen_ws2812(lua_State *L) {
   // TODO: Make sure that the GPIO system is initialized

--- a/app/modules/ws2812.h
+++ b/app/modules/ws2812.h
@@ -17,6 +17,12 @@
 #define SHIFT_LOGICAL  0
 #define SHIFT_CIRCULAR 1
 
+#ifndef MIN
+#define MIN(a,b) ((a) < (b) ? (a) : (b))
+#endif
+#ifndef MAX
+#define MAX(a,b) ((a) > (b) ? (a) : (b))
+#endif
 
 typedef struct {
   int size;
@@ -26,7 +32,8 @@ typedef struct {
 
 
 void ICACHE_RAM_ATTR ws2812_write_data(const uint8_t *pixels, uint32_t length, const uint8_t *pixels2, uint32_t length2);
-int ws2812_buffer_shift(ws2812_buffer * buffer, int shiftValue, unsigned shift_type, int pos_start, int pos_end);
+int ws2812_buffer_shift(lua_State* L, ws2812_buffer * buffer, int shiftValue, unsigned shift_type, int pos_start, int pos_end);
 int ws2812_buffer_fill(ws2812_buffer * buffer, int * colors);
+void ws2812_buffer_fade(ws2812_buffer * buffer, int fade, unsigned direction);
 
 #endif /* APP_MODULES_WS2812_H_ */

--- a/app/modules/ws2812.h
+++ b/app/modules/ws2812.h
@@ -30,9 +30,25 @@ typedef struct {
   uint8_t values[0];
 } ws2812_buffer;
 
+typedef struct {
+  size_t offset;
+  uint8_t* tmp_pixels;
+  int shiftValue;
+  size_t shift_len;
+  size_t remaining_len;
+  unsigned shift_type;
+  ws2812_buffer* buffer;
+} ws2812_buffer_shift_prepare;
+
 
 void ICACHE_RAM_ATTR ws2812_write_data(const uint8_t *pixels, uint32_t length, const uint8_t *pixels2, uint32_t length2);
-int ws2812_buffer_shift(lua_State* L, ws2812_buffer * buffer, int shiftValue, unsigned shift_type, int pos_start, int pos_end);
+// To shift the lua_State is needed for error message and memory allocation.
+// We also need the shift operation inside a timer callback, where we cannot access the lua_State,
+// so This is split up in prepare and the actual call, which can be called multiple times with the same prepare object.
+// After being done just luaM_free on the prepare object.
+void ws2812_buffer_shift_prepared(ws2812_buffer_shift_prepare* prepare);
+ws2812_buffer_shift_prepare* ws2812_buffer_get_shift_prepare(lua_State* L, ws2812_buffer * buffer, int shiftValue, unsigned shift_type, int pos_start, int pos_end);
+
 int ws2812_buffer_fill(ws2812_buffer * buffer, int * colors);
 void ws2812_buffer_fade(ws2812_buffer * buffer, int fade, unsigned direction);
 

--- a/lua_tests/mispec.lua
+++ b/lua_tests/mispec.lua
@@ -1,0 +1,159 @@
+local moduleName = ... or 'mispec'
+local M = {}
+_G[moduleName] = M
+
+-- Helpers:
+function ok(expression, desc)
+    if expression == nil then expression = false end
+    desc = desc or 'expression is not ok'
+    if not expression then
+        error(desc .. '\n' .. debug.traceback())
+    end
+end
+
+function ko(expression, desc)
+    if expression == nil then expression = false end
+    desc = desc or 'expression is not ko'
+    if expression then
+        error(desc .. '\n' .. debug.traceback())
+    end
+end
+
+function eq(a, b)
+    if type(a) ~= type(b) then
+        error('type ' .. type(a) .. ' is not equal to ' .. type(b) .. '\n' .. debug.traceback())
+    end
+    if type(a) == 'function' then
+        return string.dump(a) == string.dump(b)
+    end
+    if a == b then return true end
+    if type(a) ~= 'table' then
+        error(string.format("%q",tostring(a)) .. ' is not equal to ' .. string.format("%q",tostring(b)) .. '\n' .. debug.traceback())
+    end
+    for k,v in pairs(a) do
+        if b[k] == nil or not eq(v, b[k]) then return false end
+    end
+    for k,v in pairs(b) do
+        if a[k] == nil or not eq(v, a[k]) then return false end
+    end
+    return true
+end
+
+function failwith(message, func, ...)
+    local status, err = pcall(func, ...)
+    if status then
+        local messagePart = ""
+        if message then
+            messagePart = " containing \"" .. message .. "\""
+        end
+        error("Error expected" .. messagePart .. '\n' .. debug.traceback())
+    end
+    if (message and not string.find(err, message)) then
+        error("expected errormessage \"" .. err .. "\" to contain \"" .. message .. "\"" .. '\n' .. debug.traceback() )
+    end
+    return true
+end
+
+function fail(func, ...)
+    return failwith(nil, func, ...)
+end
+
+local function eventuallyImpl(func, retries, delayMs)
+    local prevEventually = _G.eventually
+    _G.eventually = function() error("Cannot nest eventually/andThen.") end
+    local status, err = pcall(func)
+    _G.eventually = prevEventually
+    if status then
+        M.queuedEventuallyCount = M.queuedEventuallyCount - 1
+        M.runNextPending()
+    else
+        if retries > 0 then
+            local t = tmr.create()
+            t:register(delayMs, tmr.ALARM_SINGLE, M.runNextPending)
+            t:start()
+
+            table.insert(M.pending, 1, function() eventuallyImpl(func, retries - 1, delayMs) end)
+        else
+            M.failed = M.failed + 1
+            print("\n  ! it failed:", err)
+
+            -- remove all pending eventuallies as spec has failed at this point
+            for i = 1, M.queuedEventuallyCount - 1 do
+                table.remove(M.pending, 1)
+            end
+            M.queuedEventuallyCount = 0
+            M.runNextPending()
+        end
+    end
+end
+
+function eventually(func, retries, delayMs)
+    retries = retries or 10
+    delayMs = delayMs or 300
+
+    M.queuedEventuallyCount = M.queuedEventuallyCount + 1
+
+    table.insert(M.pending, M.queuedEventuallyCount, function()
+        eventuallyImpl(func, retries, delayMs)
+    end)
+end
+
+function andThen(func)
+    eventually(func, 0, 0)
+end
+
+function describe(name, itshoulds)
+    M.name = name
+    M.itshoulds = itshoulds
+end
+
+-- Module:
+M.runNextPending = function()
+    local next = table.remove(M.pending, 1)
+    if next then
+        node.task.post(next)
+        next = nil
+    else
+        M.succeeded = M.total - M.failed
+        local elapsedSeconds = (tmr.now() - M.startTime) / 1000 / 1000
+        print(string.format(
+            '\n\nCompleted in %.2f seconds.\nSuccess rate is %.1f%% (%d failed out of %d).',
+            elapsedSeconds, 100 * M.succeeded / M.total, M.failed, M.total))
+        M.pending = nil
+        M.queuedEventuallyCount = nil
+    end
+end
+
+M.run = function()
+    M.pending = {}
+    M.queuedEventuallyCount = 0
+    M.startTime = tmr.now()
+    M.total = 0
+    M.failed = 0
+    local it = {}
+    it.should = function(_, desc, func)
+        table.insert(M.pending, function()
+            uart.write(0, '\n  * ' .. desc)
+            M.total = M.total + 1
+            if M.pre then M.pre() end
+            local status, err = pcall(func)
+            if not status then
+                print("\n  ! it failed:", err)
+                M.failed = M.failed + 1
+            end
+            if M.post then M.post() end
+            M.runNextPending()
+        end)
+    end
+    it.initialize = function(_, pre) M.pre = pre end;
+    it.cleanup = function(_, post) M.post = post end;
+    M.itshoulds(it)
+
+    print('' .. M.name .. ', it should:')
+    M.runNextPending()
+
+    M.itshoulds = nil
+    M.name = nil
+end
+
+print ("loaded mispec")

--- a/lua_tests/mispec_ws2812.lua
+++ b/lua_tests/mispec_ws2812.lua
@@ -1,0 +1,153 @@
+require 'mispec'
+
+local buffer, buffer1, buffer2
+
+local function initBuffer(buffer, ...)
+  local i,v
+  for i,v in ipairs({...}) do
+    buffer:set(i, v, v*2, v*3, v*4)
+  end
+  return buffer
+end
+
+local function equalsBuffer(buffer1, buffer2)
+  return eq(buffer1:dump(), buffer2:dump())
+end
+
+
+describe('WS2812 buffers', function(it)
+
+    it:should('initialize a buffer', function()
+        buffer = ws2812.newBuffer(9, 3)
+        ko(buffer == nil)
+        ok(eq(buffer:size(), 9), "check size")
+        ok(eq(buffer:dump(), string.char(0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0)), "initialize with 0")
+
+        failwith("should be a positive integer", ws2812.newBuffer, 9, 0)
+        failwith("should be a positive integer", ws2812.newBuffer, 9, -1)
+        failwith("should be a positive integer", ws2812.newBuffer, 0, 3)
+        failwith("should be a positive integer", ws2812.newBuffer, -1, 3)
+    end)
+
+    it:should('have correct size', function()
+        buffer = ws2812.newBuffer(9, 3)
+        ok(eq(buffer:size(), 9), "check size")
+        buffer = ws2812.newBuffer(9, 22)
+        ok(eq(buffer:size(), 9), "check size")
+        buffer = ws2812.newBuffer(13, 1)
+        ok(eq(buffer:size(), 13), "check size")
+    end)
+
+    it:should('fill a buffer with one color', function()
+        buffer = ws2812.newBuffer(3, 3)
+        buffer:fill(1,222,55)
+        ok(eq(buffer:dump(), string.char(1,222,55,1,222,55,1,222,55)), "RGB")
+        buffer = ws2812.newBuffer(3, 4)
+        buffer:fill(1,222,55, 77)
+        ok(eq(buffer:dump(), string.char(1,222,55,77,1,222,55,77,1,222,55,77)), "RGBW")
+    end)
+
+    it:should('replace correctly', function()
+        buffer = ws2812.newBuffer(5, 3)
+        buffer:replace(string.char(3,255,165,33,0,244,12,87,255))
+        ok(eq(buffer:dump(), string.char(3,255,165,33,0,244,12,87,255,0,0,0,0,0,0)), "RGBW")
+
+        buffer = ws2812.newBuffer(5, 3)
+        buffer:replace(string.char(3,255,165,33,0,244,12,87,255), 2)
+        ok(eq(buffer:dump(), string.char(0,0,0,3,255,165,33,0,244,12,87,255,0,0,0)), "RGBW")
+
+        buffer = ws2812.newBuffer(5, 3)
+        buffer:replace(string.char(3,255,165,33,0,244,12,87,255), -5)
+        ok(eq(buffer:dump(), string.char(3,255,165,33,0,244,12,87,255,0,0,0,0,0,0)), "RGBW")
+
+        failwith("Does not fit into destination", function() buffer:replace(string.char(3,255,165,33,0,244,12,87,255), 4) end)
+    end)
+
+    it:should('replace correctly issue #2921', function()
+        local buffer = ws2812.newBuffer(5, 3)
+        buffer:replace(string.char(3,255,165,33,0,244,12,87,255), -7)
+        ok(eq(buffer:dump(), string.char(3,255,165,33,0,244,12,87,255,0,0,0,0,0,0)), "RGBW")
+    end)
+
+    it:should('get/set correctly', function()
+        buffer = ws2812.newBuffer(3, 4)
+        buffer:fill(1,222,55,13)
+        ok(eq({buffer:get(2)},{1,222,55,13}))
+        buffer:set(2, 4,53,99,0)
+        ok(eq({buffer:get(1)},{1,222,55,13}))
+        ok(eq({buffer:get(2)},{4,53,99,0}))
+        ok(eq(buffer:dump(), string.char(1,222,55,13,4,53,99,0,1,222,55,13)), "RGBW")
+
+        failwith("index out of range", function() buffer:get(0) end)
+        failwith("index out of range", function() buffer:get(4) end)
+        failwith("index out of range", function() buffer:set(0,1,2,3,4) end)
+        failwith("index out of range", function() buffer:set(4,1,2,3,4) end)
+        failwith("number expected, got no value", function() buffer:set(2,1,2,3) end)
+--        failwith("extra values given", function() buffer:set(2,1,2,3,4,5) end)
+    end)
+
+    it:should('fade correctly', function()
+        buffer = ws2812.newBuffer(1, 3)
+        buffer:fill(1,222,55)
+        buffer:fade(2)
+        ok(buffer:dump() == string.char(0,111,27), "RGB")
+        buffer:fill(1,222,55)
+        buffer:fade(3, ws2812.FADE_OUT)
+        ok(buffer:dump() == string.char(0,222/3,55/3), "RGB")
+        buffer:fill(1,222,55)
+        buffer:fade(3, ws2812.FADE_IN)
+        ok(buffer:dump() == string.char(3,255,165), "RGB")
+        buffer = ws2812.newBuffer(1, 4)
+        buffer:fill(1,222,55, 77)
+        buffer:fade(2, ws2812.FADE_OUT)
+        ok(eq(buffer:dump(), string.char(0,111,27,38)), "RGBW")
+    end)
+
+    it:should('mix correctly issue #1736', function()
+        buffer1 = ws2812.newBuffer(1, 3) 
+        buffer2 = ws2812.newBuffer(1, 3)
+        buffer1:fill(10,22,54)
+        buffer2:fill(10,27,55)
+        buffer1:mix(256/8*7,buffer1,256/8,buffer2)
+        ok(eq({buffer1:get(1)}, {10,23,54}))
+    end)
+
+    it:should('mix saturation correctly ', function()
+        buffer1 = ws2812.newBuffer(1, 3) 
+        buffer2 = ws2812.newBuffer(1, 3) 
+
+        buffer1:fill(10,22,54)
+        buffer2:fill(10,27,55)
+        buffer1:mix(256/2,buffer1,-256,buffer2)
+        ok(eq({buffer1:get(1)}, {0,0,0}))
+
+        buffer1:fill(10,22,54)
+        buffer2:fill(10,27,55)
+        buffer1:mix(25600,buffer1,256/8,buffer2)
+        ok(eq({buffer1:get(1)}, {255,255,255}))
+
+        buffer1:fill(10,22,54)
+        buffer2:fill(10,27,55)
+        buffer1:mix(-257,buffer1,255,buffer2)
+        ok(eq({buffer1:get(1)}, {0,5,1}))
+    end)
+
+    it:should('mix with strings correctly ', function()
+        buffer1 = ws2812.newBuffer(1, 3) 
+        buffer2 = ws2812.newBuffer(1, 3) 
+
+        buffer1:fill(10,22,54)
+        buffer2:fill(10,27,55)
+        buffer1:mix(-257,buffer1:dump(),255,buffer2:dump())
+        ok(eq({buffer1:get(1)}, {0,5,1}))
+    end)
+    
+    it:should('power', function()
+        buffer = ws2812.newBuffer(2, 4)
+        buffer:fill(10,22,54,234)
+        ok(eq(buffer:power(), 2*(10+22+54+234)))
+    end)
+
+end)
+
+mispec.run()

--- a/lua_tests/mispec_ws2812_2.lua
+++ b/lua_tests/mispec_ws2812_2.lua
@@ -1,0 +1,149 @@
+require 'mispec'
+
+local buffer, buffer1, buffer2
+
+local function initBuffer(buffer, ...)
+  local i,v
+  for i,v in ipairs({...}) do
+    buffer:set(i, v, v*2, v*3, v*4)
+  end
+  return buffer
+end
+
+local function equalsBuffer(buffer1, buffer2)
+  return eq(buffer1:dump(), buffer2:dump())
+end
+
+
+describe('WS2812 buffers', function(it)
+
+    it:should('shift LOGICAL', function()
+
+        buffer1 = ws2812.newBuffer(4, 4)
+        buffer2 = ws2812.newBuffer(4, 4)
+
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,0,0,7,8)
+        buffer1:shift(2)
+        ok(equalsBuffer(buffer1, buffer2), "shift right")
+        
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,9,12,0,0)
+        buffer1:shift(-2)
+        ok(equalsBuffer(buffer1, buffer2), "shift left")
+        
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,7,0,8,12)
+        buffer1:shift(1, nil, 2,3)
+        ok(equalsBuffer(buffer1, buffer2), "shift middle right")
+
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,7,9,0,12)
+        buffer1:shift(-1, nil, 2,3)
+        ok(equalsBuffer(buffer1, buffer2), "shift middle left")
+
+        -- bounds checks, handle gracefully as string:sub does
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,8,9,12,0)
+        buffer1:shift(-1, ws2812.SHIFT_LOGICAL, 0,5)
+        ok(equalsBuffer(buffer1, buffer2), "shift left out of bound")
+
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,0,7,8,9)
+        buffer1:shift(1, ws2812.SHIFT_LOGICAL, 0,5)
+        ok(equalsBuffer(buffer1, buffer2), "shift right out of bound")
+
+    end)
+
+    it:should('shift LOGICAL issue #2946', function()
+        buffer1 = ws2812.newBuffer(4, 4)
+        buffer2 = ws2812.newBuffer(4, 4)
+        
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,0,0,0,0)
+        buffer1:shift(4)
+        ok(equalsBuffer(buffer1, buffer2), "shift all right")
+
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,0,0,0,0)
+        buffer1:shift(-4)
+        ok(equalsBuffer(buffer1, buffer2), "shift all left")
+
+        failwith("shifting more elements than buffer size", function() buffer1:shift(10) end)
+        failwith("shifting more elements than buffer size", function() buffer1:shift(-6) end)
+    end)
+
+    it:should('shift CIRCULAR', function()
+        buffer1 = ws2812.newBuffer(4, 4)
+        buffer2 = ws2812.newBuffer(4, 4)
+
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,9,12,7,8)
+        buffer1:shift(2, ws2812.SHIFT_CIRCULAR)
+        ok(equalsBuffer(buffer1, buffer2), "shift right")
+        
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,9,12,7,8)
+        buffer1:shift(-2, ws2812.SHIFT_CIRCULAR)
+        ok(equalsBuffer(buffer1, buffer2), "shift left")
+        
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,7,9,8,12)
+        buffer1:shift(1, ws2812.SHIFT_CIRCULAR, 2,3)
+        ok(equalsBuffer(buffer1, buffer2), "shift middle right")
+
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,7,9,8,12)
+        buffer1:shift(-1, ws2812.SHIFT_CIRCULAR, 2,3)
+        ok(equalsBuffer(buffer1, buffer2), "shift middle left")
+
+        -- bounds checks, handle gracefully as string:sub does
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,8,9,12,7)
+        buffer1:shift(-1, ws2812.SHIFT_CIRCULAR, 0,5)
+        ok(equalsBuffer(buffer1, buffer2), "shift left out of bound")
+
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,12,7,8,9)
+        buffer1:shift(1, ws2812.SHIFT_CIRCULAR, 0,5)
+        ok(equalsBuffer(buffer1, buffer2), "shift right out of bound")
+
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,12,7,8,9)
+        buffer1:shift(1, ws2812.SHIFT_CIRCULAR, -12,12)
+        ok(equalsBuffer(buffer1, buffer2), "shift right way out of bound")
+
+    end)
+
+    it:should('sub', function()
+        buffer1 = ws2812.newBuffer(4, 4)
+        buffer2 = ws2812.newBuffer(4, 4)
+        initBuffer(buffer1,7,8,9,12)
+        buffer1 = buffer1:sub(4,3)
+        ok(eq(buffer1:size(), 0), "sub empty")
+
+        buffer1 = ws2812.newBuffer(4, 4)
+        buffer2 = ws2812.newBuffer(2, 4)
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,9,12)
+        buffer1 = buffer1:sub(3,4)
+        ok(equalsBuffer(buffer1, buffer2), "sub")
+
+        buffer1 = ws2812.newBuffer(4, 4)
+        buffer2 = ws2812.newBuffer(4, 4)
+        initBuffer(buffer1,7,8,9,12)
+        initBuffer(buffer2,7,8,9,12)
+        buffer1 = buffer1:sub(-12,33)
+        ok(equalsBuffer(buffer1, buffer2), "out of bounds")
+    end)
+
+
+
+
+--[[
+ws2812.buffer:__concat()
+--]]
+
+end)
+
+mispec.run()

--- a/lua_tests/mispec_ws2812_effects.lua
+++ b/lua_tests/mispec_ws2812_effects.lua
@@ -1,0 +1,31 @@
+require 'mispec'
+
+local buffer, buffer1, buffer2
+
+describe('WS2812_effects', function(it)
+
+    it:should('set_speed', function()
+        buffer = ws2812.newBuffer(9, 3)
+        ws2812_effects.init(buffer)
+
+        ws2812_effects.set_speed(0)
+        ws2812_effects.set_speed(255)
+
+        failwith("should be", ws2812_effects.set_speed, -1)
+        failwith("should be", ws2812_effects.set_speed, 256)
+    end)
+
+    it:should('set_brightness', function()
+        buffer = ws2812.newBuffer(9, 3)
+        ws2812_effects.init(buffer)
+
+        ws2812_effects.set_brightness(0)
+        ws2812_effects.set_brightness(255)
+
+        failwith("should be", ws2812_effects.set_brightness, -1)
+        failwith("should be", ws2812_effects.set_brightness, 256)
+    end)
+
+end)
+
+mispec.run()


### PR DESCRIPTION
Fixes #2946 #2921 and more.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Cleanup code and fix issues in `ws2812` and `ws2812_effects`
Besides the afore mentioned ones I fixed a false bounds check in `ws2812_effects.set_brightness` and `ws2812_effects.set_speed`

Also add some automated tests to show the differences between current and this implementation.
You will need to precompile at least the mispec.lua file to not run out of memory.
If you don't like them I will remove them from the PR.
