### PR TITLE
net: rename net.if.info to net.ifinfo

### DIFF
--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -1008,12 +1008,12 @@ field_from_ipaddr(lua_State *L, const char * field_name, ip_addr_t* addr) {
   lua_setfield(L, -2, field_name);
 }
 
-static int net_if_info( lua_State* L ) {
+static int net_ifinfo( lua_State* L ) {
   int ifidx = luaL_optint(L, 1, 0);
 
   struct netif * nif = eagle_lwip_getif(ifidx);
   if (nif == NULL) {
-    return luaL_error( L, "unknown network interface index %d", ifidx);
+    return 0;
   }
 
   lua_createtable(L, 0,
@@ -1088,18 +1088,14 @@ LROT_BEGIN(net_dns)
   LROT_FUNCENTRY( resolve, net_dns_static )
 LROT_END( net_dns, net_dns, 0 )
 
-LROT_BEGIN(net_if)
-  LROT_FUNCENTRY( info, net_if_info )
-LROT_END(net_if, net_if, 0)
-
 LROT_BEGIN(net)
   LROT_FUNCENTRY( createServer, net_createServer )
   LROT_FUNCENTRY( createConnection, net_createConnection )
   LROT_FUNCENTRY( createUDPSocket, net_createUDPSocket )
+  LROT_FUNCENTRY( ifinfo, net_ifinfo )
   LROT_FUNCENTRY( multicastJoin, net_multicastJoin )
   LROT_FUNCENTRY( multicastLeave, net_multicastLeave )
   LROT_TABENTRY( dns, net_dns )
-  LROT_TABENTRY( if, net_if )
 #ifdef TLS_MODULE_PRESENT
   LROT_TABENTRY( cert, tls_cert )
 #endif

--- a/docs/modules/net.md
+++ b/docs/modules/net.md
@@ -83,6 +83,41 @@ none
 #### See also
 [`net.createConnection()`](#netcreateconnection)
 
+## net.ifinfo()
+
+Return information about a network interface, specified by index.
+
+#### Syntax
+`net.ifinfo(if_index)`
+
+#### Parameters
+- `if_index` the interface index; on ESP8266, `0` is the wifi client (STA) and `1`
+   is the wifi AP.
+
+#### Returns
+`nil` if the given `if_index` does not correspond to an interface.  Otherwise,
+a table containing ...
+
+* `ip`, `netmask`, and `gateway` configured for this interface, as dotted quad strings
+  or `nil` if none is set.
+
+* if DHCP was used to configure the interface, then `dhcp` will be a table containing...
+
+  * `server_ip` -- the DHCP server itself, as a dotted quad
+
+  * `client_ip` -- the IP address suggested for the client; likely, this equals `ip`
+    above, unless the configuration has been overridden.
+
+  * `ntp_server` -- the NTP server suggested by the DHCP server.
+
+DNS servers are not tracked per-interface in LwIP and, as such, are not
+reported here; use [`net.dns:getdnsserver()`](#netdnsgetdnsserver).
+
+#### Example
+
+`print(net.ifinfo(0).dhcp.ntp_server)` will show the NTP server suggested by
+the DHCP server.
+
 ## net.multicastJoin()
 
 Join multicast group.
@@ -617,43 +652,6 @@ Sets the IP of the DNS server used to resolve hostnames. Default: resolver1.open
 
 #### See also
 [`net.dns:getdnsserver()`](#netdnsgetdnsserver)
-
-# net.if Module
-
-## net.if.info()
-
-Return information about a network interface, specified by index.
-
-#### Syntax
-`net.if.info(if_index)`
-
-#### Parameters
-- `if_index` the interface index; on ESP8266, `0` is the wifi client (STA) and `1`
-   is the wifi AP.
-
-#### Returns
-`nil` if the given `if_index` does not correspond to an interface.  Otherwise,
-a table containing ...
-
-* `ip`, `netmask`, and `gateway` configured for this interface, as dotted quad strings
-  or `nil` if none is set.
-
-* if DHCP was used to configure the interface, then `dhcp` will be a table containing...
-
-  * `server_ip` -- the DHCP server itself, as a dotted quad
-
-  * `client_ip` -- the IP address suggested for the client; likely, this equals `ip`
-    above, unless the configuration has been overridden.
-
-  * `ntp_server` -- the NTP server suggested by the DHCP server.
-
-DNS servers are not tracked per-interface in LwIP and, as such, are not
-reported here; use [`net.dns:getdnsserver()`](#netdnsgetdnsserver).
-
-#### Example
-
-`print(net.if.info(0).dhcp.ntp_server)` will show the NTP server suggested by
-the DHCP server.
 
 # net.cert Module
 


### PR DESCRIPTION
Reserved words are always reserved in Lua, so let's not have people
typing net["if"]...

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.
