### PR TITLE
ESP32 Makefile: Auto-detect CPU architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ THIS_MK_FILE:=$(notdir $(lastword $(MAKEFILE_LIST)))
 THIS_DIR:=$(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 IDF_PATH=$(THIS_DIR)/sdk/esp32-esp-idf
 
+TOOLCHAIN_RELEASES_BASEURL:=https://github.com/jmattsson/esp-toolchains/releases/
 TOOLCHAIN_VERSION:=20181106.1
 PLATFORM:=linux-$(shell uname --machine)
 
@@ -29,7 +30,7 @@ $(ESP32_GCC): $(ESP32_TOOLCHAIN_DL)
 
 $(ESP32_TOOLCHAIN_DL):
 	@mkdir -p $(THIS_DIR)/cache
-	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused https://github.com/jmattsson/esp-toolchains/releases/download/$(PLATFORM)-$(TOOLCHAIN_VERSION)/toolchain-esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz -O $@ || { rm -f "$@"; exit 1; }
+	wget --tries=10 --timeout=15 --waitretry=30 --read-timeout=20 --retry-connrefused ${TOOLCHAIN_RELEASES_BASEURL}download/$(PLATFORM)-$(TOOLCHAIN_VERSION)/toolchain-esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION).tar.xz -O $@ || { rm -f -- "$@"; echo "W: Download failed. Please check ${TOOLCHAIN_RELEASES_BASEURL} for an appropriate version. If there is none for $(PLATFORM), you might need to compile it yourself."; exit 1; }
 
 else
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ THIS_DIR:=$(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 IDF_PATH=$(THIS_DIR)/sdk/esp32-esp-idf
 
 TOOLCHAIN_VERSION:=20181106.1
-PLATFORM:=linux-x86_64
+PLATFORM:=linux-$(shell uname --machine)
 
 ESP32_BIN:=$(THIS_DIR)/tools/toolchains/esp32-$(PLATFORM)-$(TOOLCHAIN_VERSION)/bin
 ESP32_GCC:=$(ESP32_BIN)/xtensa-esp32-elf-gcc


### PR DESCRIPTION
- [ ] This PR is for the `dev` branch rather than for `master`.
  - Seems like Github uses the wrong (i.e. master branch's) PR template
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

\<Description of and rationale behind this PR\>
The repo we download from only has x86_64 anyway currently, but a
download error will be much more informative than bogus errors from
an incompatible compiler.