### PR TITLE
esp32: Expose gpio_set_drive_capability API to Lua

### DIFF
--- a/components/modules/gpio.c
+++ b/components/modules/gpio.c
@@ -211,6 +211,17 @@ static int lgpio_write (lua_State *L)
 }
 
 
+// Lua: gpio.set_drive(gpio, gpio.DRIVE_x)
+static int lgpio_set_drive (lua_State *L)
+{
+  int gpio = luaL_checkint (L, 1);
+  int strength = luaL_checkint (L, 2);
+  luaL_argcheck (L, strength >= GPIO_DRIVE_CAP_0 && strength < GPIO_DRIVE_CAP_MAX,
+    2, "pad strength must be between gpio.DRIVE_0 and gpio.DRIVE_3");
+  check_err (L, gpio_set_drive_capability(gpio, (gpio_drive_cap_t)strength));
+  return 0;
+}
+
 
 static void nodemcu_gpio_callback_task (task_param_t param, task_prio_t prio)
 {
@@ -245,6 +256,7 @@ LROT_BEGIN(lgpio)
   LROT_FUNCENTRY( trig,         lgpio_trig )
   LROT_FUNCENTRY( wakeup,       lgpio_wakeup )
   LROT_FUNCENTRY( write,        lgpio_write )
+  LROT_FUNCENTRY( set_drive,    lgpio_set_drive )
 
 
   LROT_NUMENTRY ( OUT,          GPIO_MODE_OUTPUT )
@@ -262,6 +274,12 @@ LROT_BEGIN(lgpio)
   LROT_NUMENTRY ( INTR_UP_DOWN, GPIO_INTR_ANYEDGE )
   LROT_NUMENTRY ( INTR_LOW,     GPIO_INTR_LOW_LEVEL )
   LROT_NUMENTRY ( INTR_HIGH,    GPIO_INTR_HIGH_LEVEL )
+
+  LROT_NUMENTRY ( DRIVE_0,      GPIO_DRIVE_CAP_0 )
+  LROT_NUMENTRY ( DRIVE_1,      GPIO_DRIVE_CAP_1 )
+  LROT_NUMENTRY ( DRIVE_2,      GPIO_DRIVE_CAP_2 )
+  LROT_NUMENTRY ( DRIVE_DEFAULT,GPIO_DRIVE_CAP_DEFAULT )
+  LROT_NUMENTRY ( DRIVE_3,      GPIO_DRIVE_CAP_3 )
 LROT_END(lgpio, NULL, 0)
 
 NODEMCU_MODULE(GPIO, "gpio", lgpio, nodemcu_gpio_init);

--- a/docs/modules/gpio.md
+++ b/docs/modules/gpio.md
@@ -63,6 +63,29 @@ Read digital GPIO pin value.
 0 = low, 1 = high
 
 
+## gpio.set_drive()
+Set the drive strength of a given GPIO pin. The higher the drive strength, the more current can be sourced/sunk from the pin. The exact maximum depends on the power domain of the pin and how much current other pins in that domain are consuming.
+
+#### Syntax
+`gpio.set_drive(pin, strength)`
+
+#### Parameters
+- `pin`, a valid GPIO pin number.
+- `strength` the drive strength to set, one of
+    - `gpio.DRIVE_0` weakest drive strength
+    - `gpio.DRIVE_1` stronger drive strength
+    - `gpio.DRIVE_2` default drive strength
+    - `gpio.DRIVE_3` maximum drive strength
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+gpio.set_drive(4, gpio.DRIVE_3)
+```
+
+
 ## gpio.trig()
 Establish or clear a callback function to run on interrupt for a GPIO.
 

--- a/docs/modules/gpio.md
+++ b/docs/modules/gpio.md
@@ -75,6 +75,7 @@ Set the drive strength of a given GPIO pin. The higher the drive strength, the m
     - `gpio.DRIVE_0` weakest drive strength
     - `gpio.DRIVE_1` stronger drive strength
     - `gpio.DRIVE_2` default drive strength
+    - `gpio.DRIVE_DEFAULT` default drive strength (same as `DRIVE_2`)
     - `gpio.DRIVE_3` maximum drive strength
 
 #### Returns


### PR DESCRIPTION
Addresses #3098.

- [x] This PR is for the ~`dev`~ `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well.
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

As discussed on the issue, this PR exposes the API to set drive strength on a GPIO pad so its maximum current output can be increased (or decreased).