### PR TITLE
Sensor driver for BME680 sensor - update to version 3.5.9

### DIFF
--- a/app/modules/bme680.c
+++ b/app/modules/bme680.c
@@ -68,7 +68,10 @@ static uint8_t r8u(uint8_t reg) {
 	return ret[0];
 }
 
-/* This part of code is coming from the original bme680.c driver by Bosch.
+// replace 'dev->calib.' with 'bme680_data.'
+// replace 'dev->amb_temp' with 'amb_temp'
+
+/**\mainpage
  * Copyright (C) 2017 - 2018 Bosch Sensortec GmbH
  *
  * Redistribution and use in source and binary forms, with or without
@@ -108,19 +111,12 @@ static uint8_t r8u(uint8_t reg) {
  * other rights of third parties which may result from its use.
  * No license is granted by implication or otherwise under any patent or
  * patent rights of the copyright holder.
+ *
+ * File		bme680.c
+ * @date	19 Jun 2018
+ * @version	3.5.9
+ *
  */
-
-/**static variables */
-/**Look up table for the possible gas range values */
-uint32_t lookupTable1[16] = { UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647),
-        UINT32_C(2147483647), UINT32_C(2126008810), UINT32_C(2147483647), UINT32_C(2130303777), UINT32_C(2147483647),
-        UINT32_C(2147483647), UINT32_C(2143188679), UINT32_C(2136746228), UINT32_C(2147483647), UINT32_C(2126008810),
-        UINT32_C(2147483647), UINT32_C(2147483647) };
-/**Look up table for the possible gas range values */
-uint32_t lookupTable2[16] = { UINT32_C(4096000000), UINT32_C(2048000000), UINT32_C(1024000000), UINT32_C(512000000),
-        UINT32_C(255744255), UINT32_C(127110228), UINT32_C(64000000), UINT32_C(32258064), UINT32_C(16016016), UINT32_C(
-                8000000), UINT32_C(4000000), UINT32_C(2000000), UINT32_C(1000000), UINT32_C(500000), UINT32_C(250000),
-        UINT32_C(125000) };
 
 static uint8_t calc_heater_res(uint16_t temp)
 {
@@ -132,9 +128,7 @@ static uint8_t calc_heater_res(uint16_t temp)
 	int32_t var5;
 	int32_t heatr_res_x100;
 
-	if (temp < 200) /* Cap temperature */
-		temp = 200;
-	else if (temp > 400)
+	if (temp > 400) /* Cap temperature */
 		temp = 400;
 
 	var1 = (((int32_t) amb_temp * bme680_data.par_gh3) / 1000) * 256;
@@ -173,12 +167,12 @@ static int16_t calc_temperature(uint32_t temp_adc)
 	int64_t var3;
 	int16_t calc_temp;
 
-	var1 = ((int32_t) temp_adc / 8) - ((int32_t) bme680_data.par_t1 * 2);
-	var2 = (var1 * (int32_t) bme680_data.par_t2) / 2048;
-	var3 = ((var1 / 2) * (var1 / 2)) / 4096;
-	var3 = ((var3) * ((int32_t) bme680_data.par_t3 * 16)) / 16384;
+	var1 = ((int32_t) temp_adc >> 3) - ((int32_t) bme680_data.par_t1 << 1);
+	var2 = (var1 * (int32_t) bme680_data.par_t2) >> 11;
+	var3 = ((var1 >> 1) * (var1 >> 1)) >> 12;
+	var3 = ((var3) * ((int32_t) bme680_data.par_t3 << 4)) >> 14;
 	bme680_data.t_fine = (int32_t) (var2 + var3);
-	calc_temp = (int16_t) (((bme680_data.t_fine * 5) + 128) / 256);
+	calc_temp = (int16_t) (((bme680_data.t_fine * 5) + 128) >> 8);
 
 	return calc_temp;
 }
@@ -188,27 +182,37 @@ static uint32_t calc_pressure(uint32_t pres_adc)
 	int32_t var1;
 	int32_t var2;
 	int32_t var3;
-	int32_t calc_pres;
+	int32_t pressure_comp;
 
