### PR TITLE
WIP: Kconfig

### DIFF
--- a/app/Kconfig.user
+++ b/app/Kconfig.user
@@ -1,0 +1,289 @@
+menu "Global Configuration Parameters"
+
+choice NODEMCU_FLASH_SIZE # {{{
+  default NODEMCU_FLASH_SIZE_AUTO
+  prompt "Flash Size (bytes)"
+  help
+    The firmware supports a range of Flash sizes, though 4 Mbyte seems to be
+    the most common currently.  NodeMCU builds include a discovery function
+    which is enabled by FLASH_AUTOSIZE, but you can override this by commenting
+    this out and enabling the explicitly size.
+
+  config NODEMCU_FLASH_SIZE_512K
+    bool "512K"
+  
+  config NODEMCU_FLASH_SIZE_1M
+    bool "1M"
+  
+  config NODEMCU_FLASH_SIZE_2M
+    bool "2M"
+  
+  config NODEMCU_FLASH_SIZE_4M
+    bool "4M"
+  
+  config NODEMCU_FLASH_SIZE_8M
+    bool "8M"
+  
+  config NODEMCU_FLASH_SIZE_16M
+    bool "16M"
+  
+  config NODEMCU_FLASH_SIZE_AUTO
+    bool "Auto-detect"
+
+endchoice # }}}
+choice NODEMCU_DEFAULT_BAUD_RATE # {{{
+  default NODEMCU_DEFAULT_BAUD_RATE_115200
+  help
+    The firmware now selects a baudrate of 115,200 by default, which can be
+    changed here. The driver also includes automatic baud rate detection at
+    start-up.
+
+    The options 368640, 921600, and 1843200 are not recommended as they are
+    unreliable.  460800 seems to work well with most USB-serial interfaces.
+
+  config NODEMCU_DEFAULT_BAUD_RATE_300
+    bool "300"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_600
+    bool "600"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_1200
+    bool "1200"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_2400
+    bool "2400"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_4800
+    bool "4800"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_9600
+    bool "9600"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_19200
+    bool "19200"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_31250
+    bool "31250"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_38400
+    bool "38400"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_57600
+    bool "57600"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_74880
+    bool "74880"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_115200
+    bool "115200"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_230400
+    bool "230400"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_256000
+    bool "256000"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_368640
+    bool "368640"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_460800
+    bool "460800"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_921600
+    bool "921600"
+
+  config NODEMCU_DEFAULT_BAUD_RATE_1843200
+    bool "1843200"
+
+endchoice # }}}
+
+config NODEMCU_STARTUP_BANNER
+  bool "Enable startup banner"
+  default "y"
+  help
+    At start-up firmware details like:
+    
+      NodeMCU 3.0.1.0
+              branch:
+              commit:
+              release:
+              release DTS:
+              SSL: false
+              build type: integer
+              LFS: 0x0
+              modules: file,gpio,net,node,rtctime,sntp,tmr,uart,wifi
+       build 2020-01-27 17:39 powered by Lua 5.1.4 on SDK 3.0.2(824dc80)
+    
+    will be printed to serial console.  While it is mandatory for bug reports
+    and good for development, it may be unwanted for non-interactive serial
+    devices.
+
+config LUA_NUMBER_INTEGRAL
+  bool "Use 32-bit ints for Lua numbers, rather than 64-bit floats"
+  default "n"
+
+config LUA_DWORD_ALIGNED_TVALUES
+  depends on !LUA_NUMBER_INTEGRAL
+  bool "Pad floating TValues to 16, not 12, bytes"
+  default "n"
+
+config LUA_FLASH_STORE
+  hex "Lua Flash Store default partition size (bytes)"
+  default 0
+  help
+    The Lua Flash Store (LFS) allows you to store Lua code in Flash memory and
+    the Lua VMS will execute this code directly from flash without needing any
+    RAM overhead.  You can now configure LFS directly in the System Partition
+    Table insted of at compile time. However for backwards compatibility setting
+    LUA_FLASH_STORE defines the default partition size if the NodeMCU partition
+    tool is not used.
+
+config LUA_INIT_STRING
+  string "Lua initialization string"
+  default "@init.lua"
+  help
+    By default Lua executes the file init.lua at start up.  This option allows
+    you to replace this with an alternative startup.  For example, this string
+    executes the LFS module "_init" at startup or falls back to the interactive
+    prompt:
+
+      pcall(function() node.flashindex'_init'() end)
+
+    Warning: you must protect this execution otherwise you will enter a panic
+    loop; the simplest way is to wrap the action in a function invoked by a
+    pcall as shown.
+
+menuconfig NODEMCU_SPIFFS
+  bool "Enable SPIFFS support"
+  default "y"
+if NODEMCU_SPIFFS
+
+  config NODEMCU_SPIFFS_CACHE
+    bool "Enable SPIFFS caching"
+    default "y"
+
+  config NODEMCU_SPIFFS_DEFAULT_SIZE
+    hex "Default SPIFFS partition size (0xFFFFFFFF = all remaining FLASH)"
+    default 0xFFFFFFFF
+    help
+      You can now configure SPIFFS size and position directly in the System
+      Partition Table.  However for backwards compatibility
+      SPIFFS_MAX_FILESYSTEM_SIZE can be set and this defines the default SPIFFS
+      partition size if the NodeMCU partition tool is not used. The value
+      0xFFFFFFFF means the maximum size remaining.
+
+  config NODEMCU_SPIFFS_MAX_OPEN_FILES
+    int "Maximum number of open SPIFFS files"
+    default 4
+
+endif
+
+config NODEMCU_FATFS
+  bool "Enable FATFS support"
+  default "n"
+
+config NODEMCU_FS_OBJ_NAME_LEN
+  int "Maximum length of a filename (bytes)"
+  depends on NODEMCU_SPIFFS || NODEMCU_FATFS
+  default 31
+
+menuconfig NODEMCU_TLS_ENABLE
+  bool "Enable TLS support"
+  default "n"
+if NODEMCU_TLS_ENABLE
+
+  config NODEMCU_SHA2_ENABLE
+    bool "Enable the SHA2 family of hash functions"
+    default "y"
+
+  config NODEMCU_TLS_BUFFER_SIZE
+    int "Maximum TLS buffer size"
+    default 4096
+
+  choice NODEMCU_TLS_MAX_FRAGMENT_SIZE
+    prompt "Advertize a maximum fragment size for TLS connections (bytes)"
+    default NODEMCU_TLS_MAX_FRAGMENT_SIZE_4096
+
+    config NODEMCU_TLS_MAX_FRAGMENT_SIZE_NONE
+      bool "No"
+
+    config NODEMCU_TLS_MAX_FRAGMENT_SIZE_512
+      bool "512"
+
+    config NODEMCU_TLS_MAX_FRAGMENT_SIZE_1024
+      bool "1024"
+
+    config NODEMCU_TLS_MAX_FRAGMENT_SIZE_2048
+      bool "2048"
+
+    config NODEMCU_TLS_MAX_FRAGMENT_SIZE_4096
+      bool "4096"
+
+  endchoice
+
+endif
+
+config NODEMCU_GPIO_INTERRUPT
+  bool "Support GPIO interrupts"
+  default "y"
+  help
+    Necessary if your application uses the gpio.trig() or related GPIO
+    interrupt service routine code.  Disabling this may remove some runtime
+    overhead.
+
+config NODEMCU_GPIO_INTERRUPT_HOOK
+  bool "Support GPIO interrupt hooks"
+  depends on NODEMCU_GPIO_INTERRUPT
+  default "y"
+  help
+    Augment GPIO interrupt support with hook functionality; required for a few
+    modules such as rotary
+
+config NODEMCU_TIMER_SUSPEND
+  bool "Enable suspending timers"
+  default "n"
+
+config NODEMCU_PMSLEEP
+  bool "Enable power-management sleep"
+  default "n"
+
+menu "Development and Debugging Options" # {{{
+
+config NODEMCU_DEVELOPMENT_TOOLS
+  bool "Enable asserts in firmware, extras in node module"
+  default "n"
+  help
+    Adds the asserts in LUA and also some useful extras to the node module.
+    These are silent in normal operation and so can be enabled without any harm
+    (except for the code size increase and slight slowdown).
+
+config NODEMCU_DEVELOPMENT_GDB
+  bool "Use GDB to catch breaks and failed assertions"
+  depends on NODEMCU_DEVELOPMENT_TOOLS
+  default "n"
+  help 
+    Enable if you want to use the remote GDB to handle breaks and failed
+    assertions.
+
+config NODEMCU_DEVELOPMENT_GDB_GPIO
+  bool "Break on startup conditioned on GPIO"
+  depends on NODEMCU_DEVELOPMENT_GDB
+  default "n"
+  help
+    Allows specification of a GPIO pin, which if pulled low at start-up will
+    immediately initiate a GDB session.
+
+config NODEMCU_DEVELOPMENT_GDB_GPIO_PIN
+  int "GPIO pin for to initiate GDB session on startup"
+  depends on NODEMCU_DEVELOPMENT_GDB_GPIO
+  default 1
+
+config NODEMCU_DEVELOP_VERSION
+  bool "Globally enable debugging spew"
+  default "n"
+  help
+    Enables lots of debug output; normally only used by hardcore developers.
+
+endmenu # }}}
+
+endmenu

