### PR TITLE
Fix for #3089 - update hook after updating gpio bits

### DIFF
--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -307,6 +307,10 @@ int platform_gpio_register_intr_hook(uint32_t bits, platform_hook_function hook)
       uint32_t old_bits = oh.entry[i].bits;
       *(volatile uint32_t *) &oh.entry[i].bits = bits;
       *(volatile uint32_t *) &oh.all_bits = (oh.all_bits & ~old_bits) | bits;
+      ETS_GPIO_INTR_DISABLE();
+      // This is a structure copy, so interrupts need to be disabled
+      platform_gpio_hook = oh;
+      ETS_GPIO_INTR_ENABLE();
       return 1;
     }
   }


### PR DESCRIPTION
Fixes #3089 

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This little patch should fix problem that occurs  when modules like `rotary` or `softuart` hooks to gpio ISR more than one time.

If anyone could test if using more than one rotary encoder works with this patch (as this also should affect `rotary` module and I think without this patch only the first registered encoder would work) I would be thankful.
