### PR TITLE
esp32: Unref gpio.trig callbacks when type=INTR_DISABLE (#2880)

### DIFF
--- a/docs/modules/gpio.md
+++ b/docs/modules/gpio.md
@@ -67,17 +67,18 @@ Read digital GPIO pin value.
 Establish or clear a callback function to run on interrupt for a GPIO.
 
 #### Syntax
-`gpio.trig(pin, type [, callback])`
+`gpio.trig(pin [, type [, callback]])`
 
 #### Parameters
 - `pin`, see [GPIO Overview](#gpio-overview)
 - `type` trigger type, one of
+    - `gpio.INTR_DISABLE` or `nil` to disable interrupts on this pin (in which case `callback` is ignored and should be `nil` or omitted)
     - `gpio.INTR_UP` for trigger on rising edge
     - `gpio.INTR_DOWN` for trigger on falling edge
     - `gpio.INTR_UP_DOWN` for trigger on both edges
     - `gpio.INTR_LOW` for trigger on low level
     - `gpio.INTR_HIGH` for trigger on high level
-- `callback` optional function to be called when trigger fires, trigger is disabled when omitted. Parameters are:
+- `callback` optional function to be called when trigger fires. If `nil` or omitted (and `type` is not `gpio.INTR_DISABLE`) then any previously-set callback will continue to be used. Parameters are:
     - `pin`
     - `level`
 


### PR DESCRIPTION
Fixes #2880

- [x] This PR is for the `dev` branch rather than for `master`. (_actually dev-esp32_)
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

As per my comment on the issue, this change documents how to use `gpio.INTR_DISABLE` to disable an interrupt trigger, and also ensures that the callback is unrefd (and `gpio_isr_handler_remove` is called) when that happens.

It also brings the API more in line with the esp8266 version by making `type` be optional and corrects the description of what happens when `callback` is nil. The [esp8266 docs](https://nodemcu.readthedocs.io/en/dev/modules/gpio/#gpiotrig) say:

> If the type is "none" _or omitted_ then the callback function is removed and the interrupt is disabled
> ...
> The previous callback function will be used if the function is omitted

Testing:
* Checked that calling`gpio.trig(N, gpio.INTR_DISABLE)` unrefs any existing callback (checked the output of `for k,v in pairs(debug.getregistry()) do print(k,v) end` and verified there was one fewer keys listed)
* Checked that `gpio.trig(N)` is equivalent to `gpio.trig(N, gpio.INTR_DISABLE)`
* Checked a disabled interrupt can be reenabled with another call to `gpio.trig(N, TYPE, callback)`
* Checked that changing the interrupt type with a nil callback eg `gpio.trig(N, gpio.INTR_DOWN)` preserves and keeps calling the same callback.
* Checked that calling `gpio.trig(N, gpio.INTR_DISABLE, callback)` with a non-nil callback does not cause a ref to `callback` and will not cause `callback` to be called if a subsequent call to trig with a non-zero type and a nil callback is made.