-	var1 = (((int32_t) bme680_data.t_fine) / 2) - 64000;
-	var2 = ((var1 / 4) * (var1 / 4)) / 2048;
-	var2 = ((var2) * (int32_t) bme680_data.par_p6) / 4;
-	var2 = var2 + ((var1 * (int32_t) bme680_data.par_p5) * 2);
-	var2 = (var2 / 4) + ((int32_t) bme680_data.par_p4 * 65536);
-	var1 = ((var1 / 4) * (var1 / 4)) / 8192;
-	var1 = (((var1) * ((int32_t) bme680_data.par_p3 * 32)) / 8) + (((int32_t) bme680_data.par_p2 * var1) / 2);
-	var1 = var1 / 262144;
-	var1 = ((32768 + var1) * (int32_t) bme680_data.par_p1) / 32768;
-	calc_pres = (int32_t) (1048576 - pres_adc);
-	calc_pres = (int32_t) ((calc_pres - (var2 / 4096)) * (3125));
-	calc_pres = ((calc_pres / var1) * 2);
-	var1 = ((int32_t) bme680_data.par_p9 * (int32_t) (((calc_pres / 8) * (calc_pres / 8)) / 8192)) / 4096;
-	var2 = ((int32_t) (calc_pres / 4) * (int32_t) bme680_data.par_p8) / 8192;
-	var3 = ((int32_t) (calc_pres / 256) * (int32_t) (calc_pres / 256) * (int32_t) (calc_pres / 256)
-	        * (int32_t) bme680_data.par_p10) / 131072;
-	calc_pres = (int32_t) (calc_pres) + ((var1 + var2 + var3 + ((int32_t) bme680_data.par_p7 * 128)) / 16);
+	var1 = (((int32_t)bme680_data.t_fine) >> 1) - 64000;
+	var2 = ((((var1 >> 2) * (var1 >> 2)) >> 11) *
+		(int32_t)bme680_data.par_p6) >> 2;
+	var2 = var2 + ((var1 * (int32_t)bme680_data.par_p5) << 1);
+	var2 = (var2 >> 2) + ((int32_t)bme680_data.par_p4 << 16);
+	var1 = (((((var1 >> 2) * (var1 >> 2)) >> 13) *
+		((int32_t)bme680_data.par_p3 << 5)) >> 3) +
+		(((int32_t)bme680_data.par_p2 * var1) >> 1);
+	var1 = var1 >> 18;
+	var1 = ((32768 + var1) * (int32_t)bme680_data.par_p1) >> 15;
+	pressure_comp = 1048576 - pres_adc;
+	pressure_comp = (int32_t)((pressure_comp - (var2 >> 12)) * ((uint32_t)3125));
+	if (pressure_comp >= BME680_MAX_OVERFLOW_VAL)
+		pressure_comp = ((pressure_comp / var1) << 1);
+	else
+		pressure_comp = ((pressure_comp << 1) / var1);
+	var1 = ((int32_t)bme680_data.par_p9 * (int32_t)(((pressure_comp >> 3) *
+		(pressure_comp >> 3)) >> 13)) >> 12;
+	var2 = ((int32_t)(pressure_comp >> 2) *
+		(int32_t)bme680_data.par_p8) >> 13;
+	var3 = ((int32_t)(pressure_comp >> 8) * (int32_t)(pressure_comp >> 8) *
+		(int32_t)(pressure_comp >> 8) *
+		(int32_t)bme680_data.par_p10) >> 17;
 
-	return (uint32_t) calc_pres;
+	pressure_comp = (int32_t)(pressure_comp) + ((var1 + var2 + var3 +
+		((int32_t)bme680_data.par_p7 << 7)) >> 4);
+
+	return (uint32_t)pressure_comp;
+
 }
 
 static uint32_t calc_humidity(uint16_t hum_adc)
@@ -222,19 +226,19 @@ static uint32_t calc_humidity(uint16_t hum_adc)
 	int32_t temp_scaled;
 	int32_t calc_hum;
 
