### PR TITLE
Clarify LFS size build info means capacity

### DIFF
--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -163,7 +163,7 @@ static int node_info( lua_State* L )
       int table_index = lua_gettop(L);
       lua_pushboolean(L, BUILDINFO_SSL);
       lua_setfield(L, table_index, "ssl");
-      lua_pushnumber(L, BUILDINFO_LFS);
+      lua_pushnumber(L, BUILDINFO_LFS_SIZE);
       lua_setfield(L, table_index, "lfs_size");
       lua_pushstring(L, BUILDINFO_MODULES);
       lua_setfield(L, table_index, "modules");

--- a/tools/update_buildinfo.sh
+++ b/tools/update_buildinfo.sh
@@ -22,9 +22,9 @@ cat > $TEMPFILE << EndOfMessage
 #define BUILDINFO_TO_STR(x)	BUILDINFO_STR_HELPER(x)
 
 #ifdef LUA_FLASH_STORE
-#define BUILDINFO_LFS LUA_FLASH_STORE
+#define BUILDINFO_LFS_SIZE LUA_FLASH_STORE
 #else
-#define BUILDINFO_LFS 0
+#define BUILDINFO_LFS_SIZE 0
 #endif
 
 #ifdef CLIENT_SSL_ENABLE
@@ -57,7 +57,7 @@ cat > $TEMPFILE << EndOfMessage
   "\trelease DTS: " BUILDINFO_RELEASE_DTS "\n" \\
   "\tSSL: " BUILDINFO_SSL_STR "\n" \\
   "\tbuild type: " BUILDINFO_BUILD_TYPE "\n" \\
-  "\tLFS: " BUILDINFO_TO_STR(BUILDINFO_LFS) "\n" \\
+  "\tLFS: " BUILDINFO_TO_STR(BUILDINFO_LFS_SIZE) " bytes total capacity\n" \\
   "\tmodules: " BUILDINFO_MODULES "\n"
 
 EndOfMessage


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

Trivial clarification that the LFS build info means its capacity. For a while I was unsure about it because mine shows zero, so I was wondering if it might mean the amount used, or the start position.