### PR TITLE
Bugfix conn metatable method call

### DIFF
--- a/lua_modules/http/httpserver.lua
+++ b/lua_modules/http/httpserver.lua
@@ -89,7 +89,7 @@ do
       local buf = ""
       local method, url
       local ondisconnect = function(conn)
-	conn.on("sent", nil)
+        conn:on("sent", nil)
         collectgarbage("collect")
       end
       -- header parser


### PR DESCRIPTION
Here `conn` is net.socket instance, so it should be called as one.
Otherwise request is very likely to end up with crash and PANIC.

- [ ] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.
