### PR TITLE
deprecate rc module

### DIFF
--- a/app/modules/rc.c
+++ b/app/modules/rc.c
@@ -33,6 +33,10 @@ static int ICACHE_FLASH_ATTR rc_send(lua_State* L) {
   NODE_ERR("Protocol:%d\n",Protocol);
   NODE_ERR("repeat:%d\n",repeat);
   NODE_ERR("send:");
+
+  platform_print_deprecation_note("rc",
+    "in the next release. Use rfswitch module instead.");
+  
   int c,k,nRepeat;
   bits = bits-1;
   for (c = bits; c >= 0; c--)

--- a/docs/modules/rc.md
+++ b/docs/modules/rc.md
@@ -8,6 +8,10 @@ Superseded by **[rfswitch](./rfswitch.md)** module which have same functionality
 
 For more detailed description see [rfswitch module documentation](./rfswitch.md).
 
+!!! caution
+
+    This module is deprecated and will be removed in favor of the **[rfswitch](./rfswitch.md)** module.
+
 ## rc.send()
 Sends series of impulses
 


### PR DESCRIPTION
Amends #3134.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Add deprecation note before removing module