--- a/app/modules/Kconfig
+++ b/app/modules/Kconfig
@@ -161,6 +161,30 @@ config NODEMCU_CMODULE_WIFI
   help
     Provides access to the on-board WiFi chipset
 
+config NODEMCU_CMODULE_WIFI__EVENT
+  bool "Enable WiFi Event callbacks"
+  depends on NODEMCU_CMODULE_WIFI
+  default "y"
+  help
+    Enables wifi.sta.config() event callbacks
+
+config NODEMCU_CMODULE_WIFI__EVENT_DISCONN_REASON
+  bool "Enable wifi.eventmon.reason table"
+  depends on NODEMCU_CMODULE_WIFI
+  default "y"
+
+config NODEMCU_CMODULE_WIFI__SMART
+  bool "Use the Espressif SDK WiFi connection management logic"
+  depends on NODEMCU_CMODULE_WIFI
+  default "n"
+  help
+    The WiFi module optionally offers an enhanced level of WiFi connection
+    management, using internal timer callbacks.  Whilst many Lua developers
+    prefer to implement equivalent features in Lua, others will prefer the
+    Wifi module to do this for them.  Selecting "y" here will enable the
+    wifi.startsmart() and wifi.stopsmart() functions.  See the documentation
+    for further details, as the scope of these changes is not obvious.
+
 config NODEMCU_CMODULE_WIFI_MONITOR
   bool "wifi.monitor Module"
   default "n"
