### PR TITLE
Address build error when path contains whitespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ESP32_TOOLCHAIN_DL:=$(THIS_DIR)/cache/toolchain-esp32-$(PLATFORM)-$(TOOLCHAIN_VE
 all: | $(ESP32_GCC)
 %: | $(ESP32_GCC)
 	@echo Setting IDF_PATH and re-invoking...
-	@env IDF_PATH=$(IDF_PATH) PATH=$(PATH):$(ESP32_BIN) $(MAKE) -f $(THIS_MK_FILE) $@
+	@env IDF_PATH=$(IDF_PATH) PATH="$(PATH):$(ESP32_BIN)" $(MAKE) -f $(THIS_MK_FILE) $@
 	@if test "$@" = "clean"; then rm -rf $(THIS_DIR)/tools/toolchains/esp32-*; fi
 
 install_toolchain: $(ESP32_GCC)


### PR DESCRIPTION
- [x] This PR is for the `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines]
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

The path environment under Windows Subsystem for Linux typically 
contains paths with spaces.

Error Manifests as: -

Setting IDF_PATH and re-invoking...
/bin/sh: 1: Syntax error: "(" unexpected
Makefile:21: recipe for target 'flash' failed

Tested on Ubuntu 18.04 both on Linux proper and WSL.