### PR TITLE
improve mqtt documentation

### DIFF
--- a/docs/modules/mqtt.md
+++ b/docs/modules/mqtt.md
@@ -157,8 +157,8 @@ end
 
 In reality, the connected function should do something useful!
 
-The two callbacks to `:connect()` alias with the "connect" and "offline"
-callbacks available through `:on()`.
+The first callback to `:connect()` aliases with the "connect" callback available through `:on()` (the last passed callback to either of those are used). 
+The second (failure) callback is however not the same as the "offline" `:on()` callback. The "offline" callback is only called after an already established connection becomes closed. If the `connect()` call fails to establish a connection, the callback passed to `:connect()` is called and nothing else.
 
 Previously, we instructed an application to pass either the *integer* 0 or
 *integer* 1 for `secure`.  Now, this will trigger a deprecation warning; please


### PR DESCRIPTION
- [x] This PR is for the dev branch rather than for master.
- [x] This PR is compliant with the other contributing guidelines as well (if not, please describe why).
- [x] have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at docs/*.

The existing documentation invalidly states that the offline callback is same as the connection-failure callback. I had reconnect code only in my 'offline' callback, which made the system fail to reconnect when mqtt connection was not immediately possible after it was disconnected (i.e. timeout did not trigger offline callback)

