### PR TITLE
Update getting-started docs hrefs for LFS examples

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -268,10 +268,11 @@ The easiest approach is to maintain all the Lua files for your project in a sing
 
 For example to run the Telnet and FTP servers from LFS, put the following files in your project directory:
 
-* [lua_examples/lfs/_init.lua](https://github.com/nodemcu/nodemcu-firmware/tree/master/lua_examples/lfs/_init.lua).  LFS helper routines and functions.
-* [lua_examples/lfs/dummy_strings.lua](https://github.com/nodemcu/nodemcu-firmware/tree/master/lua_examples/lfs/dummy_strings.lua).  Moving common strings into LFS.
-* [lua_examples/telnet/telnet.lua](https://github.com/nodemcu/nodemcu-firmware/tree/master/lua_examples/telnet/telnet.lua).  A simple **telnet** server.
-* [lua_modules/ftp/ftpserver.lua](https://github.com/nodemcu/nodemcu-firmware/tree/master/lua_modules/ftp/ftpserver.lua).  A simple **FTP** server.
+* [lua_examples/lfs/_init.lua](../lua_examples/lfs/_init.lua).  LFS helper routines and functions.
+* [lua_examples/lfs/dummy_strings.lua](../lua_examples/lfs/dummy_strings.lua).  Moving common strings into LFS.
+* [lua_examples/telnet/telnet_fifosock.lua](../lua_examples/telnet/telnet_fifosock.lua).  A simple **telnet** server (example 1).
+* [lua_examples/telnet/telnet_pipe.lua](../lua_examples/telnet/telnet_pipe.lua).  A simple **telnet** server (example 2).
+* [lua_modules/ftp/ftpserver.lua](../lua_modules/ftp/ftpserver.lua).  A simple **FTP** server.
 
 You should always include the first two modules, but the remaining files would normally be replaced by your own project files.  Also remember that these are examples and that you are entirely free to modify or to replace them for your own application needs.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -268,10 +268,10 @@ The easiest approach is to maintain all the Lua files for your project in a sing
 
 For example to run the Telnet and FTP servers from LFS, put the following files in your project directory:
 
-* [lua_examples/lfs/_init.lua](https://github.com/nodemcu/nodemcu-firmware/tree/dev/lua_examples/lfs/_init.lua).  LFS helper routines and functions.
-* [lua_examples/lfs/dummy_strings.lua](https://github.com/nodemcu/nodemcu-firmware/tree/dev/lua_examples/lfs/dummy_strings.lua).  Moving common strings into LFS.
-* [lua_examples/telnet/telnet.lua](https://github.com/nodemcu/nodemcu-firmware/tree/dev/lua_examples/telnet/telnet.lua).  A simple **telnet** server.
-* [lua_modules/ftp/ftpserver.lua](https://github.com/nodemcu/nodemcu-firmware/tree/dev/lua_modules/ftp/ftpserver.lua).  A simple **FTP** server.
+* [lua_examples/lfs/_init.lua](https://github.com/nodemcu/nodemcu-firmware/tree/master/lua_examples/lfs/_init.lua).  LFS helper routines and functions.
+* [lua_examples/lfs/dummy_strings.lua](https://github.com/nodemcu/nodemcu-firmware/tree/master/lua_examples/lfs/dummy_strings.lua).  Moving common strings into LFS.
+* [lua_examples/telnet/telnet.lua](https://github.com/nodemcu/nodemcu-firmware/tree/master/lua_examples/telnet/telnet.lua).  A simple **telnet** server.
+* [lua_modules/ftp/ftpserver.lua](https://github.com/nodemcu/nodemcu-firmware/tree/master/lua_modules/ftp/ftpserver.lua).  A simple **FTP** server.
 
 You should always include the first two modules, but the remaining files would normally be replaced by your own project files.  Also remember that these are examples and that you are entirely free to modify or to replace them for your own application needs.
 


### PR DESCRIPTION
Ensure that the href links under the LFS section points to the master branch on GitHub.
See issue #3045

Fixes #3045.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

The build docs on RTD are done against the master branch. This PR updates the LFS examples links on the Getting Started page to point to the master branch instead of dev
