### PR TITLE
lua module ds18b20: fixed missing forward declaration

### DIFF
--- a/lua_modules/ds18b20/ds18b20.lua
+++ b/lua_modules/ds18b20/ds18b20.lua
@@ -50,6 +50,8 @@ local function to_string(addr, esc)
   end
 end
 
+local conversion
+
 local function readout(self)
   local next = false
   local sens = self.sens
@@ -114,7 +116,7 @@ local function readout(self)
   end
 end
 
-local function conversion(self)
+conversion = function (self)
   local sens = self.sens
   local powered_only = true
   for _, s in ipairs(sens) do powered_only = powered_only and s:byte(9) ~= 1 end


### PR DESCRIPTION
I had a runtime excpetion using the lua ds18b20 module. The cobersion function is used before it was declared. So i introduced a forward/deferred declaration for the conversion function before first usage,

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

\<Description of and rationale behind this PR\>