-	temp_scaled = (((int32_t) bme680_data.t_fine * 5) + 128) / 256;
+	temp_scaled = (((int32_t) bme680_data.t_fine * 5) + 128) >> 8;
 	var1 = (int32_t) (hum_adc - ((int32_t) ((int32_t) bme680_data.par_h1 * 16)))
-	        - (((temp_scaled * (int32_t) bme680_data.par_h3) / ((int32_t) 100)) / 2);
+		- (((temp_scaled * (int32_t) bme680_data.par_h3) / ((int32_t) 100)) >> 1);
 	var2 = ((int32_t) bme680_data.par_h2
-	        * (((temp_scaled * (int32_t) bme680_data.par_h4) / ((int32_t) 100))
-	                + (((temp_scaled * ((temp_scaled * (int32_t) bme680_data.par_h5) / ((int32_t) 100))) / 64)
-	                        / ((int32_t) 100)) + (int32_t) (1 * 16384))) / 1024;
+		* (((temp_scaled * (int32_t) bme680_data.par_h4) / ((int32_t) 100))
+			+ (((temp_scaled * ((temp_scaled * (int32_t) bme680_data.par_h5) / ((int32_t) 100))) >> 6)
+				/ ((int32_t) 100)) + (int32_t) (1 << 14))) >> 10;
 	var3 = var1 * var2;
-	var4 = (int32_t) bme680_data.par_h6 * 128;
-	var4 = ((var4) + ((temp_scaled * (int32_t) bme680_data.par_h7) / ((int32_t) 100))) / 16;
-	var5 = ((var3 / 16384) * (var3 / 16384)) / 1024;
-	var6 = (var4 * var5) / 2;
-	calc_hum = (((var3 + var6) / 1024) * ((int32_t) 1000)) / 4096;
+	var4 = (int32_t) bme680_data.par_h6 << 7;
+	var4 = ((var4) + ((temp_scaled * (int32_t) bme680_data.par_h7) / ((int32_t) 100))) >> 4;
+	var5 = ((var3 >> 14) * (var3 >> 14)) >> 10;
+	var6 = (var4 * var5) >> 1;
+	calc_hum = (((var3 + var6) >> 10) * ((int32_t) 1000)) >> 12;
 
 	if (calc_hum > 100000) /* Cap at 100%rH */
 		calc_hum = 100000;
@@ -244,6 +248,19 @@ static uint32_t calc_humidity(uint16_t hum_adc)
 	return (uint32_t) calc_hum;
 }
 
+
+/**static variables */
+	/**Look up table 1 for the possible gas range values */
+	uint32_t lookupTable1[16] = { UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2147483647),
+		UINT32_C(2147483647), UINT32_C(2126008810), UINT32_C(2147483647), UINT32_C(2130303777),
+		UINT32_C(2147483647), UINT32_C(2147483647), UINT32_C(2143188679), UINT32_C(2136746228),
+		UINT32_C(2147483647), UINT32_C(2126008810), UINT32_C(2147483647), UINT32_C(2147483647) };
+	/**Look up table 2 for the possible gas range values */
+	uint32_t lookupTable2[16] = { UINT32_C(4096000000), UINT32_C(2048000000), UINT32_C(1024000000), UINT32_C(512000000),
+		UINT32_C(255744255), UINT32_C(127110228), UINT32_C(64000000), UINT32_C(32258064), UINT32_C(16016016),
+		UINT32_C(8000000), UINT32_C(4000000), UINT32_C(2000000), UINT32_C(1000000), UINT32_C(500000),
+		UINT32_C(250000), UINT32_C(125000) };
+
 static uint32_t calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range)
 {
 	int64_t var1;
@@ -251,13 +268,15 @@ static uint32_t calc_gas_resistance(uint16_t gas_res_adc, uint8_t gas_range)
 	int64_t var3;
 	uint32_t calc_gas_res;
 
-	var1 = (int64_t) ((1340 + (5 * (int64_t) bme680_data.range_sw_err)) * ((int64_t) lookupTable1[gas_range])) / 65536;
-	var2 = (((int64_t) ((int64_t) gas_res_adc * 32768) - (int64_t) (16777216)) + var1);
-	var3 = (((int64_t) lookupTable2[gas_range] * (int64_t) var1) / 512);
-	calc_gas_res = (uint32_t) ((var3 + ((int64_t) var2 / 2)) / (int64_t) var2);
+	var1 = (int64_t) ((1340 + (5 * (int64_t) bme680_data.range_sw_err)) *
+		((int64_t) lookupTable1[gas_range])) >> 16;
+	var2 = (((int64_t) ((int64_t) gas_res_adc << 15) - (int64_t) (16777216)) + var1);
+	var3 = (((int64_t) lookupTable2[gas_range] * (int64_t) var1) >> 9);
+	calc_gas_res = (uint32_t) ((var3 + ((int64_t) var2 >> 1)) / (int64_t) var2);
 
 	return calc_gas_res;
 }
