### PR TITLE
Fixed an regression that MQTT client timer is disarmed prematurely when connecting to server.

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -753,7 +753,7 @@ void mqtt_socket_timer(void *arg)
   if(mud == NULL)
     return;
 
-  if(mud->connected == 0){
+  if(mud->pesp_conn.proto.tcp == NULL){
     NODE_DBG("MQTT not connected\n");
     os_timer_disarm(&mud->mqttTimer);
     return;
@@ -1289,7 +1289,7 @@ static int mqtt_socket_close( lua_State* L )
         espconn_status |= espconn_disconnect(&mud->pesp_conn);
     }
   }
-  mud->connected = 0;
+  mud->connected = false;
 
   while (mud->mqtt_state.pending_msg_q) {
     msg_destroy(msg_dequeue(&(mud->mqtt_state.pending_msg_q)));


### PR DESCRIPTION
Inside af426d0315f4c18d13468acf131f7f91a436e8e6, the `mqtt_socket_timer`
function was modified so that instead of checking the presense of
allocated `mud->pesp_conn` structure, `mud->connected` field was used
on determining if the timer need to be disarmed.

However, this is not entirely correct. If the TCP socket is actively
connecting and haven't timed out yet, then `mud->connected` is also
`false` and the timer will think the connection is broken and
disarms itself. This has two consequences:

* The connection timeout counter is no longer decremented and checked
* After connection succeeds, keepalive heartbeat is no longer being
  sent (#3166). This is particularly noticeable in MQTT over TLS
  connections, because those usually takes longer than 1 second
  to finish and the timer would had chance to execute before connection
  is established

This commit checks the presense of `pesp_conn->proto.tcp` pointer
instead, which was allocated in the same place as the (old) `pesp_conn`
struct, and according to my test indeed fixes the above issue.

Fixes #3166.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] ~The code changes are reflected in the documentation at `docs/*`.~ (N/A)

The issue was caught because of frequent disconnects from MQTT broker due to overdue heartbeats. I compiled a build with debug log on, here is what it looked like:

```
enter mqtt_socket_client.
NodeMCU_554644
length username: 43
length password: 40
MQTT: Init info: [REDACTED]
leave mqtt_socket_client.
enter mqtt_socket_on.
leave mqtt_socket_on.
enter mqtt_socket_on.
leave mqtt_socket_on.
enter mqtt_socket_connect.
TCP ip is set: 255.255.255.255
TCP port is set: 1883.
leave mqtt_socket_connect.
enter socket_dns_found.
TCP ip is set: [REDACTED]
enter socket_connect.
leave socket_connect
leave socket_dns_found.
client handshake start.
espconn_mbedtls.c 566, type[CERTIFICATE],length[889]
enter mqtt_socket_timer.
MQTT not connected
client handshake ok!
enter mqtt_socket_connected.
Send MQTT connection infomation, data len: 153, d[0]=16 
leave mqtt_socket_connectet, heap = 17320.
enter mqtt_socket_sent.
enter mqtt_socket_received (rxlen=4).
MQTT: Connected
connected to MQTT broker
send_if_poss, queue size: 0
leave mqtt_socket_received
pm open,type:2 0
Reason:[-0x7880]
enter mqtt_socket_disconnected.
```

Notice the following sequence:

```
client handshake start.
espconn_mbedtls.c 566, type[CERTIFICATE],length[889]
enter mqtt_socket_timer.
MQTT not connected (TIMER DISARMED HERE)
client handshake ok!
```

After the commit, here is what the logs looks like, notice the timer is no longer disarmed prematurely and heartbeats are indeed being sent out. Also the `event_timeout` ticks are being decremented.

```
MQTT: Init info: [REDACTED]
leave mqtt_socket_client.
enter mqtt_socket_on.
leave mqtt_socket_on.
enter mqtt_socket_on.
leave mqtt_socket_on.
enter mqtt_socket_connect.
TCP ip is set: 255.255.255.255
TCP port is set: 1883.
leave mqtt_socket_connect.
enter socket_dns_found.
TCP ip is set: [REDACTED]
enter socket_connect.
leave socket_connect
leave socket_dns_found.
client handshake start.
espconn_mbedtls.c 566, type[CERTIFICATE],length[889]
enter mqtt_socket_timer.
timer, queue size: 0
event_timeout: 60.
enter mqtt_socket_timer.
timer, queue size: 0
event_timeout: 59.
client handshake ok!
enter mqtt_socket_connected.
Send MQTT connection infomation, data len: 153, d[0]=16 
leave mqtt_socket_connectet, heap = 17320.
enter mqtt_socket_sent.
enter mqtt_socket_received (rxlen=4).
MQTT: Connected
connected to MQTT broker
send_if_poss, queue size: 0
leave mqtt_socket_received
enter mqtt_socket_timer.
timer, queue size: 0
keep_alive_tick: 1
leave mqtt_socket_timer.
enter mqtt_socket_timer.
timer, queue size: 0
keep_alive_tick: 2
leave mqtt_socket_timer.
enter mqtt_socket_timer.
timer, queue size: 0
keep_alive_tick: 3
leave mqtt_socket_timer.
[...OMITTED...]
enter mqtt_socket_timer.
timer, queue size: 0
keep_alive_tick: 29
leave mqtt_socket_timer.
enter mqtt_socket_timer.
timer, queue size: 0
keep_alive_tick: 30
leave mqtt_socket_timer.
enter mqtt_socket_timer.
timer, queue size: 0
MQTT: Send keepalive packet
Sent: 2
send_if_poss, queue size: 1
keep_alive_tick: 0
leave mqtt_socket_timer.
enter mqtt_socket_sent.
sent1, queue size: 1
send_if_poss, queue size: 0
sent2, queue size: 0
leave mqtt_socket_sent.
enter mqtt_socket_received (rxlen=2).
MQTT_DATA: msg length: 2, buffer length: 2
MQTT_DATA: type: 13, qos: 0, msg_id: 0, pending_id: 0, msg length: 2, buffer length: 2
MQTT: PINGRESP received
send_if_poss, queue size: 0
leave mqtt_socket_received
enter mqtt_socket_timer.
timer, queue size: 0
keep_alive_tick: 1
leave mqtt_socket_timer.
```