### PR TITLE
rtctime: try harder to speak in integers

### DIFF
--- a/app/modules/rtctime.c
+++ b/app/modules/rtctime.c
@@ -131,28 +131,27 @@ static int rtctime_set (lua_State *L)
   if (!rtc_time_check_magic ())
     rtc_time_prepare ();
 
-  uint32_t sec = luaL_checknumber (L, 1);
+  uint32_t sec = luaL_checkinteger (L, 1);
   uint32_t usec = 0;
   if (lua_isnumber (L, 2))
-    usec = lua_tonumber (L, 2);
+    usec = lua_tointeger (L, 2);
 
   struct rtc_timeval tv = { sec, usec };
   rtctime_settimeofday (&tv);
 
   if (lua_isnumber(L, 3))
-    rtc_time_set_rate(lua_tonumber(L, 3));
+    rtc_time_set_rate(lua_tointeger(L, 3));
   return 0;
 }
-
 
 // sec, usec = rtctime.get ()
 static int rtctime_get (lua_State *L)
 {
   struct rtc_timeval tv;
   rtctime_gettimeofday (&tv);
-  lua_pushnumber (L, tv.tv_sec);
-  lua_pushnumber (L, tv.tv_usec);
-  lua_pushnumber (L, rtc_time_get_rate());
+  lua_pushinteger (L, tv.tv_sec);
+  lua_pushinteger (L, tv.tv_usec);
+  lua_pushinteger (L, rtc_time_get_rate());
   return 3;
 }
 
@@ -160,7 +159,7 @@ static void do_sleep_opt (lua_State *L, int idx)
 {
   if (lua_isnumber (L, idx))
   {
-    uint32_t opt = lua_tonumber (L, idx);
+    uint32_t opt = lua_tointeger (L, idx);
     if (opt < 0 || opt > 4)
       luaL_error (L, "unknown sleep option");
     system_deep_sleep_set_option (opt);
@@ -170,8 +169,8 @@ static void do_sleep_opt (lua_State *L, int idx)
 // rtctime.adjust_delta (usec)
 static int rtctime_adjust_delta (lua_State *L)
 {
-  uint32_t us = luaL_checknumber (L, 1);
-  lua_pushnumber(L, rtc_time_adjust_delta_by_rate(us));
+  uint32_t us = luaL_checkinteger (L, 1);
+  lua_pushinteger(L, rtc_time_adjust_delta_by_rate(us));
   return 1;
 }
 
@@ -179,7 +178,7 @@ static int rtctime_adjust_delta (lua_State *L)
 // rtctime.dsleep (usec, option)
 static int rtctime_dsleep (lua_State *L)
 {
-  uint32_t us = luaL_checknumber (L, 1);
+  uint32_t us = luaL_checkinteger (L, 1);
   do_sleep_opt (L, 2);
   rtctime_deep_sleep_us (us); // does not return
   return 0;
@@ -192,8 +191,8 @@ static int rtctime_dsleep_aligned (lua_State *L)
   if (!rtctime_have_time ())
     return luaL_error (L, "time not available, unable to align");
 
-  uint32_t align_us = luaL_checknumber (L, 1);
-  uint32_t min_us = luaL_checknumber (L, 2);
+  uint32_t align_us = luaL_checkinteger (L, 1);
+  uint32_t min_us = luaL_checkinteger (L, 2);
   do_sleep_opt (L, 3);
   rtctime_deep_sleep_until_aligned_us (align_us, min_us); // does not return
   return 0;


### PR DESCRIPTION
Otherwise we might truncate precision with small floats and that's
unlikely to work out well for anyone.

Found by testing #2819 against Lua 5.3.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.