+
 
 uint16_t calc_dur()
 {

--- a/app/modules/bme680_defs.h
+++ b/app/modules/bme680_defs.h
@@ -39,78 +39,47 @@
  * No license is granted by implication or otherwise under any patent or
  * patent rights of the copyright holder.
  *
- * @file    bme680_defs.h
- * @date    5 Jul 2017
- * @version 3.5.1
- * @brief
- *
+ * @file	  bme680_defs.h
+ * @date	  19 Jun 2018
+ * @version	3.5.9
+ * @brief   Sensor driver for BME680 sensor
  */
 
-/*! @file bme680_defs.h
- @brief Sensor driver for BME680 sensor */
-/*!
- * @defgroup BME680 SENSOR API
- * @brief
- * @{*/
 #ifndef BME680_DEFS_H_
 #define BME680_DEFS_H_
 
-/********************************************************/
-/* header includes */
+/** header includes **/
 #ifdef __KERNEL__
 #include <linux/types.h>
+#include <linux/kernel.h>
 #else
 #include <stdint.h>
+#include <stddef.h>
 #endif
 
-#ifdef __KERNEL__
-#if (LONG_MAX) > 0x7fffffff
-#define __have_long64   1
-#elif (LONG_MAX) == 0x7fffffff
-#define __have_long32   1
+/** Common macros **/
+
+#if !defined(UINT8_C) && !defined(INT8_C)
+#define INT8_C(x)       S8_C(x)
+#define UINT8_C(x)      U8_C(x)
 #endif
 
-#if !defined(UINT8_C)
-#define INT8_C(x)       x
-#if (INT_MAX) > 0x7f
-#define UINT8_C(x)      x
-#else
-#define UINT8_C(x)      x##U
-#endif
-#endif
-
-#if !defined(UINT16_C)
-#define INT16_C(x)      x
-#if (INT_MAX) > 0x7fff
-#define UINT16_C(x)     x
-#else
-#define UINT16_C(x)     x##U
-#endif
+#if !defined(UINT16_C) && !defined(INT16_C)
+#define INT16_C(x)      S16_C(x)
+#define UINT16_C(x)     U16_C(x)
 #endif
 
 #if !defined(INT32_C) && !defined(UINT32_C)
-#if __have_long32
-#define INT32_C(x)      x##L
-#define UINT32_C(x)     x##UL
-#else
-#define INT32_C(x)      x
-#define UINT32_C(x)     x##U
-#endif
+#define INT32_C(x)      S32_C(x)
+#define UINT32_C(x)     U32_C(x)
 #endif
 
 #if !defined(INT64_C) && !defined(UINT64_C)
-#if __have_long64
-#define INT64_C(x)      x##L
-#define UINT64_C(x)     x##UL
-#else
-#define INT64_C(x)      x##LL
-#define UINT64_C(x)     x##ULL
+#define INT64_C(x)      S64_C(x)
+#define UINT64_C(x)     U64_C(x)
 #endif
-#endif
-#endif
-/**@}*/
 
-/**\name C standard macros */
+/** C standard macros **/
 #ifndef NULL
 #ifdef __cplusplus
 #define NULL   0
@@ -119,29 +88,35 @@
 #endif
 #endif
 
-/** BME680 General config */
+/** BME680 configuration macros */
+/** Enable or un-comment the macro to provide floating point data output **/
+#ifndef BME680_FLOAT_POINT_COMPENSATION
+/* #define BME680_FLOAT_POINT_COMPENSATION **/
+#endif
+
+/** BME680 General config **/
 #define BME680_POLL_PERIOD_MS		UINT8_C(10)
 
-/** BME680 I2C addresses */
+/** BME680 I2C addresses **/
 #define BME680_I2C_ADDR_PRIMARY		UINT8_C(0x76)
 #define BME680_I2C_ADDR_SECONDARY	UINT8_C(0x77)
 
-/** BME680 unique chip identifier */
+/** BME680 unique chip identifier **/
 #define BME680_CHIP_ID  UINT8_C(0x61)
 
-/** BME680 coefficients related defines */
-#define BME680_COEFF_SIZE		UINT8_C(0x41)
+/** BME680 coefficients related defines **/
+#define BME680_COEFF_SIZE		UINT8_C(41)
 #define BME680_COEFF_ADDR1_LEN		UINT8_C(25)
 #define BME680_COEFF_ADDR2_LEN		UINT8_C(16)
 
-/** BME680 field_x related defines */
+/** BME680 field_x related defines **/
 #define BME680_FIELD_LENGTH		UINT8_C(15)
 #define BME680_FIELD_ADDR_OFFSET	UINT8_C(17)
 
-/** Soft reset command */
+/** Soft reset command **/
 #define BME680_SOFT_RESET_CMD   UINT8_C(0xb6)
 
-/** Error code definitions */
+/** Error code definitions **/
 #define BME680_OK		INT8_C(0)
 /* Errors */
 #define BME680_E_NULL_PTR		    INT8_C(-1)
@@ -157,22 +132,22 @@
 #define BME680_I_MIN_CORRECTION		UINT8_C(1)
 #define BME680_I_MAX_CORRECTION		UINT8_C(2)
 
-/** Register map */
-/** Other coefficient's address */
+/** Register map **/
+/** Other coefficient's address **/
 #define BME680_ADDR_RES_HEAT_VAL_ADDR	UINT8_C(0x00)
 #define BME680_ADDR_RES_HEAT_RANGE_ADDR	UINT8_C(0x02)
 #define BME680_ADDR_RANGE_SW_ERR_ADDR	UINT8_C(0x04)
 #define BME680_ADDR_SENS_CONF_START	UINT8_C(0x5A)
 #define BME680_ADDR_GAS_CONF_START	UINT8_C(0x64)
 
-/** Field settings */
+/** Field settings **/
 #define BME680_FIELD0_ADDR		UINT8_C(0x1d)
 
-/** Heater settings */
+/** Heater settings **/
 #define BME680_RES_HEAT0_ADDR		UINT8_C(0x5a)
 #define BME680_GAS_WAIT0_ADDR		UINT8_C(0x64)
 
-/** Sensor configuration registers */
+/** Sensor configuration registers **/
 #define BME680_CONF_HEAT_CTRL_ADDR		UINT8_C(0x70)
 #define BME680_CONF_ODR_RUN_GAS_NBC_ADDR	UINT8_C(0x71)
 #define BME680_CONF_OS_H_ADDR			UINT8_C(0x72)
@@ -180,25 +155,25 @@
 #define BME680_CONF_T_P_MODE_ADDR		UINT8_C(0x74)
 #define BME680_CONF_ODR_FILT_ADDR		UINT8_C(0x75)
 
-/** Coefficient's address */
+/** Coefficient's address **/
 #define BME680_COEFF_ADDR1	UINT8_C(0x89)
 #define BME680_COEFF_ADDR2	UINT8_C(0xe1)
 
-/** Chip identifier */
+/** Chip identifier **/
 #define BME680_CHIP_ID_ADDR	UINT8_C(0xd0)
 
-/** Soft reset register */
+/** Soft reset register **/
 #define BME680_SOFT_RESET_ADDR		UINT8_C(0xe0)
 
-/** Heater control settings */
+/** Heater control settings **/
 #define BME680_ENABLE_HEATER		UINT8_C(0x00)
 #define BME680_DISABLE_HEATER		UINT8_C(0x08)
 
-/** Gas measurement settings */
+/** Gas measurement settings **/
 #define BME680_DISABLE_GAS_MEAS		UINT8_C(0x00)
 #define BME680_ENABLE_GAS_MEAS		UINT8_C(0x01)
 
-/** Over-sampling settings */
+/** Over-sampling settings **/
 #define BME680_OS_NONE		UINT8_C(0)
 #define BME680_OS_1X		UINT8_C(1)
 #define BME680_OS_2X		UINT8_C(2)
@@ -206,7 +181,7 @@
 #define BME680_OS_8X		UINT8_C(4)
 #define BME680_OS_16X		UINT8_C(5)
 
-/** IIR filter settings */
+/** IIR filter settings **/
 #define BME680_FILTER_SIZE_0	UINT8_C(0)
 #define BME680_FILTER_SIZE_1	UINT8_C(1)
 #define BME680_FILTER_SIZE_3	UINT8_C(2)
@@ -220,28 +195,27 @@
 #define BME680_SLEEP_MODE	UINT8_C(0)
 #define BME680_FORCED_MODE	UINT8_C(1)
 
-/** Delay related macro declaration */
-#define BME680_RESET_PERIOD		UINT32_C(10)
+/** Delay related macro declaration **/
+#define BME680_RESET_PERIOD	UINT32_C(10)
 
-/** SPI memory page settings */
+/** SPI memory page settings **/
 #define BME680_MEM_PAGE0	UINT8_C(0x10)
 #define BME680_MEM_PAGE1	UINT8_C(0x00)
 
-/** Ambient humidity shift value for compensation */
+/** Ambient humidity shift value for compensation **/
 #define BME680_HUM_REG_SHIFT_VAL	UINT8_C(4)
 
-/** Run gas enable and disable settings */
+/** Run gas enable and disable settings **/
 #define BME680_RUN_GAS_DISABLE	UINT8_C(0)
 #define BME680_RUN_GAS_ENABLE	UINT8_C(1)
 
-/** Buffer length macro declaration */
+/** Buffer length macro declaration **/
 #define BME680_TMP_BUFFER_LENGTH	UINT8_C(40)
 #define BME680_REG_BUFFER_LENGTH	UINT8_C(6)
 #define BME680_FIELD_DATA_LENGTH	UINT8_C(3)
 #define BME680_GAS_REG_BUF_LENGTH	UINT8_C(20)
-#define BME680_GAS_HEATER_PROF_LEN_MAX  UINT8_C(10)
 
-/** Settings selector */
+/** Settings selector **/
 #define BME680_OST_SEL			UINT16_C(1)
 #define BME680_OSP_SEL			UINT16_C(2)
 #define BME680_OSH_SEL			UINT16_C(4)
@@ -250,13 +224,13 @@
 #define BME680_HCNTRL_SEL		UINT16_C(32)
 #define BME680_RUN_GAS_SEL		UINT16_C(64)
 #define BME680_NBCONV_SEL		UINT16_C(128)
-#define BME680_GAS_SENSOR_SEL		UINT16_C(BME680_GAS_MEAS_SEL | BME680_RUN_GAS_SEL | BME680_NBCONV_SEL)
+#define BME680_GAS_SENSOR_SEL		(BME680_GAS_MEAS_SEL | BME680_RUN_GAS_SEL | BME680_NBCONV_SEL)
 
-/** Number of conversion settings*/
+/** Number of conversion settings **/
 #define BME680_NBCONV_MIN		UINT8_C(0)
 #define BME680_NBCONV_MAX		UINT8_C(10)
 
-/** Mask definitions */
+/** Mask definitions **/
 #define BME680_GAS_MEAS_MSK	UINT8_C(0x30)
 #define BME680_NBCONV_MSK	UINT8_C(0X0F)
 #define BME680_FILTER_MSK	UINT8_C(0X1C)
@@ -278,14 +252,14 @@
 #define BME680_SPI_WR_MSK	UINT8_C(0x7f)
 #define	BME680_BIT_H1_DATA_MSK	UINT8_C(0x0F)
 
-/** Bit position definitions for sensor settings */
+/** Bit position definitions for sensor settings **/
 #define BME680_GAS_MEAS_POS	UINT8_C(4)
 #define BME680_FILTER_POS	UINT8_C(2)
 #define BME680_OST_POS		UINT8_C(5)
 #define BME680_OSP_POS		UINT8_C(2)
 #define BME680_RUN_GAS_POS	UINT8_C(4)
 
-/** Array Index to Field data mapping for Calibration Data*/
+/** Array Index to Field data mapping for Calibration Data **/
 #define BME680_T2_LSB_REG	(1)
 #define BME680_T2_MSB_REG	(2)
 #define BME680_T3_REG		(3)
@@ -321,7 +295,7 @@
 #define BME680_GH1_REG		(37)
 #define BME680_GH3_REG		(38)
 
-/** BME680 register buffer index settings*/
+/** BME680 register buffer index settings **/
 #define BME680_REG_FILTER_INDEX		UINT8_C(5)
 #define BME680_REG_TEMP_INDEX		UINT8_C(4)
 #define BME680_REG_PRES_INDEX		UINT8_C(4)
@@ -330,38 +304,51 @@
 #define BME680_REG_RUN_GAS_INDEX	UINT8_C(1)
 #define BME680_REG_HCTRL_INDEX		UINT8_C(0)
 
-/** Macro to combine two 8 bit data's to form a 16 bit data */
+/** BME680 pressure calculation macros **/
+/*! This max value is used to provide precedence to multiplication or division
+ *  in pressure compensation equation to achieve least loss of precision and
+ *  avoiding overflows.
+ *  i.e Comparing value, BME680_MAX_OVERFLOW_VAL = INT32_C(1 << 30)
+ */
+#define BME680_MAX_OVERFLOW_VAL      INT32_C(0x40000000)
+
+/** Macro to combine two 8 bit data's to form a 16 bit data **/
 #define BME680_CONCAT_BYTES(msb, lsb)	(((uint16_t)msb << 8) | (uint16_t)lsb)
 
-/** Macro to SET and GET BITS of a register */
+/** Macro to SET and GET BITS of a register **/
 #define BME680_SET_BITS(reg_data, bitname, data) \
 		((reg_data & ~(bitname##_MSK)) | \
 		((data << bitname##_POS) & bitname##_MSK))
 #define BME680_GET_BITS(reg_data, bitname)	((reg_data & (bitname##_MSK)) >> \
 	(bitname##_POS))
 
-/** Macro variant to handle the bitname position if it is zero */
+/** Macro variant to handle the bitname position if it is zero **/
 #define BME680_SET_BITS_POS_0(reg_data, bitname, data) \
 				((reg_data & ~(bitname##_MSK)) | \
 				(data & bitname##_MSK))
 #define BME680_GET_BITS_POS_0(reg_data, bitname)  (reg_data & (bitname##_MSK))
 
-/** Type definitions */
-/*
- * Generic communication function pointer
- * @param[in] dev_id: Place holder to store the id of the device structure
- * 						Can be used to store the index of the Chip select or
- * 						I2C address of the device.
- * @param[in] reg_addr:	Used to select the register the where data needs to
- * 						be read from or written to.
- * @param[in/out] reg_data: Data array to read/write
- * @param[in] len: Length of the data array
+/** Type definitions **/
+/*!
+ * @brief         Generic communication function pointer
+ * @param[in]     dev_id
+ *                Place holder to store the id of the device structure
+ *                Can be used to store the index of the Chip select or
+ *                I2C address of the device.
+ * @param[in]     reg_addr
+ *                Used to select the register the where data needs to
+ *                be read from or written to.
+ * @param[in/out] reg_data
+ *                Data array to read/write
+ * @param[in]     len 
+ *                Length of the data array
  */
 typedef int8_t (*bme680_com_fptr_t)(uint8_t dev_id, uint8_t reg_addr, uint8_t *data, uint16_t len);
 
-/*
- * Delay function pointer
- * @param[in] period: Time period in milliseconds
+/*!
+ * @brief     Delay function pointer
+ * @param[in] period
+ *            Time period in milliseconds
  */
 typedef void (*bme680_delay_fptr_t)(uint32_t period);
 
@@ -375,7 +362,7 @@ enum bme680_intf {
 	BME680_I2C_INTF
 };
 
-/* structure definitions */
+/** structure definitions **/
 /*!
  * @brief Sensor field data structure
  */
@@ -386,6 +373,8 @@ struct	bme680_field_data {
 	uint8_t gas_index;
 	/*! Measurement index to track order */
 	uint8_t meas_index;
+
+#ifndef BME680_FLOAT_POINT_COMPENSATION
 	/*! Temperature in degree celsius x100 */
 	int16_t temperature;
 	/*! Pressure in Pascal */
@@ -394,6 +383,18 @@ struct	bme680_field_data {
 	uint32_t humidity;
 	/*! Gas resistance in Ohms */
 	uint32_t gas_resistance;
+#else
+	/*! Temperature in degree celsius */
+	float temperature;
+	/*! Pressure in Pascal */
+	float pressure;
+	/*! Humidity in % relative humidity x1000 */
+	float humidity;
+	/*! Gas resistance in Ohms */
+	float gas_resistance;
+
+#endif
+
 };
 
 /*!
@@ -446,8 +447,14 @@ struct	bme680_calib_data {
 	int16_t par_p9;
 	/*! Variable to store calibrated pressure data */
 	uint8_t par_p10;
+
+#ifndef BME680_FLOAT_POINT_COMPENSATION
 	/*! Variable to store t_fine size */
 	int32_t t_fine;
+#else
+	/*! Variable to store t_fine size */
+	float t_fine;
+#endif
 	/*! Variable to store heater resistance range */
 	uint8_t res_heat_range;
 	/*! Variable to store heater resistance value */
@@ -458,7 +465,7 @@ struct	bme680_calib_data {
 
 /*!
  * @brief BME680 sensor settings structure which comprises of ODR,
- * over-sampling and filter settings.
+ *        over-sampling and filter settings.
  */
 struct	bme680_tph_sett {
 	/*! Humidity oversampling */
@@ -473,7 +480,7 @@ struct	bme680_tph_sett {
 
 /*!
  * @brief BME680 gas sensor which comprises of gas settings
- *  and status parameters
+ *        and status parameters
  */
 struct	bme680_gas_sett {
 	/*! Variable to store nb conversion */
@@ -482,9 +489,9 @@ struct	bme680_gas_sett {
 	uint8_t heatr_ctrl;
 	/*! Run gas enable value */
 	uint8_t run_gas;
-	/*! Pointer to store heater temperature */
+	/*! Heater temperature value */
 	uint16_t heatr_temp;
-	/*! Pointer to store duration profile */
+	/*! Duration profile value */
 	uint16_t heatr_dur;
 };
 
@@ -500,7 +507,7 @@ struct	bme680_dev {
 	enum bme680_intf intf;
 	/*! Memory page used */
 	uint8_t mem_page;
-	/*! Ambient temperature in Degree C*/
+	/*! Ambient temperature in Degree C */
 	int8_t amb_temp;
 	/*! Sensor calibration data */
 	struct bme680_calib_data calib;
@@ -514,15 +521,17 @@ struct	bme680_dev {
 	uint8_t new_fields;
 	/*! Store the info messages */
 	uint8_t info_msg;
-	/*! Burst read structure */
+	/*! Bus read function pointer */
 	bme680_com_fptr_t read;
-	/*! Burst write structure */
+	/*! Bus write function pointer */
 	bme680_com_fptr_t write;
-	/*! Delay in ms */
+	/*! delay function pointer */
 	bme680_delay_fptr_t delay_ms;
 	/*! Communication function result */
 	int8_t com_rslt;
 };
+
+
 
 #endif /* BME680_DEFS_H_ */
 /** @}*/


### PR DESCRIPTION
Fixes #2944.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Solves the issue where the air pressure, humidity and gas resistance are not compensated during ambient temperature changes.

Updates the Bosh BME680 driver from version 3.5.1 to current version 3.5.9.