### PR TITLE
#2954: adapt LuaOTA to the new firmware api for the timer and some other sma…

### DIFF
--- a/lua_examples/luaOTA/_doTick.lua
+++ b/lua_examples/luaOTA/_doTick.lua
@@ -1,5 +1,4 @@
--- luacheck: globals self
-if (self.timer) then self.timer:stop() end--SAFETRIM
+--if (self.timer) then self.timer:stop() end--SAFETRIM
 -- function _doTick(self)
 
   -- Upvals
@@ -33,7 +32,7 @@ if (self.timer) then self.timer:stop() end--SAFETRIM
     -- some resources that are no longer needed and set backstop timer for general
     -- timeout.  This also dereferences the previous doTick cb so it can now be GCed.
     collectgarbage()
-    self.timer:alarm(0, 30000, tmr.ALARM_SINGLE, self.startApp)
+    self.timer:alarm(30000, tmr.ALARM_SINGLE, self.startApp)
     return self:_provision(socket,rec)
   end
 

--- a/lua_examples/luaOTA/check.lua
+++ b/lua_examples/luaOTA/check.lua
@@ -45,7 +45,7 @@ end
 
 function self.startApp(arg) --upval: gc, self, wifi
   gc();gc()
-  self.timer.unregister()
+  self.timer:unregister()
   self.socket = nil
   if not self.config.leave then wifi.setmode(wifi.NULLMODE,false) end
   local appMod    = self.config.app   or "luaOTA.default"

--- a/lua_examples/luaOTA/luaOTAserver.lua
+++ b/lua_examples/luaOTA/luaOTAserver.lua
@@ -23,7 +23,7 @@ local socket     = require "socket"
 local lfs        = require "lfs"
 local md5        = require "md5"
 local json       = require "cjson"
-require "etc.strict"  --  see http://www.lua.org/extras/5.1/strict.lua
+require "std.strict"  --  see http://www.lua.org/extras/5.1/strict.lua
 
 -- Local functions (implementation see below) ------------------------------------------
 
@@ -162,6 +162,10 @@ end
 ----------------------------------------------------------------------
 receive_and_parse = function(esp)
   local line = esp:receive("*l")
+  if (not line) then
+    error( "Empty response from ESP, possible cause : file signature failure, check that the secret on ESP and server match", 0)  
+    --return nil
+  end
   local packed_cmd, sig = line:sub(1,#line-6),line:sub(-6)
 -- print("reply:", packed_cmd, sig)
   local status, cmd = pcall(json.decode, packed_cmd)

--- a/lua_examples/luaOTA/luaOTAserver.lua
+++ b/lua_examples/luaOTA/luaOTAserver.lua
@@ -163,7 +163,7 @@ end
 receive_and_parse = function(esp)
   local line = esp:receive("*l")
   if (not line) then
-    error( "Empty response from ESP, possible cause: file signature failure", 0)  
+    error( "Empty response from ESP, possible cause: file signature failure", 0)
     --return nil
   end
   local packed_cmd, sig = line:sub(1,#line-6),line:sub(-6)

--- a/lua_examples/luaOTA/luaOTAserver.lua
+++ b/lua_examples/luaOTA/luaOTAserver.lua
@@ -163,7 +163,7 @@ end
 receive_and_parse = function(esp)
   local line = esp:receive("*l")
   if (not line) then
-    error( "Empty response from ESP, possible cause : file signature failure, check that the secret on ESP and server match", 0)  
+    error( "Empty response from ESP, possible cause: file signature failure", 0)  
     --return nil
   end
   local packed_cmd, sig = line:sub(1,#line-6),line:sub(-6)


### PR DESCRIPTION
Notice : This pull request is based on dev branch as the luaota_improvement branch also based on dev

Fixes #2954

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/*`.

luaOTA is behind the current version of the firmware.
there is a couple of issues. For example, the new api implementation of the timer doesn't match the latest update. we can see that the line 35 in the _doTick.lua still provide the timer id as first argument which the new version of the firmware doesn't take it. There is couple of other small issue that I fixed. I have a workable version with some fixes in this commit

