### PR TITLE
u8g2: Fix name of updateDisplay export

### DIFF
--- a/app/modules/u8g2.c
+++ b/app/modules/u8g2.c
@@ -607,7 +607,7 @@ LROT_BEGIN(lu8g2_display, NULL, LROT_MASK_INDEX)
   LROT_FUNCENTRY( setFontRefHeightExtendedText, lu8g2_setFontRefHeightExtendedText )
   LROT_FUNCENTRY( setFontRefHeightText, lu8g2_setFontRefHeightText )
   LROT_FUNCENTRY( setPowerSave, lu8g2_setPowerSave )
-  LROT_FUNCENTRY( updateDispla, lu8g2_updateDisplay )
+  LROT_FUNCENTRY( updateDisplay, lu8g2_updateDisplay )
   LROT_FUNCENTRY( updateDisplayArea, lu8g2_updateDisplayArea )
 LROT_END(lu8g2_display, NULL, LROT_MASK_INDEX)
 


### PR DESCRIPTION
Correct typo in Lua export from updateDispla() to updateDisplay()

- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [N/A] The code changes are reflected in the documentation at `docs/*`.

The function is called `updateDisplay()` everywhere except in the Lua export.