### PR TITLE
Auto-install SDK if user forgot to. (#2994)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# -*- coding: utf-8, tab-width: 2 -*-
+
 # If we haven't got IDF_PATH set already, reinvoke with IDF_PATH in the environ
 .NOTPARALLEL:
 
@@ -19,6 +21,8 @@ all: | $(ESP32_GCC)
 	@env IDF_PATH=$(IDF_PATH) PATH=$(PATH):$(ESP32_BIN) $(MAKE) -f $(THIS_MK_FILE) $@
 	@if test "$@" = "clean"; then rm -rf $(THIS_DIR)/tools/toolchains/esp32-*; fi
 
+install_toolchain: $(ESP32_GCC)
+
 $(ESP32_GCC): $(ESP32_TOOLCHAIN_DL)
 	@echo Uncompressing toolchain
 	@mkdir -p $(THIS_DIR)/tools/toolchains/
@@ -26,6 +30,8 @@ $(ESP32_GCC): $(ESP32_TOOLCHAIN_DL)
 	# the archive contains ro files
 	@chmod -R u+w $(THIS_DIR)/tools/toolchains/esp32-*
 	@touch $@
+
+download_toolchain: $(ESP32_TOOLCHAIN_DL)
 
 $(ESP32_TOOLCHAIN_DL):
 	@mkdir -p $(THIS_DIR)/cache
@@ -38,6 +44,15 @@ PROJECT_NAME:=NodeMCU
 # This is, sadly, the cleanest way to resolve the different non-standard
 # conventions for sized integers across the various components.
 BASIC_TYPES=-Du32_t=uint32_t -Du16_t=uint16_t -Du8_t=uint8_t -Ds32_t=int32_t -Ds16_t=int16_t -Duint32=uint32_t -Duint16=uint16_t -Duint8=uint8_t -Dsint32=int32_t -Dsint16=int16_t -Dsint8=int8_t
+
+$(IDF_PATH)/make/project.mk:
+	@echo "ESP-IDF isn't properly installed, will try to re-install and then re-run make:"
+	git submodule init
+	git submodule update --recursive
+	python -m pip install --user --requirement $(IDF_PATH)/requirements.txt || echo "W: pip failed, but this might be harmless. Let's just try whether it works anyway." >&2
+  # If we'd just continue, make would fake-succeed albeit with a warning
+  # "make[1]: *** No rule to make target `menuconfig'.  Stop."
+#	$(MAKE) -f $(THIS_MK_FILE) $@ || exit $?
 
 include $(IDF_PATH)/make/project.mk
 


### PR DESCRIPTION
Fixes #2994.

- [x] This PR is for the `dev`<ins>`-esp32`</ins> branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

\<Description of and rationale behind this PR\>
Make the build even easier.