@@ -186,6 +210,14 @@ config NODEMCU_CMODULE_ENDUSER_SETUP
   help
     Configure ESP8266 over WiFi rather than a UART link
 
+config NODEMCU_CMODULE_ENDUSER_SETUP__AP_SSID
+  string "enduser_setup default AP name"
+  depends on NODEMCU_CMODULE_ENDUSER_SETUP
+  default "SetupGadget"
+  help
+    Set the default SSID when this module is running in AP mode as part of
+    enduser setup.
+
 config NODEMCU_CMODULE_HTTP
   bool "http Module"
   default "n"
@@ -206,6 +238,11 @@ config NODEMCU_CMODULE_MQTT
 
 config NODEMCU_CMODULE_NET
   bool "net Module"
+  default "y"
+
+config NODEMCU_CMODULE_NET__PING
+  bool "net.ping support"
+  depends on NODEMCU_CMODULE_NET
   default "y"
 
 config NODEMCU_CMODULE_SNTP
@@ -238,6 +275,27 @@ config NODEMCU_CMODULE_I2C
   default "n"
   help
     Inter-Integrated Circuit (I2C, IIC) AKA Two-Wire Interface (TWI) master
+
+config NODEMCU_CMODULE_I2C__OLD
+  bool "Use the old I2C software driver"
+  default "n"
+  depends on NODEMCU_CMODULE_I2C
+  help
+    For compatibility reasons you can switch to old version of I2C software driver.
+    It does not support changing speed, have only one bus id = 0, does not support GPIO16
+    and works only in Standard(slow) mode with clock speed around 50kHz.
+
+config NODEMCU_CMODULE_I2C__GPIO16
+  bool "Enable the use of GPIO16 with the I2C module"
+  depends on NODEMCU_CMODULE_I2C && !NODEMCU_CMODULE_I2C__OLD
+  default "n"
+  help
+    The new I2C software driver partially supports use of GPIO16 (D0) pin for
+    SCL line.  GPIO16 does not support open-drain mode and works in push-pull
+    mode, so clock stretching will not be possible, because circuit in slave
+    device that supposed to drive SCL low during stretching will not be able
+    to hold SCL low.  Also I2C speed will be limited to no more than 400000
+    Hz (FAST mode).
 
 config NODEMCU_CMODULE_OW
   bool "ow Module"

