### PR TITLE
Extend max year from 2038 to 2106 in epoch2cal()

### DIFF
--- a/app/modules/rtctime.c
+++ b/app/modules/rtctime.c
@@ -91,10 +91,10 @@ void rtctime_deep_sleep_until_aligned_us (uint32_t align_us, uint32_t min_us)
   rtc_time_deep_sleep_until_aligned (align_us, min_us);
 }
 
-void rtctime_gmtime (const int32 stamp, struct rtc_tm *r)
+void rtctime_gmtime (const uint32 stamp, struct rtc_tm *r)
 {
   int32_t i;
-  int32_t work = stamp % (SPD);
+  uint32_t work = stamp % (SPD);
   r->tm_sec = work % 60; work /= 60;
   r->tm_min = work % 60; r->tm_hour = work / 60;
   work = stamp / (SPD);
@@ -208,8 +208,7 @@ static int rtctime_dsleep_aligned (lua_State *L)
 static int rtctime_epoch2cal (lua_State *L)
 {
   struct rtc_tm date;
-  int32_t stamp = luaL_checkint (L, 1);
-  luaL_argcheck (L, stamp >= 0, 1, "wrong arg range");
+  uint32_t stamp = luaL_checknumber (L, 1);
 
   rtctime_gmtime (stamp, &date);
 

--- a/docs/modules/rtctime.md
+++ b/docs/modules/rtctime.md
@@ -92,7 +92,7 @@ Converts a Unix timestamp to calendar format. Neither timezone nor DST correctio
 #### Returns
 A table containing the fields:
 
-- `year` 1970 ~ 2038
+- `year` 1970 ~ 2106
 - `mon` month 1 ~ 12 in current year
 - `day` day 1 ~ 31 in current month
 - `hour`

--- a/docs/modules/rtctime.md
+++ b/docs/modules/rtctime.md
@@ -87,7 +87,7 @@ Converts a Unix timestamp to calendar format. Neither timezone nor DST correctio
 `rtctime.epoch2cal(timestamp)`
 
 #### Parameters
-`timestamp` seconds since Unix epoch
+`timestamp` seconds since Unix epoch (Mind that unlike Unix timestamp this can not have negative values)
 
 #### Returns
 A table containing the fields:


### PR DESCRIPTION
- [X] This PR is for the `dev` branch rather than for `master`.
- [X] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/*`.

__Description:__
Using unsigned integer instead of signed increases amount of seconds that we can use as timestamp in rtctime.epoch2cal(stamp) function by two times.
Current max value is 2147483647 which is 19 January 2038. New value is 4294967295 which is 7 February 2106.
