### PR TITLE
fix #2565 by inverting the grb2hsv argcheck condition

### DIFF
--- a/app/modules/color_utils.c
+++ b/app/modules/color_utils.c
@@ -217,7 +217,7 @@ static int cu_grb2hsv(lua_State *L) {
   const int r = luaL_checkint(L, 2);
   const int b = luaL_checkint(L, 3);
 
-  luaL_argcheck(L, g == r && g == b, 1, "greyscale value cannot be converted to hsv");
+  luaL_argcheck(L, g != r || g != b, 1, "greyscale value cannot be converted to hsv");
 
   uint32_t hsv = grb2hsv(g, r, b);
 


### PR DESCRIPTION
Fixes #2565.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [] The code changes are reflected in the documentation at `docs/*`.

The arg check condition for `color_utils.grb2hsv()`, which was intended to protect against greyscale values, did opposite by only allowing greyscale values.

After inverting check condition, I was able to use the function. 