--- a/app/modules/Kconfig
+++ b/app/modules/Kconfig
@@ -1,0 +1,361 @@
+menu "NodeMCU modules"
+
+menu "Data Structures and Mathematics" # {{{
+
+config NODEMCU_CMODULE_BIT
+  bool "bit Module"
+  default "n"
+  help
+    Provides native functions for bitwise math operations
+
+config NODEMCU_CMODULE_BLOOM
+  bool "Bloom Module"
+  default "n"
+  help
+    Bloom filters are efficient stochastic sets with one-sided error.
+
+config NODEMCU_CMODUlE_COLOR_UTILS
+  bool "color utils Module"
+  default "n"
+  help
+    Functions for performing math in and between different color spaces.
+
+config NODEMCU_CMODULE_CRYPTO
+  bool "crypto Module"
+  default "n"
+  depends on NODEMCU_CMODULE_ENCODER
+  help
+   Functions for low-level cryptography: hashes, MACs, & symmetric ciphering
+
+config NODEMCU_CMODULE_ENCODER
+  bool "encoder Module"
+  default "n"
+  help
+    Base16 and Base64 en-/de-coding
+
+config NODEMCU_CMODULE_PIPE
+  bool "pipe Module"
+  default "n"
+  help
+    An efficient queue of bytes
+
+config NODEMCU_CMODULE_SJSON
+  bool "SJSON module"
+  default "n"
+  help
+    Bindings to the jsonsl library for JSON en-/de-coding
+
+config NODEMCU_CMODULE_STRUCT
+  bool "struct Module"
+  default "n"
+  help
+    Provides a simple packed structure (de)serializer
+
+endmenu # }}}
+menu "Development and Debugging" # {{{
+
+config NODEMCU_CMODULE_GDBSTUB
+  bool "gdbstub Module"
+  default "n"
+  help
+    The gdb stub allows interactive debugging of the NodeMCU firmware from
+    a remote computer using the UART link.
+
+config NODEMCU_CMODULE_PERF
+  bool "perf Module"
+  default "n"
+  help
+    A sampling-based statistical runtime profiler
+
+endmenu # }}}
+menu "ESP8266 Intrinsic Feature Support" # {{{
+
+config NODEMCU_CMODULE_ADC
+  bool "adc Module"
+  default "n"
+  help
+    Provides access to the on-board one-channel ADC
+
+config NODEMCU_CMODULE_CRON
+  bool "cron Module"
+  default "n"
+  help
+    Exposes on-device timers with crontab-style specification for callbacks
+
+config NODEMCU_CMODULE_FILE
+  bool "file Module"
+  default "y"
+  help
+    Exposes on-device FLASH as a filesystem using SPIFFS
+
+config NODEMCU_CMODULE_GPIO
+  bool "gpio Module"
+  default "y"
+  help
+    Provides access to hardware General Purpose I/O pins
+
+config NODEMCU_CMODULE_GPIO_PULSE
+  bool "gpio_pulse Module"
+  default "y"
+  help
+    Generates accurately-timed square waveforms on GPIO pins
+
+config NODEMCU_CMODULE_NODE
+  bool "node Module"
+  default "y"
+  help
+    Exposes information about NodeMCU and the hardware; is also the interface
+    to LFS and for rebooting the module.
+
+config NODEMCU_CMODULE_PCM
+  bool "pcm Module"
+  default "n"
+  help
+    Feeds PCM data to the onboard sigma-delta generator 
+
+config NODEMCU_CMODULE_PWM
+  bool "pwm Module"
+  default "n"
+
+config NODEMCU_CMODULE_PWM2
+  bool "pwm2 Module"
+  default "n"
+
+config NODEMCU_CMODULE_RTCFIFO
+  bool "rtcfifo Module"
+  default "n"
+  help
+    Provides access to the onboard RTC memory through a FIFO interface.
+
+config NODEMCU_CMODULE_RTCMEM
+  bool "rtcmem Module"
+  default "n"
+  help
+    Provides raw access to the onboard RTC memory
+
+config NODEMCU_CMODULE_RTCTIME
+  bool "rtctime Module"
+  default "n"
+  help
+    Advanced time-keeping support using the onboard RTC
+
+config NODEMCU_CMODULE_SIGMA_DELTA
+  bool "sigma_delta Module"
+  default "n"
+
+config NODEMCU_CMODULE_SOFTUART
+  bool "softuart Module"
+  default "n"
+
+config NODEMCU_CMODULE_TMR
+  bool "tmr Module"
+  default "y"
+
+config NODEMCU_CMODULE_UART
+  bool "uart Module"
+  default "y"
+
+config NODEMCU_CMODULE_WIFI
+  bool "wifi Module"
+  default "y"
+  help
+    Provides access to the on-board WiFi chipset
+
+config NODEMCU_CMODULE_WIFI_MONITOR
+  bool "wifi.monitor Module"
+  default "n"
+
+config NODEMCU_CMODULE_WPS
+  bool "wps Module"
+  default "n"
+
+endmenu
+
+menu "Networking"
+
+config NODEMCU_CMODULE_COAP
+  bool "coap Module"
+  default "n"
+  help
+    COnstrained Application Protocol implementation
+
+config NODEMCU_CMODULE_ENDUSER_SETUP
+  bool "enduser_setup Module"
+  default "n"
+  # depends DNS_SERVER
+  help
+    Configure ESP8266 over WiFi rather than a UART link
+
+config NODEMCU_CMODULE_HTTP
+  bool "http Module"
+  default "n"
+  help
+    HyperText Transport Protocol client
+
+config NODEMCU_CMODULE_MDNS
+  bool "mdns Module"
+  default "n"
+  help
+    Multicast DNS responder (i.e., server) module
+
+config NODEMCU_CMODULE_MQTT
+  bool "mqtt Module"
+  default "n"
+  help
+    MQ Telemetry Transport protocol version 3.1.1.
+
+config NODEMCU_CMODULE_NET
+  bool "net Module"
+  default "y"
+
+config NODEMCU_CMODULE_SNTP
+  bool "sntp Module"
+  default "n"
+  help
+    Simple Network Time Protocol implementation
+
+config NODEMCU_CMODULE_TLS
+  bool "tls Module"
+  default "n"
+  help
+    Transport Layer Security client implementation
+
+config NODEMCU_CMODULE_WEBSOCKET
+  bool "websocket Module"
+  default "n"
+
+endmenu # }}}
+menu "Wire Protocol Drivers" # {{{
+
+config NODEMCU_CMODULE_DCC
+  bool "dcc Module"
+  default "n"
+  help
+     National Model Railroad Association (NMRA) Digital Command Control (DCC) decoder
+
+config NODEMCU_CMODULE_I2C
+  bool "i2c Module"
+  default "n"
+  help
+    Inter-Integrated Circuit (I2C, IIC) AKA Two-Wire Interface (TWI) master
+
+config NODEMCU_CMODULE_OW
+  bool "ow Module"
+  default "n"
+  help
+    Dallas Semiconductor / Maxim Integrated Products 1-Wire master
+
+config NODEMCU_CMODULE_RFSWITCH
+  bool "rfswitch Module"
+  default "n"
+  help
+    Generate waveforms for transmission to low-cost 433/315MHz control devices
+
+config NODEMCU_CMODULE_SPI
+  bool "spi Module"
+  default "n"
+  help
+    Serial Peripheral Interface master
+
+endmenu # }}}
+menu "External Device Drivers" # {{{
+
+config NODEMCU_CMODULE_ADS1115
+  bool "ads1115 Module"
+  default "n"
+
+config NODEMCU_CMODULE_ADXL345
+  bool "adxl345 Module"
+  default "n"
+
+config NODEMCU_CMODULE_AM2320
+  bool "am2320 Module"
+  default "n"
+
+config NODEMCU_CMODULE_APA102
+  bool "apa102 Module"
+  default "n"
+
+config NODEMCU_CMODULE_BMP085
+  bool "bmp085 Module"
+  default "n"
+
+config NODEMCU_CMODULE_BME280
+  bool "bme280 Module"
+  default "n"
+
+config NODEMCU_CMODULE_BME680
+  bool "bme680 Module"
+  default "n"
+
+config NODEMCU_CMODULE_DHT
+  bool "dht Module"
+  default "n"
+
+config NODEMCU_CMODULE_HDC1080
+  bool "hdc1080 Module"
+  default "n"
+
+config NODEMCU_CMODULE_HMC5883L
+  bool "hmc5883l Module"
+  default "n"
+
+config NODEMCU_CMODULE_HX711
+  bool "hx711 Module"
+  default "n"
+
+config NODEMCU_CMODULE_L3G4200D
+  bool "l3g4200d Module"
+  default "n"
+
+config NODEMCU_CMODULE_MCP4725
+  bool "mcp4725 Module"
+  default "n"
+
+config NODEMCU_CMODULE_ROTARY
+  bool "rotary Module"
+  default "n"
+
+config NODEMCU_CMODULE_SI7021
+  bool "si7021 Module"
+  default "n"
+
+config NODEMCU_CMODULE_SWITEC
+  bool "switec Module"
+  default "n"
+
+config NODEMCU_CMODULE_TCS34725
+  bool "tcs34725 Module"
+  default "n"
+
+config NODEMCU_CMODULE_TM1829
+  bool "tm1829 Module"
+  default "n"
+
+config NODEMCU_CMODULE_TSL2561
+  bool "tsl2561 Module"
+  default "n"
+
+config NODEMCU_CMODULE_U8G2
+  bool "u8g2 Module"
+  default "n"
+
+config NODEMCU_CMODULE_UCG
+  bool "ucg Module"
+  default "n"
+
+config NODEMCU_CMODULE_WS2801
+  bool "ws2801 Module"
+  default "n"
+
+config NODEMCU_CMODULE_WS2812
+  bool "ws2812 Module"
+  default "n"
+
+config NODEMCU_CMODULE_XPT2046
+  bool "xpt2046 Module"
+  default "n"
+
+endmenu # }}}
+
+endmenu


### PR DESCRIPTION
WIP on #3130 

- [x] Define Kconfig files for `user_modules.h`
- [x] Define Kconfig files for most of `user_config.h`
- [ ] Deal with the rest of `user_config.h`
- [ ] Wire up `.config` generation
- [ ] Replace use of CPP symbols with Kconfig symbols
- [ ] `user_mbedtls.h` ?
- [ ] `user_modules.h` -> .config script?
- [ ] cloud builder

I will eagerly accept help on any of this. :)

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.