### PR TITLE
Kconfig: rename LUA_MODULE_* to NODEMCU_CMODULE_*

### DIFF
--- a/components/base_nodemcu/include/module.h
+++ b/components/base_nodemcu/include/module.h
@@ -54,12 +54,12 @@
 #define LOCK_IN_SECTION(s) __attribute__((used,unused,section(".lua_" #s)))
 #endif
 /* For the ROM table, we name the variable according to ( | denotes concat):
- *   cfgname | _module_selected | CONFIG_LUA_MODULE_##cfgname
- * where the CONFIG_LUA_MODULE_XYZ macro is first expanded to yield either
+ *   cfgname | _module_selected | CONFIG_NODEMCU_CMODULE_##cfgname
+ * where the CONFIG_NODEMCU_CMODULE_XYZ macro is first expanded to yield either
  * an empty string (or 1) if the module has been enabled, or the literal
- * CONFIG_LUA_MODULE_XYZ in the case it hasn't. Thus, the name of the variable
+ * CONFIG_NODEMCU_CMODULE_XYZ in the case it hasn't. Thus, the name of the variable
  * ends up looking either like XYZ_module_enabled, or if not enabled,
- * XYZ_module_enabledCONFIG_LUA_MODULE_XYZ.  This forms the basis for
+ * XYZ_module_enabledCONFIG_NODEMCU_CMODULE_XYZ.  This forms the basis for
  * letting the build system detect automatically (via nm) which modules need
  * to be linked in.
  */
@@ -67,6 +67,6 @@
   const LOCK_IN_SECTION(libs) \
     luaR_entry MODULE_PASTE_(lua_lib_,cfgname) = { luaname, LRO_FUNCVAL(initfunc) }; \
   const LOCK_IN_SECTION(rotable) \
