### PR TITLE
esp32: Correct level value in gpio.trig() callback (#2883)

### DIFF
--- a/components/modules/gpio.c
+++ b/components/modules/gpio.c
@@ -216,7 +216,7 @@ static void nodemcu_gpio_callback_task (task_param_t param, task_prio_t prio)
 {
   (void)prio;
   uint32_t gpio = (uint32_t)param & 0xffu;
-  int level = ((int)param) & 0x100u;
+  int level = (((int)param) & 0x100u) >> 8;
 
   lua_State *L = lua_getstate ();
   if (gpio_cb_refs[gpio] != LUA_NOREF)


### PR DESCRIPTION
Fixes #2883.

- [x] This PR is for the ~dev~ `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well.
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This PR changes the `level` parameter passed to the `gpio.trig()` callback so that it matches the documentation, ie `0` or `1` rather than the current behaviour of `0` or `256`. **This is a change in behaviour** which potentially could break existing code, but it's the Right Thing from the point of view of matching the documentation and matching peoples' expectations having not used the API before. I'm not sure how such changes are normally handled, I can update the docs to note the change in behaviour if desired? As it stands I haven't changed the docs since the change is to bring the implementation in line with what the docs say should be happening.

Testing done:

```
> gpio.config({ gpio=26, dir=gpio.IN, pull=gpio.PULL_DOWN })
> gpio.trig(26, gpio.INTR_UP_DOWN, print)
-- Raised and lowered pin 26 a couple of times
> 26    1
26      0
26      1
26      0
```
(previously those `1`s were `256`)