### PR TITLE
BMEXXX sensor documentation update (Lua 5.3 compatibility)

### DIFF
--- a/docs/modules/bme280.md
+++ b/docs/modules/bme280.md
@@ -178,54 +178,23 @@ sda, scl = 3, 4
 i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
 bme280.setup()
 
-P, T = bme280.baro()
-print(string.format("QFE=%d.%03d", P/1000, P%1000))
-
--- convert measure air pressure to sea level pressure
-QNH = bme280.qfe2qnh(P, alt)
-print(string.format("QNH=%d.%03d", QNH/1000, QNH%1000))
-
-H, T = bme280.humi()
-
-local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
-print(string.format("T=%s%d.%02d", Tsgn<0 and "-" or "", T/100, T%100))
-print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
-
-D = bme280.dewpoint(H, T)
-local Dsgn = (D < 0 and -1 or 1); D = Dsgn*D
-print(string.format("dew_point=%s%d.%02d", Dsgn<0 and "-" or "", D/100, D%100))
-
--- altimeter function - calculate altitude based on current sea level pressure (QNH) and measure pressure
-P = bme280.baro()
-curAlt = bme280.altitude(P, QNH)
-local curAltsgn = (curAlt < 0 and -1 or 1); curAlt = curAltsgn*curAlt
-print(string.format("altitude=%s%d.%02d", curAltsgn<0 and "-" or "", curAlt/100, curAlt%100))
-```
-
-Or simpler and more efficient
-
-```lua
-alt=320 -- altitude of the measurement place
-
-sda, scl = 3, 4
-i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
-bme280.setup()
-
 T, P, H, QNH = bme280.read(alt)
+if T then
+    print(("T=%.2f"):format(T/100))
+    print(("QFE=%.3f"):format(P/1000))
+    print(("QNH=%.3f"):format(QNH/1000))
+    print(("humidity=%.3f%%"):format(H/1000))
+    D = bme680.dewpoint(H, T)
+    print(("dew point=%.2f"):format(D/100))
+end
+
 local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
-print(string.format("T=%s%d.%02d", Tsgn<0 and "-" or "", T/100, T%100))
-print(string.format("QFE=%d.%03d", P/1000, P%1000))
-print(string.format("QNH=%d.%03d", QNH/1000, QNH%1000))
-print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
-D = bme280.dewpoint(H, T)
-local Dsgn = (D < 0 and -1 or 1); D = Dsgn*D
-print(string.format("dew_point=%s%d.%02d", Dsgn<0 and "-" or "", D/100, D%100))
 
 -- altimeter function - calculate altitude based on current sea level pressure (QNH) and measure pressure
 P = bme280.baro()
 curAlt = bme280.altitude(P, QNH)
 local curAltsgn = (curAlt < 0 and -1 or 1); curAlt = curAltsgn*curAlt
-print(string.format("altitude=%s%d.%02d", curAltsgn<0 and "-" or "", curAlt/100, curAlt%100))
+print(("altitude=%.2f"):format(curAlt/100))
 ```
 
 Use `bme280.setup(1, 3, 0, 3, 0, 4)` for "game mode" - Oversampling settings  pressure ×4, temperature ×1, humidity ×0, sensor mode: normal mode, inactive duration  = 0.5 ms, IIR filter settings  filter coefficient 16.
@@ -236,9 +205,11 @@ sda, scl = 3, 4
 i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
 bme280.setup(nil, nil, nil, 0) -- initialize to sleep mode
 bme280.startreadout(0, function ()
-  T, P = bme280.read()
-  local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
-  print(string.format("T=%s%d.%02d", Tsgn<0 and "-" or "", T/100, T%100))
+    T, P = bme280.read()
+    if T then
+        print(("T=%.2f"):format(T/100))
+        print(("QFE=%.3f"):format(P/1000))
+    end
 end)
 ```
 

--- a/docs/modules/bme680.md
+++ b/docs/modules/bme680.md
@@ -143,15 +143,13 @@ bme680.setup()
 bme680.startreadout(150, function ()
     T, P, H, G, QNH = bme680.read(alt)
     if T then
-        local Tsgn = (T < 0 and -1 or 1); T = Tsgn*T
-        print(string.format("T=%s%d.%02d", Tsgn<0 and "-" or "", T/100, T%100))
-        print(string.format("QFE=%d.%03d", P/100, P%100))
-        print(string.format("QNH=%d.%03d", QNH/100, QNH%100))
-        print(string.format("humidity=%d.%03d%%", H/1000, H%1000))
-        print(string.format("gas resistance=%d", G))
+        print(("T=%.2f"):format(T/100))
+        print(("QFE=%.2f"):format(P/100))
+        print(("QNH=%.3f"):format(QNH/100))
+        print(("humidity=%.3f%%"):format(H/1000))
+        print(("gas resistance=%d"):format(G))
         D = bme680.dewpoint(H, T)
-        local Dsgn = (D < 0 and -1 or 1); D = Dsgn*D
-        print(string.format("dew_point=%s%d.%02d", Dsgn<0 and "-" or "", D/100, D%100))
+        print(("dew point=%.2f"):format(D/100))
     end
 end)
 ```


### PR DESCRIPTION
Fixes - no reported issue>.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

BME280 and BME680 sensor modules documentation includes examples that are
- not Lua 5.3 compatible (`("%d"):format(3/2)` fails as 3/2 has no integer representation)
- were intented for integer version so includes code that is not needed in now standard flow version of the firmware.