-    luaR_entry MODULE_EXPAND_PASTE_(cfgname,MODULE_EXPAND_PASTE_(_module_selected,MODULE_PASTE_(CONFIG_LUA_MODULE_,cfgname))) \
+    luaR_entry MODULE_EXPAND_PASTE_(cfgname,MODULE_EXPAND_PASTE_(_module_selected,MODULE_PASTE_(CONFIG_NODEMCU_CMODULE_,cfgname))) \
     = {luaname, LRO_ROVAL(map ## _map)}
 #endif

--- a/components/modules/Kconfig
+++ b/components/modules/Kconfig
@@ -47,125 +47,125 @@ depends on LUA_BUILTIN_DEBUG
 endmenu
 
 
-config LUA_MODULE_ADC
+config NODEMCU_CMODULE_ADC
   bool "ADC module"
   default "n"
   help
       Includes the adc module. This module provides access to the
       adc1 hardware.
 
-config LUA_MODULE_BIT
+config NODEMCU_CMODULE_BIT
   bool "Bit module"
   default "n"
   help
       Includes the bit module. This module provide bit manipulation functions
       on Lua numbers.
 
-config LUA_MODULE_BTHCI
+config NODEMCU_CMODULE_BTHCI
   bool "BlueTooth HCI interface module"
   default "n"
   select BT_ENABLED
   help
       Includes the simple BlueTooth HCI module.
 
-config LUA_MODULE_CAN
+config NODEMCU_CMODULE_CAN
   bool "CAN module"
   default "n"
   help
       Includes the can module.
 
-config LUA_MODULE_CRYPTO
+config NODEMCU_CMODULE_CRYPTO
   bool "Crypto module"
   default "n"
   help
       Includes the crypto module.
 
-config LUA_MODULE_DAC
+config NODEMCU_CMODULE_DAC
   bool "DAC module"
   default "n"
   help
       Includes the dac module.
 
-config LUA_MODULE_DHT
+config NODEMCU_CMODULE_DHT
   bool "DHT11/21/22/AM2301/AM2302 module"
   default "n"
   help
       Includes the dht module.
 
-config LUA_MODULE_ENCODER
+config NODEMCU_CMODULE_ENCODER
   bool "Encoder module"
   default "n"
   help
       Includes the encoder module. This provides hex and base64 encoding and
       decoding functionality.
 
-config LUA_MODULE_ETH
+config NODEMCU_CMODULE_ETH
   bool "Ethernet module"
   default "n"
   help
       Includes the ethernet module.
 
-config LUA_MODULE_FILE
+config NODEMCU_CMODULE_FILE
   bool "File module"
   default "y"
   help
       Includes the file module (recommended).
 
-config LUA_MODULE_GPIO
+config NODEMCU_CMODULE_GPIO
   bool "GPIO module"
   default "y"
   help
       Includes the GPIO module (recommended).
 
-config LUA_MODULE_HTTP
+config NODEMCU_CMODULE_HTTP
   bool "HTTP module"
   default "y"
   help
       Includes the HTTP module (recommended).
 
-config LUA_MODULE_I2C
+config NODEMCU_CMODULE_I2C
   bool "I2C module"
   default "y"
   help
       Includes the I2C module (recommended).
 
-config LUA_MODULE_I2S
+config NODEMCU_CMODULE_I2S
   bool "I2S module"
   default "n"
   help
       Includes the I2S module.
 
-config LUA_MODULE_LEDC
+config NODEMCU_CMODULE_LEDC
   bool "LEDC module"
   default "n"
   help
       Includes the LEDC module.
 
-config LUA_MODULE_MQTT
+config NODEMCU_CMODULE_MQTT
   bool "MQTT module"
   default "n"
   help
       Includes the MQTT module.
 
-config LUA_MODULE_NET
+config NODEMCU_CMODULE_NET
   bool "Net module"
   default "y"
   help
       Includes the net module (recommended).
 
-config LUA_MODULE_NODE
+config NODEMCU_CMODULE_NODE
   bool "Node module"
   default "y"
   help
       Includes the node module (recommended).
 
-config LUA_MODULE_OW
+config NODEMCU_CMODULE_OW
   bool "1-Wire module"
   default "y"
   help
       Includes the 1-Wire (ow) module (recommended).
 
-config LUA_MODULE_OTAUPGRADE
+config NODEMCU_CMODULE_OTAUPGRADE
   bool "Over-The-Air upgrade module"
   default "n"
   help
@@ -173,70 +173,70 @@ config LUA_MODULE_OTAUPGRADE
       a partition table with at least two OTA partitions, plus the OTA data
       partition. See the IDF documentation for details.
 
-config LUA_MODULE_PULSECNT
+config NODEMCU_CMODULE_PULSECNT
   bool "Pulse counter module"
   default "n"
   help
       Includes the pulse counter module to use ESP32's built-in pulse counting hardware.
 
-config LUA_MODULE_QRCODEGEN
+config NODEMCU_CMODULE_QRCODEGEN
   bool "QR Code Generator module"
   default "n"
   help
       Includes the QR Code Generator from
       https://www.nayuki.io/page/qr-code-generator-library
 
-config LUA_MODULE_SDMMC
+config NODEMCU_CMODULE_SDMMC
   bool "SD-MMC module"
   default "n"
   help
       Includes the sdmmc module.
 
-config LUA_MODULE_SIGMA_DELTA
+config NODEMCU_CMODULE_SIGMA_DELTA
   bool "Sigma-Delta module"
   default "n"
   help
       Includes the sigma_delta module. This module provides access to the
       sigma-delta hardware.
 	  
-config LUA_MODULE_SJSON
+config NODEMCU_CMODULE_SJSON
   bool "SJSON module"
   default "n"
   help
       Includes the sjson module.
 
-config LUA_MODULE_SODIUM
+config NODEMCU_CMODULE_SODIUM
   bool "Sodium module"
   default "n"
   help
       Includes the libsodium crypto module.
 
-config LUA_MODULE_SPI
+config NODEMCU_CMODULE_SPI
   bool "SPI module"
   default "n"
   help
       Includes the spi module.
 
-config LUA_MODULE_STRUCT
+config NODEMCU_CMODULE_STRUCT
   bool "Struct module"
   default "n"
   help
       Includes the struct module. This module provides [un]packing of raw
       byte strings into Lua values and vice versa.
 
-config LUA_MODULE_TMR
+config NODEMCU_CMODULE_TMR
   bool "Timer module"
   default "y"
   help
       Includes the timer module (recommended).
 
-config LUA_MODULE_TOUCH
+config NODEMCU_CMODULE_TOUCH
   bool "Touch module"
   default "n"
   help
       Includes the touch module to use ESP32's built-in touch sensor hardware.
 
-config LUA_MODULE_U8G2
+config NODEMCU_CMODULE_U8G2
   bool "U8G2 module"
   default "n"
   help
@@ -244,28 +244,28 @@ config LUA_MODULE_U8G2
 
 source "$PROJECT_PATH/components/u8g2/u8g2.kconfig"
 
-config LUA_MODULE_UCG
+config NODEMCU_CMODULE_UCG
   bool "UCG module"
   default "n"
-  select LUA_MODULE_SPI
+  select NODEMCU_CMODULE_SPI
   help
       Includes the ucg module.
 
 source "$PROJECT_PATH/components/ucg/ucg.kconfig"
 
-config LUA_MODULE_WIFI
+config NODEMCU_CMODULE_WIFI
   bool "WiFi module"
   default "y"
   help
       Includes the WiFi module (recommended).
 
-config LUA_MODULE_WS2812
+config NODEMCU_CMODULE_WS2812
   bool "WS2812 module"
   default "n"
   help
       Includes the ws2812 module.
 	  
-config LUA_MODULE_TIME
+config NODEMCU_CMODULE_TIME
   bool "Time module"
   default "n"
   help

--- a/components/modules/bthci.c
+++ b/components/modules/bthci.c
@@ -32,7 +32,7 @@
  */
 
 #include "sdkconfig.h"
-#ifdef CONFIG_LUA_MODULE_BTHCI
+#ifdef CONFIG_NODEMCU_CMODULE_BTHCI
 
 #include "module.h"
 #include "lauxlib.h"

--- a/components/modules/component.mk
+++ b/components/modules/component.mk
@@ -1,5 +1,5 @@
 # Match up all the module source files with their corresponding Kconfig
-# option in the form LUA_MODULE_<modname> and if enabled, add a
+# option in the form NODEMCU_CMODULE_<modname> and if enabled, add a
 # "-u <modname>_module_selected1" option to force the linker to include
 # the module. See components/core/include/module.h for further details on
 # how this works.
@@ -13,8 +13,8 @@ ifneq (4.0, $(firstword $(sort $(MAKE_VERSION) 4.0)))
 endif
 
 MODULE_NAMES:=$(call uppercase,$(patsubst $(COMPONENT_PATH)/%.c,%,$(wildcard $(COMPONENT_PATH)/*.c)))
-FORCE_LINK:=$(foreach mod,$(MODULE_NAMES),$(if $(CONFIG_LUA_MODULE_$(mod)), -u $(mod)_module_selected1))
-COMPONENT_ADD_LDFLAGS=$(FORCE_LINK) -lmodules $(if $(CONFIG_LUA_MODULE_BTHCI),-lbtdm_app)
+FORCE_LINK:=$(foreach mod,$(MODULE_NAMES),$(if $(CONFIG_NODEMCU_CMODULE_$(mod)), -u $(mod)_module_selected1))
+COMPONENT_ADD_LDFLAGS=$(FORCE_LINK) -lmodules $(if $(CONFIG_NODEMCU_CMODULE_BTHCI),-lbtdm_app)
 
 # These are disabled by default in the IDF, so switch them back on
 CFLAGS += \

--- a/components/modules/u8g2.c
+++ b/components/modules/u8g2.c
@@ -19,7 +19,7 @@
 #include "sdkconfig.h"
 #endif
 
-#ifndef CONFIG_LUA_MODULE_U8G2
+#ifndef CONFIG_NODEMCU_CMODULE_U8G2
 // ignore unused functions if u8g2 module will be skipped anyhow
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif

--- a/components/modules/ucg.c
+++ b/components/modules/ucg.c
@@ -19,7 +19,7 @@
 #include "sdkconfig.h"
 #endif
 
-#ifndef CONFIG_LUA_MODULE_UCG
+#ifndef CONFIG_NODEMCU_CMODULE_UCG
 // ignore unused functions if ucg module will be skipped anyhow
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif

--- a/components/platform/Kconfig
+++ b/components/platform/Kconfig
@@ -137,7 +137,7 @@ config LUA_EMBEDDED_FLASH_STORE
 config BUILD_FATFS
   bool "Support for FAT filesystems"
   default "n"
-  select LUA_MODULE_SDMMC
+  select NODEMCU_CMODULE_SDMMC
   help
       Include support for accessing FAT filesystems on SD cards.
 

--- a/components/platform/include/user_version.h
+++ b/components/platform/include/user_version.h
@@ -6,9 +6,9 @@
 #define NODE_VERSION_REVISION	0U
 #define NODE_VERSION_INTERNAL   0U
 
-#define NODE_VERSION	"NodeMCU ESP32"
+#define NODE_VERSION	"NodeMCU ESP32" " built with Docker provided by frightanic.com\n\tbranch: dev-esp32\n\tcommit: f4887bf134235c05e6c9b2efad370e6d5018f91a\n\tSSL: true\n\tmodules: -\n"
 #ifndef BUILD_DATE
-#define BUILD_DATE	  "unspecified"
+#define BUILD_DATE	  "created on 2020-05-30 18:01\n"
 #endif
 
 #define SDK_VERSION "IDF"

--- a/components/u8g2/u8g2.kconfig
+++ b/components/u8g2/u8g2.kconfig
@@ -1,9 +1,9 @@
 menu "Displays"
-     depends on LUA_MODULE_U8G2
+     depends on NODEMCU_CMODULE_U8G2
 
 menuconfig U8G2_COMM_I2C
        bool "I2C"
-       select LUA_MODULE_I2C
+       select NODEMCU_CMODULE_I2C
        default "y"
 
 config U8G2_I2C_LD7032_60X32
@@ -204,7 +204,7 @@ config U8G2_I2C_UC1611_EW50850
 
 menuconfig U8G2_COMM_SPI
        bool "SPI"
-       select LUA_MODULE_SPI
+       select NODEMCU_CMODULE_SPI
        default "y"
 
 config U8G2_SPI_HX1230_96X68
@@ -625,10 +625,10 @@ config U8G2_SPI_UC1701_MINI12864
 endmenu
 
 menu "Fonts"
-     depends on LUA_MODULE_U8G2
+     depends on NODEMCU_CMODULE_U8G2
 
 config U8G2_FONT_SELECTION
-       depends on LUA_MODULE_U8G2
+       depends on NODEMCU_CMODULE_U8G2
        string  "Font list"
        default "font_6x10_tf,font_unifont_t_symbols"
        help

--- a/components/ucg/ucg.kconfig
+++ b/components/ucg/ucg.kconfig
@@ -1,63 +1,63 @@
 menu "Displays"
-     depends on LUA_MODULE_UCG
+     depends on NODEMCU_CMODULE_UCG
 
 config UCG_DISPLAY_HX8352C_18X240X400
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "hx8352c_18x240x400_hw_spi"
        default "n"
 
 config UCG_DISPLAY_ILI9163_18X128X128
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "ili9163_18x128x128_hw_spi"
        default "n"
 
 config UCG_DISPLAY_ILI9341_18X240X320
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "ili9341_18x240x320_hw_spi"
        default "y"
 
 config UCG_DISPLAY_ILI9486_18X320X480
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "ili9486_18x320x480_hw_spi"
        default "n"
 
 config UCG_DISPLAY_PCF8833_16X132X132
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "pcf8833_16x132x132_hw_spi"
        default "n"
 
 config UCG_DISPLAY_SEPS225_16X128X128_UNIVISION
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "seps225_16x128x128_uvis_hw_spi"
        default "n"
 
 config UCG_DISPLAY_SSD1351_18X128X128_ILSOFT
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "ssd1351_18x128x128_hw_spi"
        default "n"
 
 config UCG_DISPLAY_SSD1351_18X128X128_FT
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "ssd1351_18x128x128_ft_hw_spi"
        default "n"
 
 config UCG_DISPLAY_SSD1331_18X96X64_UNIVISION
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "ssd1331_18x96x64_uvis_hw_spi"
        default "n"
 
 config UCG_DISPLAY_ST7735_18X128X160
-       depends on LUA_MODULE_SPI
+       depends on NODEMCU_CMODULE_SPI
        bool "st7735_18x128x160_hw_spi"
        default "y"
 
 endmenu
 
 menu "Fonts"
-     depends on LUA_MODULE_UCG
+     depends on NODEMCU_CMODULE_UCG
 
 config UCG_FONT_SELECTION
-       depends on LUA_MODULE_UCG
+       depends on NODEMCU_CMODULE_UCG
        string  "Font list"
        default "font_7x13B_tr,font_helvB08_hr,font_helvB10_hr,font_helvB12_hr,font_helvB18_hr,font_ncenB24_tr,font_ncenR12_tr,font_ncenR14_hr"
        help

--- a/docs/extn-developer-faq.md
+++ b/docs/extn-developer-faq.md
@@ -29,10 +29,10 @@ This is a non-exhaustive list, obviously, but some key points are:
   - **`user_modules.h` is also gone**. Module selection is now done
     via Kconfig. Rather than adding a #define to `user_modules.h`,
     add an option in `components/modules/Kconfig` of the form
-    `LUA_MODULE_XYZ`, and the existing `NODEMCU_MODULE()` macros
+    `NODEMCU_CMODULE_XYZ`, and the existing `NODEMCU_MODULE()` macros
     will take care of the rest. Example Kconfig entry:
     ```
-    config LUA_MODULE_XYZ
+    config NODEMCU_CMODULE_XYZ
       bool "Xyz module"
       default "y"
       help


### PR DESCRIPTION
As we begin to contemplate baking into firmware modules entirely written
in Lua or which are split between both Lua and C, the name LUA_MODULE_*
more obviously refers to the in-Lua bits, so rename the C ones out of
the way.

- [x] This PR is for the `dev-esp32` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

I have not yet convinced my machine to build for the esp32, but I think this is probably about right.  Still, someone checking for me would be welcome.

This is part of #3130, indirectly, at least in keeping with the idea of harmonizing the two branches.