### PR TITLE
DS18B20 Lua module - removing integer version related code

### DIFF
--- a/docs/lua-modules/ds18b20.md
+++ b/docs/lua-modules/ds18b20.md
@@ -5,8 +5,9 @@
 
 This Lua module provides access to [DS18B20](https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf) 1-Wire digital thermometer.
 
-!!! note
-	The module requires `ow` C module built into firmware.
+For integer version of firmware use [ds18b20-integer.lua](../../lua_modules/ds18b20/ds18b20-integer.lua) module - measured temperatures are multiplied by 10000.
+
+The module requires `ow` C module built into firmware.
 
 ### Require
 ```lua


### PR DESCRIPTION
Fixes - no reported issue.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This PR removes code supporting integer version of the firmware. As float version is now standard I think there is no reason to have integer version support in standard volume.
