### PR TITLE
Fixed conflict in documentation and example for method newChannel()

### DIFF
--- a/docs/modules/ledc.md
+++ b/docs/modules/ledc.md
@@ -15,7 +15,7 @@ Configures a PIN to be controlled by the LEDC system.
 
 #### Syntax
 ```lua
-ledc.setup({
+myChannel = ledc.newChannel({
   gpio=x,
   bits=ledc.TIMER_10_BIT || ledc.TIMER_11_BIT || ledc.TIMER_12_BIT || ledc.TIMER_13_BIT || ledc.TIMER_14_BIT || ledc.TIMER_15_BIT,
   mode=ledc.HIGH_SPEED || ledc.LOW_SPEED,
@@ -53,7 +53,7 @@ List of configuration tables:
 
 #### Example
 ```lua
-ledc.setup({
+myChannel = ledc.newChannel({
   gpio=19,
   bits=ledc.TIMER_13_BIT,
   mode=ledc.HIGH_SPEED,


### PR DESCRIPTION
It now correctly uses ledc.newChannel() and saves the return value instead of invoking ledc.setup().

Fixes no existing issue.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

The previous example was incorrect because ledc.setup() does not exist and the example given for a method should use the method.
