### PR TITLE
fix a memory leak in ws2812_buffer_shift

### DIFF
--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -278,7 +278,8 @@ int ws2812_buffer_shift(lua_State* L, ws2812_buffer * buffer, int shiftValue, un
   ws2812_buffer_shift_prepare* prepare = ws2812_buffer_get_shift_prepare(L, buffer, shiftValue, shift_type, pos_start, pos_end);
   ws2812_buffer_shift_prepared(prepare);
   // Free memory
-  luaM_free(L, prepare);
+  luaM_freemem(L, prepare, sizeof(ws2812_buffer_shift_prepare) + prepare->shift_len);
+
   return 0;
 }
 


### PR DESCRIPTION
fix a memory leak in ws2812_buffer_shift by freeing the same amount of bytes we allocated before

Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

Memory was allocated with `luaM_malloc(L, sizeof(ws2812_buffer_shift_prepare) + shift_len);`
but freed with `luaM_free(L, prepare);` this caused a leak by shift_len bytes per call.

The code I used to test with:
```lua
while (true) do
    buffer:shift(10, ws2812.SHIFT_CIRCULAR)
    ws2812.write(buffer)
    print(node.egc.meminfo())
    --coroutine.yield()
end
```
This caused a leak of 40 bytes per call before this commit, while after the numbers are stable.