### PR TITLE
ESP32: Simplify task.c to use handles as callbacks

### DIFF
--- a/components/task/include/task/task.h
+++ b/components/task/include/task/task.h
@@ -27,9 +27,8 @@ bool task_post(task_prio_t priority, task_handle_t handle, task_param_t param);
 #define task_post_medium(handle,param) task_post(TASK_PRIORITY_MEDIUM, handle, param)
 #define task_post_high(handle,param)   task_post(TASK_PRIORITY_HIGH,   handle, param)
 
-inline task_handle_t task_get_id(task_callback_t t) {
-    return (task_handle_t)t;
-}
+task_handle_t task_get_id(task_callback_t t);
+bool lua_run(task_prio_t priority, task_param_t param, task_callback_t callback);
 
 /* Init, must be called before any posting happens */
 void task_init (void);

--- a/components/task/include/task/task.h
+++ b/components/task/include/task/task.h
@@ -13,9 +13,9 @@ typedef enum {
   TASK_PRIORITY_COUNT
 } task_prio_t;
 
-typedef uint32_t task_handle_t;
 typedef intptr_t task_param_t;
-
+typedef void (*task_callback_t)(task_param_t param, task_prio_t prio);
+typedef task_callback_t task_handle_t;
 /*
 * Signals are a 32-bit number of the form header:14; count:18. The header
 * is just a fixed fingerprint and the count is allocated serially by the
@@ -27,9 +27,9 @@ bool task_post(task_prio_t priority, task_handle_t handle, task_param_t param);
 #define task_post_medium(handle,param) task_post(TASK_PRIORITY_MEDIUM, handle, param)
 #define task_post_high(handle,param)   task_post(TASK_PRIORITY_HIGH,   handle, param)
 
-typedef void (*task_callback_t)(task_param_t param, task_prio_t prio);
-
-task_handle_t task_get_id(task_callback_t t);
+inline task_handle_t task_get_id(task_callback_t t) {
+    return (task_handle_t)t;
+}
 
 /* Init, must be called before any posting happens */
 void task_init (void);


### PR DESCRIPTION
- [X] This PR is for the `dev-esp32` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/*`.

This PR simplifies `task.c` code to avoid having to register "nodemcu tasks". These nodemcu tasks are actually a collection of registered event callbacks (rather than actually tasks) that can be posted to via a handle.

Instead of registering a callback and obtaining a handle (which is actually an index to a dynamic array of function pointers), this refactor uses the callback pointer directly, so it is not actually necessary to register and maintain this array.

In oder to make this a step by step refactor and make it easier to understand, the interface of `tasks.c` is left intact. Further changes will clean up code using `tasks.c` 

This refactor results in using a little bit less of memory, no dynamic allocation and better performance since no pointer lookups are necessary when dispatching events.