### PR TITLE
Lua 5.1 / 5.3 alignment and document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .gdb_history
+app/lua/.std
+app/lua53/.std
 sdk/
 cache/
 .ccache/

--- a/app/coap/coap.h
+++ b/app/coap/coap.h
@@ -7,7 +7,6 @@ extern "C" {
 
 #include <stdint.h>
 #include <stddef.h>
-#include "lualib.h"
 #include "lauxlib.h"
 
 #define MAXOPT 16

--- a/app/coap/endpoints.c
+++ b/app/coap/endpoints.c
@@ -5,7 +5,6 @@
 
 #include "lua.h"
 #include "lauxlib.h"
-#include "lualib.h"
 
 #include "os_type.h"
 #include "user_interface.h"

--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -14,12 +14,12 @@
 
 #include "osapi.h"
 #include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
 #include "user_interface.h"
 #include "espconn.h"
 #include "mem.h"
-#include "limits.h"
 #include "httpclient.h"
-#include "stdlib.h"
 #include "pm/swtimer.h"
 
 #define REDIRECTION_FOLLOW_MAX 20

--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -247,7 +247,8 @@
 
 #define LUA_TASK_PRIO             USER_TASK_PRIO_0
 #define LUA_PROCESS_LINE_SIG      2
-#define LUA_OPTIMIZE_DEBUG        2
+// LUAI_OPTIMIZE_DEBUG 0 = Keep all debug; 1 = keep line number info; 2 = remove all debug
+#define LUAI_OPTIMIZE_DEBUG       1
 #define READLINE_INTERVAL        80
 #define STRBUF_DEFAULT_INCREMENT  3
 #define LUA_USE_BUILTIN_DEBUG_MINIMAL // for debug.getregistry() and debug.traceback()

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -25,9 +25,9 @@
 */
 
 #define lauxlib_c
+#include "lauxlib.h"
 #define LUA_LIB
 
-#include "lauxlib.h"
 #include "lgc.h"
 #include "ldo.h"
 #include "lobject.h"

--- a/app/lua/lauxlib.h
+++ b/app/lua/lauxlib.h
@@ -9,6 +9,9 @@
 #define lauxlib_h
 
 #include "lua.h"
+#ifdef LUA_LIB
+#include "lnodemcu.h"
+#endif
 
 #include <stdio.h>
 
@@ -162,8 +165,16 @@ LUALIB_API void (luaL_pushresult) (luaL_Buffer *B);
 
 /* }====================================================== */
 
-LUALIB_API int luaL_pcallx (lua_State *L, int narg, int nres);
-LUALIB_API int luaL_posttask( lua_State* L, int prio );
+LUALIB_API int  (luaL_pushlfsmodules) (lua_State *L);
+LUALIB_API int  (luaL_pushlfsmodule) (lua_State *L);
+LUALIB_API int  (luaL_pushlfsdts) (lua_State *L);
+
+LUALIB_API void (luaL_lfsreload) (lua_State *L);
+LUALIB_API int  (luaL_pcallx) (lua_State *L, int narg, int nres);
+LUALIB_API int  (luaL_posttask) ( lua_State* L, int prio );
+#define  LUA_TASK_LOW    0
+#define  LUA_TASK_MEDIUM 1
+#define  LUA_TASK_HIGH   2
 
 /* }====================================================== */
 

--- a/app/lua/lbaselib.c
+++ b/app/lua/lbaselib.c
@@ -10,7 +10,6 @@
 #define LUA_LIB
 
 #include "lua.h"
-#include "lnodemcu.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/app/lua/lcode.c
+++ b/app/lua/lcode.c
@@ -780,8 +780,6 @@ void luaK_posfix (FuncState *fs, BinOpr op, expdesc *e1, expdesc *e2) {
 }
 
 
-#ifdef LUA_OPTIMIZE_DEBUG
-
 /*
  * Attempted to write to last (null terminator) byte of lineinfo, so need
  * to grow the lineinfo vector and extend the fill bytes
@@ -828,10 +826,8 @@ static void generateInfoDeltaLine(FuncState *fs, int line) {
   fs->lastlineOffset = p - fs->f->packedlineinfo - 1;
 #undef addDLbyte
 }
-#endif
 
 void luaK_fixline (FuncState *fs, int line) {
-#ifdef LUA_OPTIMIZE_DEBUG
   /* The fixup line can be the same as existing one and in this case there's nothing to do */
   if (line != fs->lastline) {
     /* first remove the current line reference */
@@ -862,9 +858,6 @@ void luaK_fixline (FuncState *fs, int line) {
     /* Then add the new line reference */
     generateInfoDeltaLine(fs, line);
   }
-#else
-   fs->f->lineinfo[fs->pc - 1] = line;
-#endif
 }
 
 
@@ -876,7 +869,6 @@ static int luaK_code (FuncState *fs, Instruction i, int line) {
                   MAX_INT, "code size overflow");
   f->code[fs->pc] = i;
   /* save corresponding line information */
-#ifdef LUA_OPTIMIZE_DEBUG
   /* note that frst time fs->lastline==0 through, so the else branch is taken */
   if (fs->pc == fs->lineinfoLastPC+1) {
     if (line == fs->lastline && f->packedlineinfo[fs->lastlineOffset] < INFO_MAX_LINECNT) {
@@ -890,11 +882,6 @@ static int luaK_code (FuncState *fs, Instruction i, int line) {
     luaK_fixline(fs,line);
   }
   fs->lineinfoLastPC = fs->pc;
-#else
-  luaM_growvector(fs->L, f->lineinfo, fs->pc, f->sizelineinfo, int,
-                  MAX_INT, "code size overflow");
-  f->lineinfo[fs->pc] = line;
-#endif
   return fs->pc++;
 }
 

--- a/app/lua/ldebug.h
+++ b/app/lua/ldebug.h
@@ -13,7 +13,6 @@
 
 #define pcRel(pc, p)	(cast(int, (pc) - (p)->code) - 1)
 
-#ifdef LUA_OPTIMIZE_DEBUG
 #  include "lvm.h"
 #  define getline(f,pc) (((f)->packedlineinfo) ? luaG_getline((f), pc) : 0)
 #  define INFO_FILL_BYTE   0x7F
@@ -23,9 +22,6 @@
 #  define INFO_DELTA_7BITS 0x7F
 #  define INFO_MAX_LINECNT  126
 #  define lineInfoTop(fs) ((fs)->f->packedlineinfo + (fs)->lastlineOffset)
-#else
-#  define getline(f,pc) (((f)->lineinfo) ? (f)->lineinfo[pc] : 0)
-#endif
 
 #define resethookcount(L)	(L->hookcount = L->basehookcount)
 
@@ -41,9 +37,7 @@ LUAI_FUNC void luaG_runerror (lua_State *L, const char *fmt, ...);
 LUAI_FUNC void luaG_errormsg (lua_State *L);
 LUAI_FUNC int luaG_checkcode (const Proto *pt);
 LUAI_FUNC int luaG_checkopenop (Instruction i);
-#ifdef LUA_OPTIMIZE_DEBUG
 LUAI_FUNC int luaG_getline (const Proto *f, int pc);
 LUAI_FUNC int luaG_stripdebug (lua_State *L, Proto *f, int level, int recv);
-#endif
 
 #endif

--- a/app/lua/ldump.c
+++ b/app/lua/ldump.c
@@ -228,7 +228,6 @@ static void DumpDebug(const Proto* f, DumpState* D)
 {
  int i,n;
 
-#ifdef LUA_OPTIMIZE_DEBUG
  n = (D->strip || f->packedlineinfo == NULL) ? 0: strlen(cast(char *,f->packedlineinfo))+1;
  DumpInt(n,D);
  Align4(D);
@@ -236,15 +235,6 @@ static void DumpDebug(const Proto* f, DumpState* D)
  {
   DumpBlock(f->packedlineinfo, n, D);
  }
-#else
- n= (D->strip) ? 0 : f->sizelineinfo;
- DumpInt(n,D);
- Align4(D);
- for (i=0; i<n; i++)
- {
-  DumpInt(f->lineinfo[i],D);
- }
- #endif
 
  n= (D->strip) ? 0 : f->sizelocvars;
  DumpInt(n,D);

--- a/app/lua/lflash.c
+++ b/app/lua/lflash.c
@@ -194,20 +194,19 @@ static int loadLFS (lua_State *L);
 static int loadLFSgc (lua_State *L);
 static void procFirstPass (void);
 
-/* lua_lfsreload() and lua_lfsindex() are exported via lua.h */
+/* luaL_lfsreload() is exported via lauxlib.h */
 
 /*
  * Library function called by node.flashreload(filename).
  */
-LUALIB_API int lua_lfsreload (lua_State *L) {
+LUALIB_API void luaL_lfsreload (lua_State *L) {
   const char *fn = lua_tostring(L, 1), *msg = "";
   int status;
 
   if (G(L)->LFSsize == 0) {
     lua_pushstring(L, "No LFS partition allocated");
-    return 1;
+    return;
   }
-
 
  /*
   * Do a protected call of loadLFS.
@@ -237,7 +236,7 @@ LUALIB_API int lua_lfsreload (lua_State *L) {
     lua_cpcall(L, &loadLFSgc, NULL);
     lua_settop(L, 0);
     lua_pushstring(L, msg);
-    return 1;
+    return;
   }
 
   if (status == 0) {
@@ -257,60 +256,20 @@ LUALIB_API int lua_lfsreload (lua_State *L) {
   NODE_ERR(msg);
 
   while (1) {}  // Force WDT as the ROM software_reset() doesn't seem to work
-  return 0;
 }
 
 
-/*
- * If the arg is a valid LFS module name then return the LClosure
- * pointing to it. Otherwise return:
- *  -  The Unix time that the LFS was built
- *  -  The base address and length of the LFS
- *  -  An array of the module names in the LFS
- */
-LUAI_FUNC int lua_lfsindex (lua_State *L) {
-  int n = lua_gettop(L);
-
-  /* Return nil + the LFS base address if the LFS size > 0 and it isn't loaded */
-  if (!(G(L)->ROpvmain)) {
-    lua_settop(L, 0);
-    lua_pushnil(L);
-    if (G(L)->LFSsize) {
-      lua_pushinteger(L, (lua_Integer) flashAddr);
-      lua_pushinteger(L, flashAddrPhys);
-      lua_pushinteger(L, G(L)->LFSsize);
-      return 4;
-    } else {
-      return 1;
-    }
-  }
-
-  /* Push the LClosure of the LFS index function */
-  Closure *cl = luaF_newLclosure(L, 0, hvalue(gt(L)));
-  cl->l.p = G(L)->ROpvmain;
-  lua_settop(L, n+1);
-  setclvalue(L, L->top-1, cl);
-
-  /* Move it infront of the arguments and call the index function */
-  lua_insert(L, 1);
-  lua_call(L, n, LUA_MULTRET);
-
-  /* Return it if the response if a single value (the function) */
-  if (lua_gettop(L) == 1)
-    return 1;
-
-  lua_assert(lua_gettop(L) == 2);
-
-  /* Otherwise add the base address of the LFS, and its size bewteen the */
-  /* Unix time and the module list, then return all 4 params. */
-  lua_pushinteger(L, (lua_Integer) flashAddr);
-  lua_insert(L, 2);
-  lua_pushinteger(L, flashAddrPhys);
-  lua_insert(L, 3);
-  lua_pushinteger(L, cast(FlashHeader *, flashAddr)->flash_size);
-  lua_insert(L, 4);
-  return 5;
+LUA_API void lua_getlfsconfig (lua_State *L, int *config) {
+  if (!config)
+    return;
+  config[0] = (int) flashAddr;                   /* LFS region mapped address */
+  config[1] = flashAddrPhys;                 /* LFS region base flash address */
+  config[2] = G(L)->LFSsize;                        /* LFS region actual size */
+  config[3] = cast(FlashHeader *, flashAddr)->flash_size;  /* LFS region used */
+  config[4] = 0;                                       /* Not used in Lua 5.1 */
 }
+
+
 /* =====================================================================================
  * The following routines use my uzlib which was based on pfalcon's inflate and
  * deflate routines.  The standard NodeMCU make also makes two host tools uz_zip
@@ -483,7 +442,7 @@ void procSecondPass (void) {
 }
 
 /*
- * loadLFS)() is protected called from luaN_reload_reboot so that it can recover
+ * loadLFS)() is protected called from luaL_lfsreload() so that it can recover
  * from out of memory and other thrown errors.  loadLFSgc() GCs any resources.
  */
 static int loadLFS (lua_State *L) {

--- a/app/lua/lflash.h
+++ b/app/lua/lflash.h
@@ -43,8 +43,5 @@ typedef struct {
 } FlashHeader;
 
 LUAI_FUNC void luaN_init (lua_State *L);
-LUAI_FUNC int  luaN_flashSetup (lua_State *L);
-LUAI_FUNC int  luaN_reload_reboot (lua_State *L);
-LUAI_FUNC int  luaN_index (lua_State *L);
 #endif
 

--- a/app/lua/lfunc.c
+++ b/app/lua/lfunc.c
@@ -125,12 +125,7 @@ Proto *luaF_newproto (lua_State *L) {
   f->numparams = 0;
   f->is_vararg = 0;
   f->maxstacksize = 0;
-#ifdef LUA_OPTIMIZE_DEBUG
   f->packedlineinfo = NULL;
-#else
-  f->sizelineinfo = 0;
-  f->lineinfo = NULL;
-#endif
   f->sizelocvars = 0;
   f->locvars = NULL;
   f->linedefined = 0;
@@ -146,13 +141,9 @@ void luaF_freeproto (lua_State *L, Proto *f) {
   luaM_freearray(L, f->locvars, f->sizelocvars, struct LocVar);
   luaM_freearray(L, f->upvalues, f->sizeupvalues, TString *);
   luaM_freearray(L, f->code, f->sizecode, Instruction);
-#ifdef LUA_OPTIMIZE_DEBUG
   if (f->packedlineinfo) {
     luaM_freearray(L, f->packedlineinfo, strlen(cast(char *, f->packedlineinfo))+1, unsigned char);
   }
-#else
-  luaM_freearray(L, f->lineinfo, f->sizelineinfo, int);
-#endif
   luaM_free(L, f);
 }
 

--- a/app/lua/lgc.c
+++ b/app/lua/lgc.c
@@ -327,11 +327,7 @@ static l_mem propagatemark (global_State *g) {
                              sizeof(LocVar) * p->sizelocvars +
                              sizeof(TString *) * p->sizeupvalues +
                              sizeof(Instruction) * p->sizecode +
-#ifdef LUA_OPTIMIZE_DEBUG
                                (p->packedlineinfo ?  strlen(cast(char *, p->packedlineinfo))+1 : 0);
-#else
-                               sizeof(int) * p->sizelineinfo;
-#endif
     }
     default: lua_assert(0); return 0;
   }
@@ -515,7 +511,7 @@ void luaC_freeall (lua_State *L) {
 
 static void markmt (global_State *g) {
   int i;
-  for (i=0; i<NUM_TAGS; i++)
+  for (i=0; i<LUA_NUMTAGS; i++)
     if (g->mt[i] && isrwtable(g->mt[i])) markobject(g, g->mt[i]);
 }
 

--- a/app/lua/lmathlib.c
+++ b/app/lua/lmathlib.c
@@ -14,7 +14,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 #undef PI
 #define PI (3.14159265358979323846)

--- a/app/lua/loadlib.c
+++ b/app/lua/loadlib.c
@@ -23,7 +23,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 /* prefix for open functions in C libraries */
 #define LUA_POF		"luaopen_"
@@ -474,7 +473,7 @@ static int ll_require (lua_State *L) {
   }
   /* Is this a readonly table? */
   lua_getfield(L, LUA_GLOBALSINDEX, name);
-  if(lua_isrotable(L,-1)) {
+  if(lua_istable(L,-1)) {
     return 1;
   } else {
     lua_pop(L, 1);
@@ -567,7 +566,7 @@ static int ll_module (lua_State *L) {
   const char *modname = luaL_checkstring(L, 1);
   /* Is this a readonly table? */
   lua_getfield(L, LUA_GLOBALSINDEX, modname);
-  if(lua_isrotable(L,-1)) {
+  if(lua_istable(L,-1)) {
     return 0;
   } else {
     lua_pop(L, 1);

--- a/app/lua/lobject.h
+++ b/app/lua/lobject.h
@@ -17,7 +17,7 @@
 /* tags for values visible from Lua */
 #define LAST_TAG	LUA_TTHREAD
 
-#define NUM_TAGS	(LAST_TAG+1)
+#define LUA_NUMTAGS	(LAST_TAG+1)
 
 #define READONLYMASK    (1<<7)      /* denormalised bitmask for READONLYBIT and */
 #define LFSMASK         (1<<6)      /* LFSBIT to avoid include proliferation */
@@ -111,7 +111,7 @@ typedef struct lua_TValue {
 #define ttisnil(o)		(ttype(o) == LUA_TNIL)
 #define ttisnumber(o)		(ttype(o) == LUA_TNUMBER)
 #define ttisstring(o)		(ttype(o) == LUA_TSTRING)
-#define ttistable(o)		(basettype(o) == LUA_TTABLE)
+#define ttistable(o)		(ttnov(o) == LUA_TTABLE)
 #define ttisrwtable(o)		(type(o) == LUA_TTABLE)
 #define ttisrotable(o)		(ttype(o) & LUA_TISROTABLE)
 #define ttisboolean(o)		(ttype(o) == LUA_TBOOLEAN)
@@ -120,12 +120,12 @@ typedef struct lua_TValue {
 #define ttislightuserdata(o)	(ttype(o) == LUA_TLIGHTUSERDATA)
 #define ttislightfunction(o)	(ttype(o) == LUA_TLIGHTFUNCTION)
 #define ttisclfunction(o)	(ttype(o) == LUA_TFUNCTION)
-#define ttisfunction(o)		(basettype(o) == LUA_TFUNCTION)
+#define ttisfunction(o)		(ttnov(o) == LUA_TFUNCTION)
 
 /* Macros to access values */
 
 #define ttype(o)	((void) (o)->value, (o)->tt)
-#define basettype(o)	((void) (o)->value, ((o)->tt & LUA_TMASK))
+#define ttnov(o)	((void) (o)->value, ((o)->tt & LUA_TMASK))
 #define gcvalue(o)	check_exp(iscollectable(o), (o)->value.gc)
 #define pvalue(o)	check_exp(ttislightuserdata(o), (o)->value.p)
 #define fvalue(o)	check_exp(ttislightfunction(o), (o)->value.p)
@@ -277,20 +277,13 @@ typedef struct Proto {
   TValue *k;  /* constants used by the function */
   Instruction *code;
   struct Proto **p;  /* functions defined inside the function */
-#ifdef LUA_OPTIMIZE_DEBUG
   unsigned char *packedlineinfo;
-#else
-  int *lineinfo;  /* map from opcodes to source lines */
-#endif
   struct LocVar *locvars;  /* information about local variables */
   TString **upvalues;  /* upvalue names */
   TString  *source;
   int sizeupvalues;
   int sizek;  /* size of `k' */
   int sizecode;
-#ifndef LUA_OPTIMIZE_DEBUG
-  int sizelineinfo;
-#endif
   int sizep;  /* size of `p' */
   int sizelocvars;
   int linedefined;

--- a/app/lua/lparser.h
+++ b/app/lua/lparser.h
@@ -72,12 +72,10 @@ typedef struct FuncState {
   lu_byte nactvar;  /* number of active local variables */
   upvaldesc upvalues[LUAI_MAXUPVALUES];  /* upvalues */
   unsigned short actvar[LUAI_MAXVARS];  /* declared-variable stack */
-#ifdef LUA_OPTIMIZE_DEBUG
   int packedlineinfoSize; /* only used during compilation for line info */
   int lastline;           /* ditto */
   int lastlineOffset;     /* ditto */
   int lineinfoLastPC;     /* ditto */
-#endif
 } FuncState;
 
 

--- a/app/lua/lstate.c
+++ b/app/lua/lstate.c
@@ -184,6 +184,7 @@ LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud) {
   g->memlimit = 0;
   g->gcpause = LUAI_GCPAUSE;
   g->gcstepmul = LUAI_GCMUL;
+  g->stripdefault = LUAI_OPTIMIZE_DEBUG;
   g->gcdept = 0;
 #ifdef EGC_INITIAL_MODE
   g->egcmode = EGC_INITIAL_MODE;
@@ -203,7 +204,7 @@ LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud) {
   g->LFSsize        = 0;
   g->error_reporter = 0;
 #endif
-  for (i=0; i<NUM_TAGS; i++) g->mt[i] = NULL;
+  for (i=0; i<LUA_NUMTAGS; i++) g->mt[i] = NULL;
   if (luaD_rawrunprotected(L, f_luaopen, NULL) != 0) {
     /* memory allocation error: free partial state */
     close_state(L);

--- a/app/lua/lstate.h
+++ b/app/lua/lstate.h
@@ -87,12 +87,13 @@ typedef struct global_State {
   lu_mem gcdept;  /* how much GC is `behind schedule' */
   int gcpause;  /* size of pause between successive GCs */
   int gcstepmul;  /* GC `granularity' */
+  int stripdefault;  /* default stripping level for compilation */
   int egcmode;    /* emergency garbage collection operation mode */
   lua_CFunction panic;  /* to be called in unprotected errors */
   TValue l_registry;
   struct lua_State *mainthread;
   UpVal uvhead;  /* head of double-linked list of all open upvalues */
-  struct Table *mt[NUM_TAGS];  /* metatables for basic types */
+  struct Table *mt[LUA_NUMTAGS];  /* metatables for basic types */
   TString *tmname[TM_N];  /* array with tag-method names */
 #ifndef LUA_CROSS_COMPILER
   stringtable ROstrt;  /* Flash-based hash table for RO strings */

--- a/app/lua/ltable.h
+++ b/app/lua/ltable.h
@@ -20,21 +20,16 @@
 #define isrwtable(t) (gettt(t)==LUA_TTABLE)
 
 LUAI_FUNC const TValue *luaH_getnum (Table *t, int key);
-LUAI_FUNC const TValue *luaH_getnum_ro (void *t, int key);
 LUAI_FUNC TValue *luaH_setnum (lua_State *L, Table *t, int key);
 LUAI_FUNC const TValue *luaH_getstr (Table *t, TString *key);
-LUAI_FUNC const TValue *luaH_getstr_ro (void *t, TString *key);
 LUAI_FUNC TValue *luaH_setstr (lua_State *L, Table *t, TString *key);
 LUAI_FUNC const TValue *luaH_get (Table *t, const TValue *key);
-LUAI_FUNC const TValue *luaH_get_ro (void *t, const TValue *key);
 LUAI_FUNC TValue *luaH_set (lua_State *L, Table *t, const TValue *key);
 LUAI_FUNC Table *luaH_new (lua_State *L, int narray, int lnhash);
 LUAI_FUNC void luaH_resizearray (lua_State *L, Table *t, int nasize);
 LUAI_FUNC void luaH_free (lua_State *L, Table *t);
 LUAI_FUNC int luaH_next (lua_State *L, Table *t, StkId key);
-LUAI_FUNC int luaH_next_ro (lua_State *L, void *t, StkId key);
 LUAI_FUNC int luaH_getn (Table *t);
-LUAI_FUNC int luaH_getn_ro (void *t);
 LUAI_FUNC int luaH_isdummy (Node *n);
 
 #define LUA_MAX_ROTABLE_NAME  32

--- a/app/lua/ltablib.c
+++ b/app/lua/ltablib.c
@@ -12,7 +12,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 
 #define aux_getn(L,n)	(luaL_checktype(L, n, LUA_TTABLE), luaL_getn(L, n))

--- a/app/lua/ltm.c
+++ b/app/lua/ltm.c
@@ -70,7 +70,7 @@ const TValue *luaT_gettmbyobj (lua_State *L, const TValue *o, TMS event) {
       mt = uvalue(o)->metatable;
       break;
     default:
-      mt = G(L)->mt[basettype(o)];
+      mt = G(L)->mt[ttnov(o)];
   }
   return (mt ? luaH_getstr(mt, G(L)->tmname[event]) : luaO_nilobject);
 }

--- a/app/lua/lua.h
+++ b/app/lua/lua.h
@@ -9,9 +9,9 @@
 #ifndef lua_h
 #define lua_h
 #include <stdint.h>
-#include "stdarg.h"
-#include "stddef.h"
-#include "ctype.h"
+#include <stdarg.h>
+#include <stddef.h>
+#include <ctype.h>
 
 #include "luaconf.h"
 
@@ -99,8 +99,8 @@ typedef void * (*lua_Alloc) (void *ud, void *ptr, size_t osize, size_t nsize);
 #include LUA_USER_H
 #endif
 
-#if defined(LUA_OPTIMIZE_DEBUG) && LUA_OPTIMIZE_DEBUG == 0
-#undef LUA_OPTIMIZE_DEBUG
+#ifndef LUAI_OPTIMIZE_DEBUG
+#define LUAI_OPTIMIZE_DEBUG 2
 #endif
 
 /* type of numbers in Lua */
@@ -125,6 +125,7 @@ LUA_API lua_CFunction (lua_atpanic) (lua_State *L, lua_CFunction panicf);
 /*
 ** basic stack manipulation
 */
+LUA_API int   (lua_absindex) (lua_State *L, int idx);
 LUA_API int   (lua_gettop) (lua_State *L);
 LUA_API void  (lua_settop) (lua_State *L, int idx);
 LUA_API void  (lua_pushvalue) (lua_State *L, int idx);
@@ -148,9 +149,11 @@ LUA_API int             (lua_type) (lua_State *L, int idx);
 LUA_API int             (lua_fulltype) (lua_State *L, int idx);
 LUA_API const char     *(lua_typename) (lua_State *L, int tp);
 
-LUA_API int            (lua_equal) (lua_State *L, int idx1, int idx2);
-LUA_API int            (lua_rawequal) (lua_State *L, int idx1, int idx2);
-LUA_API int            (lua_lessthan) (lua_State *L, int idx1, int idx2);
+LUA_API int             (lua_rawequal) (lua_State *L, int idx1, int idx2);
+#define LUA_OPEQ    0
+#define LUA_OPLT    1
+#define LUA_OPLE    2
+LUA_API int             (lua_compare) (lua_State *L, int idx1, int idx2, int op);
 
 LUA_API lua_Number      (lua_tonumber) (lua_State *L, int idx);
 LUA_API lua_Integer     (lua_tointeger) (lua_State *L, int idx);
@@ -183,10 +186,11 @@ LUA_API int   (lua_pushthread) (lua_State *L);
 /*
 ** get functions (Lua -> stack)
 */
-LUA_API void  (lua_gettable) (lua_State *L, int idx);
-LUA_API void  (lua_getfield) (lua_State *L, int idx, const char *k);
-LUA_API void  (lua_rawget) (lua_State *L, int idx);
-LUA_API void  (lua_rawgeti) (lua_State *L, int idx, int n);
+LUA_API int   (lua_gettable) (lua_State *L, int idx);
+LUA_API int   (lua_getfield) (lua_State *L, int idx, const char *k);
+LUA_API int   (lua_rawget) (lua_State *L, int idx);
+LUA_API int   (lua_rawgeti) (lua_State *L, int idx, int n);
+LUA_API int   (lua_rawgetp) (lua_State *L, int idx, const void *p);
 LUA_API void  (lua_createtable) (lua_State *L, int narr, int nrec);
 LUA_API void *(lua_newuserdata) (lua_State *L, size_t sz);
 LUA_API int   (lua_getmetatable) (lua_State *L, int objindex);
@@ -200,6 +204,7 @@ LUA_API void  (lua_settable) (lua_State *L, int idx);
 LUA_API void  (lua_setfield) (lua_State *L, int idx, const char *k);
 LUA_API void  (lua_rawset) (lua_State *L, int idx);
 LUA_API void  (lua_rawseti) (lua_State *L, int idx, int n);
+LUA_API void  (lua_rawsetp) (lua_State *L, int idx, const void *p);
 LUA_API int   (lua_setmetatable) (lua_State *L, int objindex);
 LUA_API int   (lua_setfenv) (lua_State *L, int idx);
 
@@ -212,8 +217,8 @@ LUA_API int   (lua_pcall) (lua_State *L, int nargs, int nresults, int errfunc);
 LUA_API int   (lua_cpcall) (lua_State *L, lua_CFunction func, void *ud);
 LUA_API int   (lua_load) (lua_State *L, lua_Reader reader, void *dt,
                                         const char *chunkname);
-
-LUA_API int (lua_dumpEx) (lua_State *L, lua_Writer writer, void *data, int stripping);
+LUA_API int   (lua_dump) (lua_State *L, lua_Writer writer, void *data, int stripping);
+LUA_API int   (lua_stripdebug) (lua_State *L, int stripping);
 
 
 /*
@@ -273,9 +278,7 @@ LUA_API void lua_setallocf (lua_State *L, lua_Alloc f, void *ud);
 #define lua_strlen(L,i)		lua_objlen(L, (i))
 
 #define lua_isfunction(L,n)	(lua_type(L, (n)) == LUA_TFUNCTION)
-#define lua_islightfunction(L,n) (lua_fulltype(L, (n)) == LUA_TLIGHTFUNCTION)
 #define lua_istable(L,n)	(lua_type(L, (n)) == LUA_TTABLE)
-#define lua_isrotable(L,n)	(lua_fulltype(L, (n)) == LUA_TROTABLE)
 #define lua_islightuserdata(L,n) (lua_type(L, (n)) == LUA_TLIGHTUSERDATA)
 #define lua_isnil(L,n)		(lua_type(L, (n)) == LUA_TNIL)
 #define lua_isboolean(L,n)	(lua_type(L, (n)) == LUA_TBOOLEAN)
@@ -291,9 +294,10 @@ LUA_API void lua_setallocf (lua_State *L, lua_Alloc f, void *ud);
 
 #define lua_tostring(L,i)	lua_tolstring(L, (i), NULL)
 
-#define lua_dump(L,w,d)		lua_dumpEx(L,w,d,0)
+#define lua_equal(L,idx1,idx2)		lua_compare(L,(idx1),(idx2),LUA_OPEQ)
+#define lua_lessthan(L,idx1,idx2)	lua_compare(L,(idx1),(idx2),LUA_OPLT)
 
-/* error codes from cross-compiler returned by lua_dumpEx */
+/* error codes from cross-compiler returned by lua_dump */
 /* target integer is too small to hold a value */
 #define LUA_ERR_CC_INTOVERFLOW 101
 
@@ -382,14 +386,18 @@ struct lua_Debug {
 
 /* }====================================================================== */
 
+/* NodeMCU extensions to the standard API */
+
 typedef struct ROTable ROTable;
 typedef const struct ROTable_entry ROTable_entry;
 
 LUA_API void (lua_pushrotable) (lua_State *L, const ROTable *p);
 LUA_API void (lua_createrotable) (lua_State *L, ROTable *t, ROTable_entry *e, ROTable *mt);
+LUA_API int  (lua_pushstringsarray) (lua_State *L, int opt);
+LUA_API int  (lua_freeheap) (void);
 
-LUAI_FUNC int  lua_lfsreload (lua_State *L);
-LUAI_FUNC int  lua_lfsindex (lua_State *L);
+LUA_API void (lua_getlfsconfig) (lua_State *L, int *);
+LUA_API int  (lua_pushlfsindex) (lua_State *L);
 
 #define EGC_NOT_ACTIVE        0   // EGC disabled
 #define EGC_ON_ALLOC_FAILURE  1   // run EGC on allocation failure
@@ -400,15 +408,13 @@ LUAI_FUNC int  lua_lfsindex (lua_State *L);
 
 #define LUA_QUEUE_APP   0
 #define LUA_QUEUE_UART  1
-#define LUA_TASK_LOW    0
-#define LUA_TASK_MEDIUM 1
-#define LUA_TASK_HIGH   2
 
 /**DEBUG**/extern void dbg_printf(const char *fmt, ...)
                        __attribute__ ((format (printf, 1, 2)));
 #define luaN_freearray(L,b,l)  luaM_freearray(L,b,l,sizeof(*b));
 
-LUA_API void lua_setegcmode(lua_State *L, int mode, int limit);
+LUA_API void (lua_setegcmode) (lua_State *L, int mode, int limit);
+LUA_API void (lua_getegcinfo) (lua_State *L, int *totals);
 
 #else
 

--- a/app/lua/luac_cross/Makefile
+++ b/app/lua/luac_cross/Makefile
@@ -43,7 +43,7 @@ LUASRC  := lapi.c      lauxlib.c   lbaselib.c  lcode.c     ldblib.c    ldebug.c 
            ldo.c       ldump.c     lfunc.c     lgc.c       linit.c     llex.c \
            lmathlib.c  lmem.c      loadlib.c   lobject.c   lopcodes.c  lparser.c \
            lstate.c    lstring.c   lstrlib.c   ltable.c    ltablib.c \
-           ltm.c       lundump.c   lvm.c       lzio.c
+           ltm.c       lundump.c   lvm.c       lzio.c      lnodemcu.c
 UZSRC   := uzlib_deflate.c crc32.c
 
 #

--- a/app/lua/luac_cross/lflashimg.c
+++ b/app/lua/luac_cross/lflashimg.c
@@ -186,10 +186,8 @@ static void scanProtoStrings(lua_State *L, const Proto* f) {
   if (f->source)
     addTS(L, f->source);
 
-#ifdef LUA_OPTIMIZE_DEBUG
   if (f->packedlineinfo)
     addTS(L, luaS_new(L, cast(const char *, f->packedlineinfo)));
-#endif
 
   for (i = 0; i < f->sizek; i++) {
     if (ttisstring(f->k + i))
@@ -355,11 +353,7 @@ static void *flashCopy(lua_State* L, int n, const char *fmt, void *src) {
 }
 
 /* The debug optimised version has a different Proto layout */
-#ifdef LUA_OPTIMIZE_DEBUG
 #define PROTO_COPY_MASK  "AHAAAAAASIIIIIIIAI"
-#else
-#define PROTO_COPY_MASK  "AHAAAAAASIIIIIIIIAI"
-#endif
 
 /*
  * Do the actual prototype copy.
@@ -383,14 +377,10 @@ static void *functionToFlash(lua_State* L, const Proto* orig) {
   f.k = cast(TValue *, flashCopy(L, f.sizek, "V", f.k));
   f.code = cast(Instruction *, flashCopy(L, f.sizecode, "I", f.code));
 
-#ifdef LUA_OPTIMIZE_DEBUG
   if (f.packedlineinfo) {
     TString *ts=luaS_new(L, cast(const char *,f.packedlineinfo));
     f.packedlineinfo = cast(unsigned char *, resolveTString(L, ts)) + sizeof (FlashTS);
   }
-#else
-  f.lineinfo = cast(int *, flashCopy(L, f.sizelineinfo, "I", f.lineinfo));
-#endif
   f.locvars = cast(struct LocVar *, flashCopy(L, f.sizelocvars, "SII", f.locvars));
   f.upvalues = cast(TString **, flashCopy(L, f.sizeupvalues, "S", f.upvalues));
   return cast(void *, flashCopy(L, 1, PROTO_COPY_MASK, &f));

--- a/app/lua/luac_cross/mingw32-Makefile.mak
+++ b/app/lua/luac_cross/mingw32-Makefile.mak
@@ -36,8 +36,8 @@ LUACSRC := luac.c      lflashimg.c liolib.c    loslib.c    print.c
 LUASRC  := lapi.c      lauxlib.c   lbaselib.c  lcode.c     ldblib.c    ldebug.c \
            ldo.c       ldump.c     lfunc.c     lgc.c       linit.c     llex.c \
            lmathlib.c  lmem.c      loadlib.c   lobject.c   lopcodes.c  lparser.c \
-           lrotable.c  lstate.c    lstring.c   lstrlib.c   ltable.c    ltablib.c \
-           ltm.c       lundump.c   lvm.c       lzio.c
+           lstate.c    lstring.c   lstrlib.c   ltable.c    ltablib.c \
+           ltm.c       lundump.c   lvm.c       lzio.c      lnodemcu.c
 UZSRC   := uzlib_deflate.c crc32.c
 #
 # This relies on the files being unique on the vpath

--- a/app/lua/lundump.c
+++ b/app/lua/lundump.c
@@ -223,18 +223,12 @@ static void LoadDebug(LoadState* S, Proto* f)
  n=LoadInt(S);
  Align4(S);
 
-#ifdef LUA_OPTIMIZE_DEBUG
  if(n) {
    f->packedlineinfo=luaM_newvector(S->L,n,unsigned char);
    LoadBlock(S,f->packedlineinfo,n);
  } else {
    f->packedlineinfo=NULL;
  }
-#else
- f->lineinfo=luaM_newvector(S->L,n,int);
- LoadVector(S,f->lineinfo,n,sizeof(int));
- f->sizelineinfo=n;
- #endif
  n=LoadInt(S);
  f->locvars=luaM_newvector(S->L,n,LocVar);
  f->sizelocvars=n;

--- a/app/lua/lvm.c
+++ b/app/lua/lvm.c
@@ -271,7 +271,7 @@ int luaV_lessthan (lua_State *L, const TValue *l, const TValue *r) {
 }
 
 
-static int lessequal (lua_State *L, const TValue *l, const TValue *r) {
+int luaV_lessequal (lua_State *L, const TValue *l, const TValue *r) {
   int res;
   if (ttype(l) != ttype(r))
     return luaG_ordererror(L, l, r);
@@ -570,7 +570,7 @@ void luaV_execute (lua_State *L, int nexeccalls) {
       }
       case OP_LEN: {
         const TValue *rb = RB(i);
-        switch (basettype(rb)) {
+        switch (ttnov(rb)) {
           case LUA_TTABLE: {
             setnvalue(ra, cast_num(luaH_getn(hvalue(rb))));
             break;
@@ -620,7 +620,7 @@ void luaV_execute (lua_State *L, int nexeccalls) {
       }
       case OP_LE: {
         Protect(
-          if (lessequal(L, RKB(i), RKC(i)) == GETARG_A(i))
+          if (luaV_lessequal(L, RKB(i), RKC(i)) == GETARG_A(i))
             dojump(L, pc, GETARG_sBx(*pc));
         )
         pc++;

--- a/app/lua/lvm.h
+++ b/app/lua/lvm.h
@@ -23,6 +23,7 @@
 
 
 LUAI_FUNC int luaV_lessthan (lua_State *L, const TValue *l, const TValue *r);
+LUAI_FUNC int luaV_lessequal (lua_State *L, const TValue *l, const TValue *r);
 LUAI_FUNC int luaV_equalval (lua_State *L, const TValue *t1, const TValue *t2);
 LUAI_FUNC const TValue *luaV_tonumber (const TValue *obj, TValue *n);
 LUAI_FUNC int luaV_tostring (lua_State *L, StkId obj);

--- a/app/lua53/lauxlib.h
+++ b/app/lua53/lauxlib.h
@@ -14,6 +14,9 @@
 
 #include "lua.h"
 
+#ifdef LUA_LIB
+#include "lnodemcu.h"
+#endif
 
 
 /* extra error code for 'luaL_loadfilex' */
@@ -282,8 +285,13 @@ extern void dbg_printf(const char *fmt, ...);
 #define LUA_TASK_MEDIUM 1
 #define LUA_TASK_HIGH   2
 
-LUALIB_API int (luaL_posttask) (lua_State* L, int prio);
-LUALIB_API int (luaL_pcallx) (lua_State *L, int narg, int nres);
+LUALIB_API int  (luaL_pushlfsmodules) (lua_State *L);
+LUALIB_API int  (luaL_pushlfsdts) (lua_State *L);
+LUALIB_API void (luaL_lfsreload) (lua_State *L);
+LUALIB_API int  (luaL_posttask) (lua_State* L, int prio);
+LUALIB_API int  (luaL_pcallx) (lua_State *L, int narg, int nres);
+
+#define luaL_pushlfsmodule(l) lua_pushlfsfunc(L);
 
 /* }============================================================ */
 

--- a/app/lua53/lbaselib.c
+++ b/app/lua53/lbaselib.c
@@ -18,7 +18,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 
 static int luaB_print (lua_State *L) {

--- a/app/lua53/lcorolib.c
+++ b/app/lua53/lcorolib.c
@@ -16,7 +16,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 
 static lua_State *getco (lua_State *L) {

--- a/app/lua53/linit.c
+++ b/app/lua53/linit.c
@@ -47,7 +47,6 @@ extern LROT_TABLE(dblib);
 extern LROT_TABLE(co_funcs);
 extern LROT_TABLE(mathlib);
 extern LROT_TABLE(utf8);
-extern LROT_TABLE(LFS);
 
 #define LROT_ROM_ENTRIES \
   LROT_TABENTRY( string, strlib ) \
@@ -56,7 +55,6 @@ extern LROT_TABLE(LFS);
   LROT_TABENTRY( coroutine, co_funcs ) \
   LROT_TABENTRY( math, mathlib ) \
   LROT_TABENTRY( utf8, utf8 ) \
-  LROT_TABENTRY( LFS, LFS ) \
   LROT_TABENTRY( ROM, rotables )
 
 #define LROT_LIB_ENTRIES \

--- a/app/lua53/lmathlib.c
+++ b/app/lua53/lmathlib.c
@@ -17,8 +17,7 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
-#include "ldebug.h"
+
 #undef PI
 #define PI	(l_mathop(3.141592653589793238462643383279502884))
 
@@ -135,7 +134,7 @@ static int math_fmod (lua_State *L) {
       lua_pushinteger(L, lua_tointeger(L, 1) % d);
   } else {
     lua_Number m, a=luaL_checknumber(L, 1), b=luaL_checknumber(L, 2);
-    if (b==0) luaG_runerror(L,"modulo by zero");
+    if (b==0) luaL_error(L,"modulo by zero");
     m = a/b;
     lua_pushnumber(L, a - b*(m > 0.0 ? floor(m) : ceil(m)));
   }

--- a/app/lua53/lnodemcu.c
+++ b/app/lua53/lnodemcu.c
@@ -30,21 +30,21 @@
 **    *  POSIX vs VFS file API abstraction
 **    *  Emulate Platform_XXX() API
 **    *  ESP and HOST lua_debugbreak() test stubs
-**    *  NodeMCU lua.h API extensions
-**    *  NodeMCU LFS Table emulator
+**    *  NodeMCU lua.h LUA_API extensions
+**    *  NodeMCU lauxlib.h LUALIB_API extensions
 **    *  NodeMCU bootstrap to set up and to reimage LFS resources
 **
 ** Just search down for //== or ==// to flip through the sections.
 */
 
-#define byte_addr(p) cast(char *,p)
+#define byte_addr(p)    cast(char *,p)
 #define byteptr(p)      cast(lu_byte *, p)
-#define byteoffset(p,q) (byteptr(p) - byteptr(q))
+#define byteoffset(p,q) ((int) cast(ptrdiff_t, (byteptr(p) - byteptr(q))))
 #define wordptr(p)      cast(lu_int32 *, p)
 #define wordoffset(p,q) (wordptr(p) - wordptr(q))
 
 
-//== Wrap POSIX and VFS file API =============================================//
+//====================== Wrap POSIX and VFS file API =========================//
 #ifdef LUA_USE_ESP
 int luaopen_file(lua_State *L);
 #  define l_file(f)   int f
@@ -62,7 +62,6 @@ int luaopen_file(lua_State *L);
 #  define l_rewind(f) rewind(f)
 #endif
 
-//== Emulate Platform_XXX() API ==============================================//
 #ifdef LUA_USE_ESP
 
 extern void dbg_printf(const char *fmt, ...);                // DEBUG
@@ -78,6 +77,8 @@ extern void dbg_printf(const char *fmt, ...);                // DEBUG
 #define lockFlashWrite()
 
 #else // LUA_USE_HOST
+
+//==== Emulate Platform_XXX() API within host luac.cross -e environement =====//
 
 #include<stdio.h>                                             // DEBUG
 /*
@@ -124,9 +125,9 @@ extern char  *LFSimageName;
 
 #define platform_rcr_write(id,rec,l) (128)
 #define platform_flash_phys2mapped(n) \
-    (byteptr(LFSaddr) + (n) - LFSbase)
+    ((ptrdiff_t)(((size_t)LFSaddr) - LFSbase) + (n))
 #define platform_flash_mapped2phys(n) \
-    (byteoffset(n, LFSaddr) + LFSbase)
+    ((size_t)(n) - ((size_t)LFSaddr) + LFSbase)
 #define platform_flash_get_sector_of_address(n) ((n)>>12)
 #define platform_rcr_delete(id) LFSimageName = NULL
 #define platform_rcr_read(id,s) \
@@ -170,7 +171,7 @@ static void platform_s_flash_write(const void *from, lu_int32 to, lu_int32 len) 
 
 #endif
 
-//== ESP and HOST lua_debugbreak() test stubs ================================//
+//============= ESP and HOST lua_debugbreak() test stubs =====================//
 
 #ifdef DEVELOPMENT_USE_GDB
 /*
@@ -204,7 +205,7 @@ LUALIB_API void lua_debugbreak(void) {
 }
 #endif
 
-//== NodeMCU lua.h API extensions ============================================//
+//===================== NodeMCU lua.h API extensions =========================//
 
 LUA_API int lua_freeheap (void) {
 #ifdef LUA_USE_HOST
@@ -214,34 +215,39 @@ LUA_API int lua_freeheap (void) {
 #endif
 }
 
-LUA_API int lua_getstrings(lua_State *L, int opt) {
-  stringtable *tb = NULL;
-  Table *t;
-  int i, j, n = 0;
-
-  if (n == 0)
-    tb = &G(L)->strt;
-#ifdef LUA_USE_ESP
-  else if (n == 1 && G(L)->ROstrt.hash)
-    tb = &G(L)->ROstrt;
-#endif
-  if (tb == NULL)
-   return 0;
-
+LUA_API int lua_pushstringsarray(lua_State *L, int opt) {
+  stringtable *strt = NULL;
+  int i, j = 1;
+ 
   lua_lock(L);
-  t = luaH_new(L);
+  if (opt == 0)
+    strt = &G(L)->strt;
+#ifdef LUA_USE_ESP
+  else if (opt == 1 && G(L)->ROstrt.hash)
+    strt = &G(L)->ROstrt;
+#endif
+  if (strt == NULL) {
+    setnilvalue(L->top);
+    api_incr_top(L);
+    lua_unlock(L);
+    return 0;
+  }
+
+  Table *t = luaH_new(L);
   sethvalue(L, L->top, t);
   api_incr_top(L);
-  luaH_resize(L, t, tb->nuse, 0);
+  luaH_resize(L, t, strt->nuse, 0);
   luaC_checkGC(L);
   lua_unlock(L);
 
-  for (i = 0, j = 1; i < tb->size; i++) {
-    TString *o;
-    for(o = tb->hash[i]; o; o = o->u.hnext) {
+  /* loop around all strt hash entries */
+  for (i = 0, j = 1; i < strt->size; i++) {
+    TString *e;
+    /* loop around all TStings in this entry's chain */
+    for(e = strt->hash[i]; e; e = e->u.hnext) {
       TValue s;
-      setsvalue(L, &s, o);
-      luaH_setint(L, hvalue(L->top-1), j++, &s);  /* table[n] = true */
+      setsvalue(L, &s, e);
+      luaH_setint(L, hvalue(L->top-1), j++, &s);
     }
   }
   return 1;
@@ -274,72 +280,91 @@ LUA_API void lua_createrotable (lua_State *L, ROTable *t,
   t->entry     = cast(ROTable_entry *, e);
 }
 
-//== NodeMCU LFS Table emulator ==============================================//
-
-static int lfs_func (lua_State* L);
-
-LROT_BEGIN(LFS_meta, NULL, LROT_MASK_INDEX)
-  LROT_FUNCENTRY( __index, lfs_func)
-LROT_END(LFS_meta, NULL, LROT_MASK_INDEX)
-
-LROT_BEGIN(LFS, LROT_TABLEREF(LFS_meta), 0)
-LROT_END(LFS, LROT_TABLEREF(LFS_meta), 0)
-
-
-static int lfs_func (lua_State* L) {           /*T[1] = LFS, T[2] = fieldname */
-  const char *name = lua_tostring(L, 2);
-  LFSHeader *fh = G(L)->l_LFS;
-  Proto *f;
-  LClosure *cl;
-  lua_settop(L,2);
-  if (!fh) {                                  /* return nil if LFS not loaded */
-    lua_pushnil(L);
-    return 1;
+LUA_API void lua_getlfsconfig (lua_State *L, int *config) {
+  global_State *g = G(L);
+  LFSHeader *l = g->l_LFS;  
+  if (!config)
+    return;
+  config[0] = (int) (size_t) l;                  /* LFS region mapped address */
+  config[1] = platform_flash_mapped2phys(config[0]);    /* ditto phys address */
+  config[2] = g->LFSsize;                           /* LFS region actual size */
+  if (g->ROstrt.hash) {
+    config[3] = l->flash_size;                             /* LFS region used */
+    config[4] = l->timestamp;                         /* LFS region timestamp */
+  } else { 
+    config[3] = config[4] = 0;
   }
-  if (!strcmp(name, "_config")) {
-    size_t ba = cast(size_t, fh);
-    lua_createtable(L, 0, 3);
-    lua_pushinteger(L, cast(lua_Integer, ba));
-    lua_setfield(L, -2, "lfs_mapped");
-    lua_pushinteger(L, cast(lua_Integer, platform_flash_mapped2phys(ba)));
-    lua_setfield(L, -2, "lfs_base");
-    lua_pushinteger(L, G(L)->LFSsize);
-    lua_setfield(L, -2, "lfs_size");
-    return 1;
-  } else if (!strcmp(name, "_list")) {
-    int i = 1;
-    setobjs2s(L, L->top-2, &G(L)->LFStable);  /* overwrite T[1] with LSFtable */
-    lua_newtable(L);                                /* new list table at T[3] */
-    lua_pushnil(L);                                 /* first key (nil) at T4] */
-    while (lua_next(L, 1) != 0) {         /* loop over LSFtable k,v at T[4:5] */
-      lua_pop(L, 1);                                            /* dump value */
-      lua_pushvalue(L, -1);                                        /* dup key */
-      lua_rawseti(L, 3, i++);                                 /* table[i]=key */
+}
+
+LUA_API int  (lua_pushlfsindex) (lua_State *L) {
+  lua_lock(L);
+  setobj2n(L, L->top, &G(L)->LFStable);
+  api_incr_top(L);
+  lua_unlock(L);
+  return  ttnov(L->top-1);
+}
+
+/*
+ * In Lua 5.3 luac.cross generates a top level Proto for each source file with 
+ * one upvalue that must be the set to the _ENV variable when its closure is
+ * created, and as such this parallels some ldo.c processing.
+ */
+LUA_API int  (lua_pushlfsfunc) (lua_State *L) {
+  lua_lock(L);
+  const TValue *t = &G(L)->LFStable;
+  if (ttisstring(L->top-1) && ttistable(t)) {
+    const TValue *v = luaH_getstr (hvalue(t), tsvalue(L->top-1));
+    if (ttislightuserdata(v)) {
+      Proto *f = pvalue(v);   /* The pvalue is a Proto * for the Lua function */
+      LClosure *cl = luaF_newLclosure(L, f->sizeupvalues);
+      setclLvalue(L, L->top-1, cl);
+      luaF_initupvals(L, cl);
+      cl->p = f;
+      if (cl->nupvalues >= 1) {                   /* does it have an upvalue? */
+        UpVal *uv1 = cl->upvals[0];
+        TValue *val = uv1->v;
+        /* set 1st upvalue as global env table from registry */
+        setobj(L, val, luaH_getint(hvalue(&G(L)->l_registry), LUA_RIDX_GLOBALS));
+        luaC_upvalbarrier(L, uv1);
+      }
+      return 1;
     }
-    return 1;
-  } else if (!strcmp(name, "_time")) {
-    lua_pushinteger(L, fh->timestamp);
-    return 1;
   }
-  setobjs2s(L, L->top-2, &G(L)->LFStable);    /* overwrite T[1] with LSFtable */
-  if (lua_rawget(L,1) != LUA_TNIL) {                    /* get LFStable[name] */
-    lua_pushglobaltable(L);
-    f = cast(Proto *, lua_topointer(L,-2));
-    lua_lock(L);
-    cl = luaF_newLclosure(L, f->sizeupvalues);
-    setclLvalue(L, L->top-2, cl);       /* overwrite f addr slot with closure */
-    cl->p = f;                                                /* bind f to it */
-    if (cl->nupvalues >= 1) {           /* does it have at least one upvalue? */
-      luaF_initupvals(L, cl );                            /* initialise upvals */
-      setobj(L, cl->upvals[0]->v, L->top-1);             /* set UV[1] to _ENV */
-    }
-    lua_unlock(L);
-    lua_pop(L,1);                          /* pop _ENV leaving closure at ToS */
+  setnilvalue(L->top-1);
+  lua_unlock(L);
+  return 0;
+}
+
+
+//================ NodeMCU lauxlib.h LUALIB_API extensions ===================//
+
+/*
+ * Return an array of functions in LFS
+ */
+LUALIB_API int  (luaL_pushlfsmodules) (lua_State *L) {
+  int i = 1;
+  if (lua_pushlfsindex(L) == LUA_TNIL)
+    return 0;                                 /* return nil if LFS not loaded */
+  lua_newtable(L);      /* create dest table and move above LFS index ROTable */
+  lua_insert(L, -2);
+  lua_pushnil(L);
+  while (lua_next(L, -2) != 0) {
+    lua_pop(L, 1);                       /* dump the value (ptr to the Proto) */
+    lua_pushvalue(L, -1);                            /* dup key (module name) */
+    lua_rawseti(L, -4, i++);
   }
+  lua_pop(L, 1);                                /* dump the LFS index ROTable */
   return 1;
 }
 
-//== NodeMCU bootstrap to set up and to reimage LFS resources ================//
+LUALIB_API int  (luaL_pushlfsdts) (lua_State *L) {
+  int config[5];
+  lua_getlfsconfig(L, config);
+  lua_pushinteger(L, config[4]);
+  return 1;
+}
+
+//======== NodeMCU bootstrap to set up and to reimage LFS resources ==========//
 /*
 ** This processing uses 2 init hooks during the Lua startup. The first is
 ** called early in the Lua state setup to initialize the LFS if present. The
@@ -494,9 +519,9 @@ LUAI_FUNC int luaN_init (lua_State *L) {
       if (n < 0) {
         global_State *g = G(L);
         g->LFSsize     = F->size;
+        g->l_LFS       = fh;
       /* Set up LFS hooks on normal Entry */
         if (fh->flash_sig   == FLASH_SIG) {
-          g->l_LFS       = fh;
           g->seed        = fh->seed;
           g->ROstrt.hash = cast(TString **, F->addr + fh->oROhash);
           g->ROstrt.nuse = fh->nROuse ;
@@ -565,9 +590,9 @@ LUAI_FUNC int luaN_init (lua_State *L) {
 #define getfield(L,t,f) \
   lua_getglobal(L, #t); luaL_getmetafield( L, 1, #f ); lua_remove(L, -2);
 
-LUAI_FUNC int  lua_lfsreload (lua_State *L) {
-  int n = 0;
+LUALIB_API void luaL_lfsreload (lua_State *L) {
 #ifdef LUA_USE_ESP
+  int n = 0;
   size_t l;
   int off = 0;
   const char *img = lua_tolstring(L, 1, &l);
@@ -579,30 +604,70 @@ LUAI_FUNC int  lua_lfsreload (lua_State *L) {
   lua_getglobal(L, "file");
   if (lua_isnil(L, 2)) {
     lua_pushstring(L, "No file system mounted");
-    return 1;
+    return;
   }
   lua_getfield(L, 2, "exists");
   lua_pushstring(L, img + off);
   lua_call(L, 1, 1);
   if (G(L)->LFSsize == 0 || lua_toboolean(L, -1) == 0) {
     lua_pushstring(L, "No LFS partition allocated");
-    return 1;
+    return;
   }
   n = platform_rcr_write(PLATFORM_RCR_FLASHLFS, img, l+1);/* incl trailing \0 */
   if (n>0)
     system_restart();
 #endif
-  lua_pushboolean(L, n>0);
-  return 1;
 }
 
-LUAI_FUNC int  lua_lfsindex (lua_State *L) {
-  lua_settop(L,1);
-  if (lua_isstring(L, 1)){
-    lua_getglobal(L, "LFS");
-    lua_getfield(L, 2, lua_tostring(L,1));
-  } else {
-    lua_pushnil(L);
+
+#ifdef LUA_USE_ESP
+extern void lua_main(void);
+/*
+** Task callback handler. Uses luaN_call to do a protected call with full traceback
+*/
+static void do_task (platform_task_param_t task_fn_ref, uint8_t prio) {
+  lua_State* L = lua_getstate();
+  if(task_fn_ref == (platform_task_param_t)~0 && prio == LUA_TASK_HIGH) {
+    lua_main();                   /* Undocumented hook for lua_main() restart */
+    return;
   }
-  return 1;
+  if (prio < LUA_TASK_LOW|| prio > LUA_TASK_HIGH)
+    luaL_error(L, "invalid posk task");
+/* Pop the CB func from the Reg */
+  lua_rawgeti(L, LUA_REGISTRYINDEX, (int) task_fn_ref);
+  luaL_checktype(L, -1, LUA_TFUNCTION);
+  luaL_unref(L, LUA_REGISTRYINDEX, (int) task_fn_ref);
+  lua_pushinteger(L, prio);
+  luaL_pcallx(L, 1, 0);
 }
+
+/*
+** Schedule a Lua function for task execution
+*/
+LUALIB_API int luaL_posttask ( lua_State* L, int prio ) {         // [-1, +0, -]
+  static platform_task_handle_t task_handle = 0;
+  if (!task_handle)
+    task_handle = platform_task_get_id(do_task);
+  if (L == NULL && prio == LUA_TASK_HIGH+1) { /* Undocumented hook for lua_main */
+    platform_post(LUA_TASK_HIGH, task_handle, (platform_task_param_t)~0);
+    return -1;
+  }
+  if (lua_isfunction(L, -1) && prio >= LUA_TASK_LOW && prio <= LUA_TASK_HIGH) {
+    int task_fn_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    if(!platform_post(prio, task_handle, (platform_task_param_t)task_fn_ref)) {
+      luaL_unref(L, LUA_REGISTRYINDEX, task_fn_ref);
+      luaL_error(L, "Task queue overflow. Task not posted");
+    }
+    return task_fn_ref;
+  } else {
+    return luaL_error(L, "invalid posk task");
+  }
+}
+#else
+/*
+** Task execution isn't supported on HOST builds so returns a -1 status
+*/
+LUALIB_API int luaL_posttask( lua_State* L, int prio ) {            // [-1, +0, -]
+  return -1;
+}
+#endif

--- a/app/lua53/lnodemcu.h
+++ b/app/lua53/lnodemcu.h
@@ -40,12 +40,12 @@
 #define LROT_ENTRYREF(rt)    (rt ##_entries)
 #define LROT_TABLEREF(rt)    (&rt ##_ROTable)
 #define LROT_BEGIN(rt,mt,f)  LROT_TABLE(rt); \
-  static const ROTable_entry rt ## _entries[] = {
+  static ROTable_entry rt ## _entries[] = {
 #define LROT_ENTRIES_IN_SECTION(rt,s) \
-  static const ROTable_entry LOCK_IN_SECTION(s) rt ## _entries[] = {
+  static ROTable_entry LOCK_IN_SECTION(s) rt ## _entries[] = {
 #define LROT_END(rt,mt,f)    {NULL, LRO_NILVAL} }; \
   const ROTable rt ## _ROTable = { \
-    (GCObject *)1,LUA_TTBLROF, LROT_MARKED, \
+    (GCObject *)1, LUA_TTBLROF, LROT_MARKED, \
     cast(lu_byte, ~(f)), (sizeof(rt ## _entries)/sizeof(ROTable_entry)) - 1, \
     cast(Table *, mt), cast(ROTable_entry *, rt ## _entries) };
 #define LROT_BREAK(rt)       };

--- a/app/lua53/loadlib.c
+++ b/app/lua53/loadlib.c
@@ -22,7 +22,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 #ifndef LUA_USE_HOST
 #include <fcntl.h>

--- a/app/lua53/lobject.h
+++ b/app/lua53/lobject.h
@@ -584,12 +584,6 @@ typedef struct ROTable {
 */
 #define luaO_nilobject		(&luaO_nilobject_)
 
-/*
-** KeyCache used for resolution of ROTable entries and Cstrings
-*/
-typedef size_t KeyCache;
-typedef KeyCache KeyCacheLine[KEYCACHE_M];
-
 LUAI_DDEC const TValue luaO_nilobject_;
 
 /* size of buffer for 'luaO_utf8esc' function */

--- a/app/lua53/lparser.c
+++ b/app/lua53/lparser.c
@@ -23,9 +23,9 @@
 #include "lobject.h"
 #include "lopcodes.h"
 #include "lparser.h"
-#include "lstate.h"
 #include "lstring.h"
 #include "ltable.h"
+#include "lundump.h"
 
 
 
@@ -1633,6 +1633,13 @@ static void mainfunc (LexState *ls, FuncState *fs) {
 }
 
 
+static void compile_stripdebug(lua_State *L, Proto *f) {
+  int level =  G(L)->stripdefault;
+  if (level > 0)
+    luaU_stripdebug(L, f, level, 1);
+}
+
+
 LClosure *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff,
                        Dyndata *dyd, const char *name, int firstchar) {
   LexState lexstate;
@@ -1654,6 +1661,7 @@ LClosure *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff,
   lua_assert(!funcstate.prev && funcstate.nups == 1 && !lexstate.fs);
   /* all scopes should be correctly finished */
   lua_assert(dyd->actvar.n == 0 && dyd->gt.n == 0 && dyd->label.n == 0);
+  compile_stripdebug(L, funcstate.f);
   L->top--;  /* remove scanner's table */
   return cl;  /* closure is on the stack, too */
 }

--- a/app/lua53/lstate.c
+++ b/app/lua53/lstate.c
@@ -307,7 +307,7 @@ void luaE_freethread (lua_State *L, lua_State *L1) {
   luaM_free(L, l);
 }
 
-LUA_API KeyCache *(lua_getcache) (int lineno) {
+LUAI_FUNC KeyCache *luaE_getcache (int lineno) {
   return &G(L0)->cache[lineno][0];
 }
 
@@ -347,6 +347,7 @@ LUA_API lua_State *lua_newstate (lua_Alloc f, void *ud) {
   g->gcfinnum = 0;
   g->gcpause = LUAI_GCPAUSE;
   g->gcstepmul = LUAI_GCMUL;
+  g->stripdefault = LUAI_OPTIMIZE_DEBUG;
   g->ROstrt.size = 0;
   g->ROstrt.nuse = 0;
   g->ROstrt.hash = NULL;

--- a/app/lua53/lstate.h
+++ b/app/lua53/lstate.h
@@ -133,6 +133,11 @@ typedef struct CallInfo {
 #define setoah(st,v)	((st) = ((st) & ~CIST_OAH) | (v))
 #define getoah(st)	((st) & CIST_OAH)
 
+/*
+** KeyCache used for resolution of ROTable entries and Cstrings
+*/
+typedef size_t KeyCache;
+typedef KeyCache KeyCacheLine[KEYCACHE_M];
 
 /*
 ** 'global state', shared by all threads of this state
@@ -168,6 +173,7 @@ typedef struct global_State {
   unsigned int gcfinnum;  /* number of finalizers to call in each GC step */
   int gcpause;  /* size of pause between successive GCs */
   int gcstepmul;  /* GC 'granularity' */
+  int stripdefault;  /* default stripping level for compilation */
   l_mem gcmemfreeboard;  /* Free board which triggers EGC */
   lua_CFunction panic;  /* to be called in unprotected errors */
   struct lua_State *mainthread;
@@ -229,8 +235,6 @@ union GCUnion {
   struct Proto p;
   struct lua_State th;  /* thread */
 };
-
-
 #define cast_u(o)	cast(union GCUnion *, (o))
 
 /* macros to convert a GCObject into a specific value */
@@ -262,7 +266,6 @@ LUAI_FUNC void luaE_freethread (lua_State *L, lua_State *L1);
 LUAI_FUNC CallInfo *luaE_extendCI (lua_State *L);
 LUAI_FUNC void luaE_freeCI (lua_State *L);
 LUAI_FUNC void luaE_shrinkCI (lua_State *L);
-
+LUAI_FUNC KeyCache *luaE_getcache (int cl);
 
 #endif
-

--- a/app/lua53/lstrlib.c
+++ b/app/lua53/lstrlib.c
@@ -23,7 +23,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 
 /*
@@ -189,11 +188,16 @@ static int writer (lua_State *L, const void *b, size_t size, void *B) {
 
 static int str_dump (lua_State *L) {
   luaL_Buffer b;
-  int strip = lua_tointeger(L, 2);
-  if (lua_isboolean(L, 2) && lua_toboolean(L, 2))
-    strip = 2;
+  int strip, tstrip = lua_type(L, 2);
+  if (tstrip == LUA_TBOOLEAN) {
+    strip = lua_toboolean(L, 2) ? 2 : 0;
+  } else if (tstrip == LUA_TNONE || tstrip == LUA_TNIL) {
+    strip = -1;  /* This tells lua_dump to use the global strip default */
+  } else { 
+    strip = lua_tointeger(L, 2);
+    luaL_argcheck(L, (unsigned)(strip) < 3, 2, "strip out of range");
+  }
   luaL_checktype(L, 1, LUA_TFUNCTION);
-  luaL_argcheck(L, 3 > (unsigned)(strip), 1, "strip out of range");
   lua_settop(L, 1);
   luaL_buffinit(L,&b);
   if (lua_dump(L, writer, &b, strip) != 0)
@@ -201,7 +205,6 @@ static int str_dump (lua_State *L) {
   luaL_pushresult(&b);
   return 1;
 }
-
 
 
 /*

--- a/app/lua53/ltable.c
+++ b/app/lua53/ltable.c
@@ -739,7 +739,7 @@ static const TValue* rotable_findentry(ROTable *t, TString *key, unsigned *ppos)
   const int tl = getlsizenode(t);
   const char *strkey = getstr(key);
   const int hash = HASH(t, key);
-  KeyCache *cl = lua_getcache(hash);
+  KeyCache *cl = luaE_getcache(hash);
   int i, j = 1, l;
 
   if (!e || gettt(key) != LUA_TSHRSTR)

--- a/app/lua53/ltablib.c
+++ b/app/lua53/ltablib.c
@@ -18,7 +18,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 
 /*

--- a/app/lua53/lua.c
+++ b/app/lua53/lua.c
@@ -238,9 +238,20 @@ static int pmain (lua_State *L) {
   * then attempting the open will trigger a file system format.
   */
   platform_rcr_read(PLATFORM_RCR_INITSTR, (void**) &init);
-  status = (init[0] == '@') ?
-           luaL_loadfile(L, init+1) :
-           luaL_loadbuffer(L, init, strlen(init), "=INIT");
+  if (init[0] == '!') { /* !module is a compile-free way of executing LFS module */
+    luaL_pushlfsmodule(L);
+    lua_pushstring(L, init+1);
+    lua_call(L, 1, 1);  /* return LFS.module or nil */
+    status = LUA_OK;
+    if (!lua_isfunction(L, -1)) {
+      lua_pushfstring(L, "cannot load LFS.%s", init+1);
+      status = LUA_ERRRUN;
+    }
+  } else {
+    status = (init[0] == '@') ?
+             luaL_loadfile(L, init+1) :
+             luaL_loadbuffer(L, init, strlen(init), "=INIT");
+  }
   if (status == LUA_OK)
     status = docall(L, 0);
   if (status != LUA_OK)

--- a/app/lua53/lua.h
+++ b/app/lua53/lua.h
@@ -153,6 +153,10 @@ LUA_API lua_CFunction (lua_atpanic) (lua_State *L, lua_CFunction panicf);
 
 LUA_API const lua_Number *(lua_version) (lua_State *L);
 
+#ifndef LUAI_OPTIMIZE_DEBUG
+#define LUAI_OPTIMIZE_DEBUG 2
+#endif
+
 
 /*
 ** basic stack manipulation
@@ -282,7 +286,8 @@ LUA_API int   (lua_pcallk) (lua_State *L, int nargs, int nresults, int errfunc,
 LUA_API int   (lua_load) (lua_State *L, lua_Reader reader, void *dt,
                           const char *chunkname, const char *mode);
 
-LUA_API int (lua_dump) (lua_State *L, lua_Writer writer, void *data, int strip);
+LUA_API int   (lua_dump) (lua_State *L, lua_Writer writer, void *data, int strip);
+LUA_API int   (lua_stripdebug) (lua_State *L, int stripping);
 
 
 /*
@@ -465,17 +470,17 @@ struct lua_Debug {
 
 typedef struct ROTable ROTable;
 typedef const struct ROTable_entry ROTable_entry;
-typedef size_t KeyCache;
 
 LUA_API void (lua_pushrotable) (lua_State *L, const ROTable *p);
 LUA_API void (lua_createrotable) (lua_State *L, ROTable *t, const ROTable_entry *e, ROTable *mt);
 LUA_API lua_State *(lua_getstate) (void);
-LUA_API KeyCache *(lua_getcache) (int cl);
-LUA_API int (lua_getstrings) (lua_State *L, int opt);
+LUA_API int (lua_pushstringsarray) (lua_State *L, int opt);
 LUA_API int (lua_freeheap) (void);
 
-LUAI_FUNC int  lua_lfsreload (lua_State *L);
-LUAI_FUNC int  lua_lfsindex (lua_State *L);
+LUA_API void (lua_getlfsconfig) (lua_State *L, int *);
+LUA_API int  (lua_pushlfsindex) (lua_State *L);
+LUA_API int  (lua_pushlfsfunc) (lua_State *L);
+
 
 #define luaN_freearray(L,a,l) luaM_freearray(L,a,l)
 
@@ -492,8 +497,6 @@ LUALIB_API void (lua_debugbreak)(void);
 #define lua_debugbreak() (void)(0)
 #define ASSERT(s) (void)(0)
 #endif
-
-LUAI_FUNC int luaG_stripdebug (lua_State *L, Proto *f, int level, int recv);
 
 
 // from undump.c

--- a/app/lua53/lundump.h
+++ b/app/lua53/lundump.h
@@ -48,6 +48,7 @@ LUAI_FUNC int luaU_DumpAllProtos(lua_State *L, const Proto *m, lua_Writer w,
                          void *data, int strip);
 
 LUAI_FUNC int luaU_undumpLFS(lua_State *L, ZIO *Z, int isabs);
+LUAI_FUNC int luaU_stripdebug (lua_State *L, Proto *f, int level, int recv);
 
 typedef struct FlashHeader LFSHeader;
 /*

--- a/app/lua53/lutf8lib.c
+++ b/app/lua53/lutf8lib.c
@@ -19,7 +19,6 @@
 
 #include "lauxlib.h"
 #include "lualib.h"
-#include "lnodemcu.h"
 
 #define MAXUNICODE	0x10FFFF
 

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -1,14 +1,9 @@
 // Module for interfacing with system
 #include "module.h"
 #include "lauxlib.h"
-#include "lstate.h"
 #include "lmem.h"
 
-
 #include "platform.h"
-#if LUA_VERSION_NUM == 501
-#include "lflash.h"
-#endif
 #include <stdint.h>
 #include <string.h>
 #include "user_interface.h"
@@ -163,14 +158,27 @@ static void add_string_field( lua_State* L, const char *s, const char *name) {
   lua_setfield(L, -2, name);
 }
 
-static int node_info( lua_State* L )
-{
-  const char* options[] = {"hw", "sw_version", "build_config", "legacy", NULL};
-  int option = luaL_checkoption (L, 1, options[3], options);
+static void get_lfs_config ( lua_State* L ){
+    int config[5];
+    lua_getlfsconfig(L, config);
+    lua_createtable(L, 0, 4);
+    add_int_field(L, config[0], "lfs_mapped");
+    add_int_field(L, config[1], "lfs_base");
+    add_int_field(L, config[2], "lfs_size");
+    add_int_field(L, config[3], "lfs_used");
+}
+
+static int node_info( lua_State* L ){
+  const char* options[] = {"lfs", "hw", "sw_version", "build_config", "legacy", NULL};
+  int option = luaL_checkoption (L, 1, options[4], options);
 
   switch (option) {
-    case 0: { // hw
-      lua_createtable (L, 0, 5);
+    case 0: { // lfs
+      get_lfs_config(L);
+      return 1;
+    }
+    case 1: { // hw
+      lua_createtable(L, 0, 5);
       add_int_field(L, system_get_chip_id(),             "chip_id");
       add_int_field(L, spi_flash_get_id(),               "flash_id");
       add_int_field(L, flash_rom_get_size_byte() / 1024, "flash_size");
@@ -178,8 +186,8 @@ static int node_info( lua_State* L )
       add_int_field(L, flash_rom_get_speed(),            "flash_speed");
       return 1;
     }
-    case 1: { // sw_version
-      lua_createtable (L, 0, 7);     
+    case 2: { // sw_version
+      lua_createtable(L, 0, 7);     
       add_int_field(L, NODE_VERSION_MAJOR,       "node_version_major");
       add_int_field(L, NODE_VERSION_MINOR,       "node_version_minor");
       add_int_field(L, NODE_VERSION_REVISION,    "node_version_revision");
@@ -189,8 +197,8 @@ static int node_info( lua_State* L )
       add_string_field(L, BUILDINFO_RELEASE_DTS, "git_commit_dts");
       return 1;
     }
-    case 2: { // build_config
-      lua_createtable (L, 0, 4);
+    case 3: { // build_config
+      lua_createtable(L, 0, 4);
       lua_pushboolean(L, BUILDINFO_SSL);
       lua_setfield(L, -2, "ssl");
       lua_pushnumber(L, BUILDINFO_LFS_SIZE);
@@ -199,8 +207,7 @@ static int node_info( lua_State* L )
       add_string_field(L, BUILDINFO_BUILD_TYPE, "number_type");
       return 1;
     }
-    default:
-    {
+    default: { // legacy
       platform_print_deprecation_note("node.info() without parameter", "in the next version");
       lua_pushinteger(L, NODE_VERSION_MAJOR);
       lua_pushinteger(L, NODE_VERSION_MINOR);
@@ -333,8 +340,6 @@ static int writer(lua_State* L, const void* p, size_t size, void* u)
 }
 
 #if LUA_VERSION_NUM == 501
-#undef lua_dump
-#define lua_dump lua_dumpEx
 #define getproto(o)	(clvalue(o)->l.p)
 #endif
 
@@ -461,8 +466,6 @@ static int node_restore (lua_State *L)
   return 0;
 }
 
-#if defined(LUA_OPTIMIZE_DEBUG) && LUA_VERSION_NUM == 501
-
 /* node.stripdebug([level[, function]]). 
  * level:    1 don't discard debug
  *           2 discard Local and Upvalue debug info
@@ -472,54 +475,36 @@ static int node_restore (lua_State *L)
  * If function is omitted, this is the default setting for future compiles
  * The function returns an estimated integer count of the bytes stripped.
  */
-LUA_API int luaG_stripdebug (lua_State *L, Proto *f, int level, int recv);
 static int node_stripdebug (lua_State *L) {
 
   int n = lua_gettop(L);
-  if (n == 0) {
-    lua_pushlightuserdata(L, &luaG_stripdebug );
-    lua_gettable(L, LUA_REGISTRYINDEX);
-    if (lua_isnil(L, -1)) {
-      lua_pop(L, 1);
-      lua_pushinteger(L, LUA_OPTIMIZE_DEBUG);
-    }
-    return 1;
-  }
+  int strip = 0;
 
-  int level = luaL_checkint(L, 1);
-  luaL_argcheck(L, level > 0 && level < 4, 1, "must in range 1-3");
-
-  if (n == 1) {
-    /* Store the default level in the registry if no function parameter */
-    lua_pushlightuserdata(L, &luaG_stripdebug);
-    lua_pushinteger(L, level);
-    lua_settable(L, LUA_REGISTRYINDEX);
-    return 0;
-  }
-
-  if (level == 1) {
-    lua_pushinteger(L, 0);
-    return 1;
-  }
+  lua_settop(L, 2);
+  if (!lua_isnil(L, 1)) {
+    strip = lua_tointeger(L, 1);
+    luaL_argcheck(L, strip > 0 && strip < 4, 1, "Invalid strip level");
+  } 
 
   if (lua_isnumber(L, 2)) {
-    int scope = luaL_checkint(L, 2);
-    if (scope > 0) {
-      /* if the function parameter is a +ve integer then climb to find function */
+    /* Use debug interface to replace stack level by corresponding function */
+    int scope = luaL_checkinteger(L, 2);
+    if (scope > 0) { 
       lua_Debug ar;
-      lua_pop(L, 1); /* pop level as getinfo will replace it by the function */
+      lua_pop(L, 1);
       if (lua_getstack(L, scope, &ar)) {
-        lua_getinfo(L, "f", &ar);
+        lua_getinfo(L, "f", &ar);  /* put function at [2] (ToS) */
       }
     }
   }
+ 
+  int isfunc = lua_isfunction(L, 2);
+  luaL_argcheck(L, n < 2 || isfunc, 2, "not a valid function");
 
-  luaL_argcheck(L, lua_isfunction(L, 2), 2, "must be a Lua Function");
-  Proto *f = getproto(L->ci->func + 1);
-  lua_pushinteger(L, luaG_stripdebug(L, f, level, 1));
+  /* return result of lua_stripdebug, adding 1 if this is get/set level) */ 
+  lua_pushinteger(L, lua_stripdebug(L, strip - 1) + (isfunc ? 0 : 1));
   return 1;
 }
-#endif
 
 
 #if LUA_VERSION_NUM == 501
@@ -539,9 +524,10 @@ static int node_egc_setmode(lua_State* L) {
 }
 // totalallocated, estimatedused = node.egc.meminfo()
 static int node_egc_meminfo(lua_State *L) {
-  global_State *g = G(L);
-  lua_pushinteger(L, g->totalbytes);
-  lua_pushinteger(L, g->estimate);
+  int totals[2];
+  lua_getegcinfo(L, totals);
+  lua_pushinteger(L, totals[0]);
+  lua_pushinteger(L, totals[1]);
   return 2;
 }
 #endif
@@ -650,6 +636,56 @@ static int node_writercr (lua_State *L) {
   return 1;
 }
 #endif
+
+// Lua: n = node.lfsreload(lfsimage)
+static int node_lfsreload (lua_State *L) {
+  lua_settop(L, 1);
+  luaL_lfsreload(L);
+  return 1;
+}
+
+// Lua: n = node.flashindex(module)
+static int node_lfsindex (lua_State *L) {
+  lua_settop(L, 1);
+  luaL_pushlfsmodule(L);
+  return 1;
+}
+
+
+//== node.LFS Table emulator ==============================================//
+
+static int node_lfs_func (lua_State* L) {      /*T[1] = LFS, T[2] = fieldname */
+  lua_remove(L, 1);
+  const char *name = lua_tostring(L, 1);
+  if (!name) {
+    lua_pushnil(L);
+  } else if (!strcmp(name, "config")) {
+    get_lfs_config(L);
+  } else if (!strcmp(name, "get")) {
+    lua_pushcfunction(L, &node_lfsindex);
+  } else if (!strcmp(name, "list")) {
+    luaL_pushlfsmodules(L);
+    if (lua_istable(L, -1) && lua_getglobal(L, "table") == LUA_TTABLE) {
+      lua_getfield(L, -1, "sort");
+      lua_remove(L, -2);       /* remove table table */
+      lua_pushvalue(L, -2);    /* dup array of modules ref to ToS */
+      lua_call(L, 1, 0);
+    }
+  } else if (!strcmp(name, "time")) {
+    luaL_pushlfsdts(L);
+  } else {
+    luaL_pushlfsmodule(L);
+  }
+  return 1;
+}
+
+LROT_BEGIN(node_lfs_meta, NULL, LROT_MASK_INDEX)
+  LROT_FUNCENTRY( __index, node_lfs_func)
+LROT_END(node_lfs_meta, NULL, LROT_MASK_INDEX)
+
+LROT_BEGIN(node_lfs, LROT_TABLEREF(node_lfs_meta), 0)
+LROT_END(node_lfs, LROT_TABLEREF(node_lfs_meta), 0)
+
 
 typedef enum pt_t { lfs_addr=0, lfs_size, spiffs_addr, spiffs_size, max_pt} pt_t;
 
@@ -826,8 +862,10 @@ LROT_BEGIN(node, NULL, 0)
   LROT_FUNCENTRY( heap, node_heap )
   LROT_FUNCENTRY( info, node_info )
   LROT_TABENTRY( task, node_task )
-  LROT_FUNCENTRY( flashreload, lua_lfsreload )
-  LROT_FUNCENTRY( flashindex, lua_lfsindex )
+  LROT_FUNCENTRY( flashindex, node_lfsindex )
+  LROT_FUNCENTRY( LFSindex, node_lfsindex )
+  LROT_FUNCENTRY( LFSreload, node_lfsreload )
+  LROT_TABENTRY( LFS, node_lfs )
   LROT_FUNCENTRY( setonerror, node_setonerror )
   LROT_FUNCENTRY( startupcommand, node_startupcommand )
   LROT_FUNCENTRY( restart, node_restart )
@@ -856,9 +894,7 @@ LROT_BEGIN(node, NULL, 0)
   LROT_FUNCENTRY( bootreason, node_bootreason )
   LROT_FUNCENTRY( restore, node_restore )
   LROT_FUNCENTRY( random, node_random )
-#if LUA_VERSION_NUM == 501 && defined(LUA_OPTIMIZE_DEBUG)
   LROT_FUNCENTRY( stripdebug, node_stripdebug )
-#endif
 #if LUA_VERSION_NUM == 501
   LROT_TABENTRY( egc, node_egc )
 #endif

--- a/app/modules/sjson.c
+++ b/app/modules/sjson.c
@@ -1,7 +1,6 @@
 #define LUA_LIB
 
 #include "lauxlib.h"
-#include "lstring.h"
 
 #ifndef LOCAL_LUA
 #include "module.h"

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include "llimits.h"
+#include <stdint.h>
 #include "gpio.h"
 #include "user_interface.h"
 #include "driver/gpio16.h"
@@ -215,7 +215,7 @@ static void ICACHE_RAM_ATTR platform_gpio_intr_dispatcher (void *dummy){
   uint32_t j=0;
   uint32_t gpio_status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
   uint32_t now = system_get_time();
-  UNUSED(dummy);
+  (void)(dummy);
 
 #ifdef GPIO_INTERRUPT_HOOK_ENABLE
   if (gpio_status & platform_gpio_hook->all_bits) {
@@ -986,13 +986,13 @@ uint32_t platform_rcr_read (uint8_t rec_id, void **rec) {
 }
 
 uint32_t platform_rcr_delete (uint8_t rec_id) {
-  void *rec = NULL;
-  platform_rcr_read (rec_id, &rec);
+  uint32_t *rec = NULL;
+  platform_rcr_read(rec_id, (void**)&rec);
   if (rec) {
-    uint32_t *pHdr = cast(uint32_t *,rec)-1;
+    uint32_t *pHdr = rec - 1;  /* the header is the word proceeding the rec */ 
     platform_rcr_t hdr = {.hdr = *pHdr};
     hdr.id = PLATFORM_RCR_DELETED;
-    platform_s_flash_write(&hdr, platform_flash_mapped2phys(cast(uint32_t, pHdr)), WORDSIZE);
+    platform_s_flash_write(&hdr, platform_flash_mapped2phys((uint32_t) pHdr), WORDSIZE);
     return 0;
   }
   return ~0;

--- a/app/websocket/websocketclient.c
+++ b/app/websocket/websocketclient.c
@@ -26,7 +26,6 @@
 #include "user_interface.h"
 #include "espconn.h"
 #include "mem.h"
-#include "limits.h"
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>

--- a/app/websocket/websocketclient.h
+++ b/app/websocket/websocketclient.h
@@ -29,8 +29,8 @@
 #include "user_interface.h"
 #include "espconn.h"
 #include "mem.h"
-#include "limits.h"
-#include "stdlib.h"
+#include <limits.h>
+#include <stdlib.h>
 
 #if defined(USES_SDK_BEFORE_V140)
 #define espconn_send espconn_sent

--- a/docs/lua53.md
+++ b/docs/lua53.md
@@ -1,0 +1,272 @@
+## Background and Objectives
+
+The NodeMCU firmware is currently based on the Lua 5.1.4 core with the `eLua` patch and other NodeMCU specific enhancements and optimisations ("**Lua51**").  This paper discusses the rebaselining of NodeMCU to the latest production Lua version 5.3.5 ("**Lua53**").  Our goals in this upgrade were:
+
+-  NodeMCU should offer a current Lua version, 5.3.5 that is as functionally complete as practical.
+
+-  Lua53 will adopt a minimum change strategy against the standard Lua source code base, that is changes to the VM and runtime system will only be made where there is a compelling reasons for any change, for example Lua53 preserves some valuable NodeMCU enhancements, for example the addition of Lua VM support for constant Lua program and data being executable directly from Flash ROM in order to free up RAM for application use to mitigate the RAM limitations of ESP-class IoT devices
+
+-  NodeMCU will provide a clear and stable migration path for both existing hardware libraries and ESP Lua applications being migrated from Lua51 to Lua53.
+
+-  The Lua53 implementation will provide a common code base for ESP8266 and ESP32 architectures.  (The current Lua51 implementation was historically been forked with variant code bases for the two architectures.)
+
+## Specific Design Decisions
+
+-  The NodeMCU C module API is built on the standard Lua C API that is common across the Lua51 and Lua53 build environments but again with limited changes needs to reflect our IoT changes.  Note that Lua 5.3 introduced some core functional and C API changes; however, the use the standard Lua 5.3 compatibility modes largely hides these changes, though modules may optionally make use of the `LUA_VERSION_NUM` define should version-specific code variants be needed.
+
+-  The historic NodeMCU C module API (following `eLua` precedent and) added some extensions that somewhat compromised the orthogonal design principles of the standard Lua API; these are that modules should only access the Lua runtime via the `lua_XXX` macros and and calls exported through the `lua.h` header (or the wrapped helper `luaL_XXXX` versions exported through the `lauxlib.h` header).  Such inconsistencies will be removed from the existing NodeMCU API and modules, so that all modules can be compiled and executed within either the Lua51 or the Lua53 environment.
+
+-  Lua publishes Reference Manuals (LRM) for the Language specification, core libraries and C APIs.  The Lua53 implementation will include a supplemental Reference Manual to document the NodeMCU extensions to the core libraries and C APIs.  As these API are unified across Lua51 and 53, this also provides a common reference that can also be used for developing both Lua51 and Lua53 modules.
+
+-  The two Lua code bases will be maintained within a common Git branch (in parallel NodeMCU sub-directories `app/lua` and `app/lua53`), with an optional make parameter `LUA=53` selecting a build with Lua based on `app/lua53`, thus generating a Lua 5.3 firmware image.  (At a later stage once Lua53 is proven and stable, we will swap the default to Lua53 and move the Lua51 tree into frozen support.)
+
+-  Many of the important features of the `eLua` changes to Lua51 used by NodeMCU have now been incorporated into core Lua53 and can continue to be used 'out of the box'.   Other NodeMCU **LFS**, **ROTable** and **LCD** functionality has been rewritten for NodeMCU, so the Lua53 code base will no longer uses the `eLua` patch.
+
+-  Lua53 will ultimately support three build targets that correspond to the ESP8266, ESP32 and native host targets using a _common Lua53 source directory_.  The ESP build targets generate a firmware image for the corresponding ESP chip class, and the host target generates a host based `luac.cross` executable.  This last can either be built standalone or as a sub-make of the ESP builds.
+
+-  The Lua53 host build `luac.cross` executable will continue to extend the standard functionality by adding support for LFS image compilation and include a Lua runtime execution environment that can be invoked with the `-e` option.  An optional make target also adds the [Lua Test Suite](https://www.lua.org/tests/) to this environment to enable use of this test suite.
+
+-  Lua 5.3 introduces the concept of **subtypes** which are used for Numbers and Functions, and Lua53 follows this model adding a ROTables subtype for Tables.
+
+   -  **Lua numbers** have separate **Integer** and **Floating point** subtypes.  There is therefore no advantage in having separate Integer and Floating point build variants.  Lua53 therefore ignores the `LUA_NUMBER_INTEGRAL` build option.  However it will provide option to use 32 or 64 bit numeric values with floating point numbers being stored as single or double precision respectively as well as the current hybrid where integers are 32-bit and `double` for floating point.  Hence 32-bit integer only applications will have similar memory use and runtime performance as existing Lua51 Integer builds.
+
+   -  **Lua tables** have separate **RWTable** and **ROTable** subtypes.  The Lua53 implementation of this subtyping will be backported to Lua51 where these are separate types, so that the table access API is the same for both Lua51 and Lua53.
+
+   -  **Lua Functions** have separate **Lua**, **C** and **lightweight C** subtypes, with this last being a special case where the C function has no upvals and so it doesn't need an associated `Closure` structure.  It is also essentially the same TValue type as our lightweight functions, but there is no need for and explicit API support for it.
+
+-  Lua 5.3 also introduces another small number of other but significant Lua language and  core library / API changes.  Our Lua53 implementation does not limit these, though we have enabled the appropriate compatibility modes to limit the impact at a Lua developer level.  These are discussed in further detail in the following compatibility sections.
+
+-  Many standard OS services aren't available on a embedded IoT device, so Lua53 will follow the Lua51 precedent by omitting the `os` library for target builds as the relevant functionally is largely replaced by the `node` library.
+
+-  Flash based code execution can incur runtime performance impacts if not mitigated. Some small code changes are required as the current GCC toolchain for the Xtensa processors doesn't handle all of these mitigations during code generation.  For example, as the hardware only supports aligned word access to flash memory ,'hot' byte constant accesses have been encapsulated to remove non-aligned exceptions at a cost of one extra Xtensa instruction per access; the remaining byte accesses to flash use a software exception handler.  
+
+-  NodeMCU employs a single threaded event loop model (somewhat akin to Node.js), and this is supported by some task extensions to the C API that facilitate use of a callback mechanism.
+
+## Detailed Implementation Notes
+
+We follow two broad principles (1) everything other than the Lua source directory is common, and (2) only change the Lua core when there is a compelling reason.  The following sub-sections describe these issues / changes in detail.
+
+### Build variants and includes
+
+Lua53 supports three build targets which correspond to:
+
+-  The ESP8266 (and derivative ESP8385) architectures use the Espressif non-OS SDK and its GCC Xtensa tool-chain.  The macros `LUA_USE_ESP8266` and `LUA_USE_ESP` are defined for this target.
+
+-  The ESP32 architecture using the Espressif IDF and its GCC Xtensa toolchain.  The macros `LUA_USE_ESP32` and `LUA_USE_ESP` are defined for this target.
+
+-  A host architecture using the standard host C toolchain.  The macro `LUA_USE_HOST` is defined for this target.  We currently support any POSIX environment that supports the GCC toolchain and Windows builds using native MSVC, WSL, Cygwin and MinGW.
+
+`LUA_USE_HOST` and `LUA_USE_ESP` are in effect mutually exclusive: `LUA_USE_ESP` is defined for a target firmware build, and `LUA_USE_HOST` for a build of the host-based `luac.cross` executable for the host environment.  Note that `LUA_USE_HOST` also defines `LUA_CROSS_COMPILER` as used in Lua51.
+
+Our Lua51 source has been recently migrated to use `newlib` conformant headers and C runtime calls.  An example of this is that the standard SDK headers supplied by Espressif include `"c_string.h"` and use `c_strcmp()` as the string comparison function.  NodeMCU source files use `<string.h>` and `strcmp()`.
+
+_**Caution**: The NodeMCU source is _compliant_ rather than fully _conformant_ with the standard headers such as `<string.h>`; that is the current subset of these APIs used by the code will successfully compile, link and execute as an image, but code additions which attempt to use extra functions defined in the APIs might not; this at least minimises the need to change standard source code to compile and run on the ESP8266._
+
+As with Lua51, Lua53 heavily customises the `linit.c`, `lua.c` and `luac.c` files because of the demands of an embedded runtime environment.  Given the amount of change, these are stripped of the functionally dead code.
+
+### TString types and implementation
+
+The Lua 5.3 makes a significant modification to the treatment of strings, dividing them into two separate subtypes based on the string length (at `LUAI_MAXSHORTLEN`, 40 in the current implementation).  This decision reflects two empirical observations based on a broad range of practical Lua applications: the long the string, the less likely the application is to recreate it independently; and the cost of ensuring uniqueness increases linearly with the length of the string.  Hence Lua53 now treats the string type differently:
+
+-  **Short Strings** are stored uniquely using the `strt` and `ROstrt` string table as discussed below.  Two short TStrings are identical if and only if their addresses are the same.
+
+-  **Long Strings** are created and copied by reference, but are not guaranteed to be stored uniquely.
+
+Since short strings are stored uniquely, identity comparison is based comparing their TString address.  For long TStrings identify comparison is a little more complex:
+
+-  They are identical if their addresses are the same
+-  They are different if their lengths are different.
+-  Failing these short circuits, a full `memcmp()` must be carried out.
+
+Lua GC of both types is essentially the same, excepting that collection of long strings does not need to update the `strt`.
+
+Note that for real applications, identical long strings are rarely generated by other than by copy-reference and hence in general the runtime savings benefits exceed the small chance of storage duplication.  Also note that this and other sub-typing is hidden at the Lua C API level and is handled privately inside the Lua VM implementation.
+
+Whilst running Lua applications make heavy use of TStrings, the Lua VM itself makes little use of TStrings and typically pushes any string literals as CStrings.  The Lua53 VM introduced a key cache to avoid the runtime cost of hashing string and doing the `strt` lookup for this type of CString constant.  The NodeMCU implementation shares this key cache is shared with ROTable field resolution.
+
+Short strings in the standard Lua VM are bound at runtime into the the RAM-based `strt` string table.  Our LFS implementation adds a second LFS-based readonly `ROstrt` string table that is  is created during LFS image load and then referenced on subsequent CPU restarts. The Lua VM and C API resolves each new short string   first against the `strt`, then the `ROstrt` string table, before adding any unresolved strings into the `strt`.  Hence short strings are interned across these two `strt` and `ROstrt` string tables.  Thus any runtime reference to strings already in the LFS `ROstrt` do not create additional entries in RAM.  So applications are free include dummy resource functions (such as `dummy_strings.lua` in `lua_examples/lfs`) to preload additional strings into `ROstrt` and thus avoid needing RAM for these.  Such functions don't need to called; simply inclusion in the LFS build is sufficient.
+
+An LFS section below discusses further implementation details.
+
+### ROTables
+
+The ROTables concept was introduced in `eLua`, with the ROTable format designed to be compiled by being declarable with C source and so statically included in the firmware at built-time, rather taking up RAM.  This essential functionality has been preserved across both Lua51 and Lua53.  At an API level ROTables are handled as a table subtype within the Lua VM except that:
+-  ROTables are declared statically in C code.
+-  Only a subset of key and value types is supported for ROTables.
+-  Attempting to write to a ROTable field will raise an error.
+-  The C API provides a method to push a ROTable reference direct to the Lua stack, but other than this, the Lua API to read ROTables and Tables is the same.
+
+We have now completely replaced the `eLua` implementation for Lua53, with this implementation backported to Lua51.  Tables are now declared using `LROT` macros with the `LROT_END()` macro also generating a `ROTable` structure, which is a variant of the standard `Table` header and linking to the `luaR_entry` vector declared using the various `LROT_XXXXENTRY()` macros.  This has new implementation has some major advantages:
+
+-  RWTables and ROTables are separate subtypes of Table, and so only minor code changes are needed within `ltable.c` to implement this, with the implementation now effectively hidden from the rest of the runtime and any library modules; this has enabled us to remove most of the ROTable code patches added by `eLua`.
+
+-  The `luaR_entry` vector is a linear list, so (unlike a standard RAM Table) any ROTable has no associate hash table for fast key lookup.  However we have introduced a unified ROTable key cache to provide direct access into ROTable entries with a typical hit rate over 99% (key cache misses still require a linear key scan), and so average ROTable access is only slightly slower than RAM Table access, unlike the `eLua` implementation which was extremely slow. 
+
+-  The `ROTable` structure variants are not GC collectable and so the `next` field is set to the marker constant `((GCObject *) 1)`, and (since ROTables can only refer to other RO objects) this allows the Lua GC to short-circuit GC sweeps across such RO nodes.  The `ROTable` structure variant also drops unused fields to save space, and again this is handled internally within `ltable.c`.
+
+-  As all tables have a header record that includes a valid `flags` field, the `fasttm()` optimisations now work for both `ROTables` and `Tables`.
+
+The same Lua51 ROTables functionality and limitations also apply to Lua53 in order to minimise migration impact for C module libraries:
+
+-  ROTables can only have string keys and a limited set of Lua value types (Numeric, Light CFunc, Light UserData, ROTable, string and Nil). In Lua 5.3 `Integer` and `Float` are now separate numeric subtypes, so `LROT_INTENTRY()` takes an integer value. The new `LROT_FLOATENTRY()` is used for a non-integer values. This isn't a migration issue as none of the modules use floating point constants in ROTables declared in our modules; there is the only one currently used is in `math.PI`.
+
+   -  For 5.1 builds, `LROT_FLOATENTRY()` is a synonym of `LROT_NUMENTRY()`.
+   -  For 5.3 builds, `LROT_NUMENTRY()` is a synonym of  `LROT_INTENTRY()`.
+
+-  Some ordering limitations apply: `luaR_entry` vectors can be unordered _except for any metafields_:  Any entry with a key name starting in "_" _must_ must be ordered and placed at the start of the vector.
+
+-  The `LROT_BEGIN()` and  `LROT_END()` take the same three parameters. (These are ignored in the case of the `LROT_BEGIN()` macro, but by convention these are the same to facilitate the begin / end pairing).
+    -  The first field is the table name.
+    -  The second field is used to reference the ROTable's metatable (or `NULL` if it doesn't have one).
+    -  The third field is 0 unless the table is a metatable, in which case it is a bit mask used to define the `fasttm()` `flags` field.  This must match any metafield entries for metafield lookup to work correctly.
+
+### Proto Structures
+
+Standard Lua 5.3 contains a new peep hole optimisation relating to closures: the Proto structure now contains one RW field pointing to the last closure created, and the GC adopts a lazy approach to recovering these closures. When a new closure is created, if the old one exists _and the upvals are the same_ then it is reused instead of creating a new one. This allows peephole optimisation of a usecase where a function closure is embedded in a do loop, so the higher cost closure creation is done once rather than `n` times.
+
+This reduces runtime at the cost of RAM overhead.  However for RAM limited IoTs this change introduced two major issues: first, LFS relies on Protos being read-only and this RW `cache` field breaks this assumption; second closures can now exist past their lifetime, and this delays their GC.  Memory constrained NodeMCU applications rely on the fact that dead closed upvals can be GCed once the closure is complete.  This optimisation changes this behaviour.  Not good.
+
+Lua53 **_removes_** this optimisation for all prototypes.
+
+### Locale support
+
+Standard Lua 5.3 introduces localisation support.  NodeMCU Lua53 disables this because IoT implementation doesn't have the appropriate OS support.
+
+### Memory Optimisations
+
+Various Lua structures have `double` fields which are align(8) by default.  There is no reason or performance benefit for doing align(8) on ESPs so all Lua code is compiled with the `-fpack-struct=4` option.
+
+Lua53 also reimplements the Lua51 LCD (Lua Compact Debug) patch. This replaces the `sizecode` `ìnt` vector giving line info with a packed byte array that is typically 15-30× smaller.  See the [LCD whitepaper]( https://nodemcu.readthedocs.io/en/master/lcd/) for more information on this algo.
+
+### Unaligned exception avoidance
+
+By default the GCC compiler emits a `l8ui` instruction to access byte fields on the ESP8266 and ESP32 Xtensa processors. This instruction will generate an unaligned fetch exception when this byte field is in Flash memory (as will accessing short fields).  These exceptions are handled  by emulating the instruction in software using an unaligned access handler; this allows execution to continue albeit with the runtime cost of handling the exception in software. We wish to avoid the performance hit of executing this handler for such exceptions.
+
+`lobject.h` defines a new `GET_BYTE_FN(name,t,wo,bo)` macro. In the case of host targets this macro generates the normal field access, but in the case of Xtensa targets these macros define an `static inline` access function for each field.  Use of these functions at the default `-O2` optimisation level cause the code generator to emit a pair of `l32i.n` + `extui` instructions replacing the single `l8ui` instruction.  This has the cost of an extra instruction execution for accessing RAM data, but also removes the 200+ clock overhead of the software exception handler in the case of flash memory accesses.
+
+There are 9 byte fields in the `GCObject`,`TString`, `Proto`, `ROTable` structures that can either be statically compiled as `const struct` into libraries or generated by the lua cros compiler into the LFS region, and the `GET_BYTE_FN` macro has been used to create access macros for these fields, and read references of the form `(o)->tt` (for example) have been recoded using the access macro form `gettt(o)`.  There are 44 such changed access references in the source which together represent perhaps 99% of potential sources of this software exception within the Lua VM. 
+
+The access macro hasn't been used where access is guarded by a conditional that implies the field in a RAM structure and therefore the `l8ui` instruction is executed correctly in hardware.  Another exclusion is in modules such as `lcode.c` which are only used in compilation, and where the addition runtime penalty is acceptable.
+
+A wider review of `const char` initialisers and `-S` asm output from the compiler confirms that there are few other cases of character loads of constant data, largely because inline character constants such as '@' are loaded into a register as an immediate parameter to a `movi.n` instruction.  Ditto use of short fields.
+
+### Modulus and division operation avoidance
+
+The Lua runtime uses the modulus (`%`) and divide (`/`) operators in a number of computations. This isn't an issue for most uses where the divisor is an integer power of 2 since the gcc optimiser substitutes a fast machine code equivalent which typically executes 1-4 inline Xtensa instructions (ditto for many constant multiplies).  The compiler will also fold any used in constant expressions to avoid runtime evaluation. However the ESP Xtensa CPU doesn't implement modulus and divide operations in hardware, so these generate a call to a subroutine such as `_udivsi3()` which typically involves 500 instructions or so to evaluate.  A couple of frequent uses have been replaced.  (I have ensured that such uses are space delimited, so seaching for " % " will locate these. `grep -P " (%|/) (?!(2|4|8|16))" app/lua53/*.[hc]` will list them off.)
+
+### Key cache
+
+Standard Lua 5.3 introduced a string key cache for constant Cstring to TString lookup.  In parallel NodeMCU Lua51 also introduced a lookaside cache for ROTable fields access.  In practice this provides single probe access for over 99% of key hit accesses to ROTable entries.
+
+In Lua53 these two caching functions (for CString and ROTable key lookup) have been unified into a common Key cache to provide both caching functions with the runtime overhead of a single cache table in RAM.  Folding these two lookups into a single Key cache isn't ideal, but given our limited RAM this allows the cache use to be rebalanced at runtime reflection the relative use of CString and ROTable key lookups.
+
+### Flash image generation and loading
+
+The current Lua51 `app/lua` implementation has two variants for dumping and loading Lua bytecode: (1) `ldump.c` + `lundump.c`; (2) `lflashimg.c` + `lflash.c`. In Lua53, these have been unified into a single load / unload mechanism.  However, this mechanism must facilitate sequential loading into flash storage, which is is straight forward _if_ with some small changes to the standard internal ordering of the LC file format.  The reason for this is that any `Proto` can embed other Proto definitions internally, creating a Proto hierarchy.  The standard Lua dump algorithm dumps some Proto header components, then recurses into any sub-Protos before completing the wrapping Proto dump.  As a result each Proto's resources get interleaved with those of its subordinate Proto hierarchy.  This means that resources get to written to RAM non-serially, which is bad news for writing serially to the LFS region.  
+
+The NodeMCU Lua53 dump reorders the proto hierarchy tree walk, so that resources of the lowest protos in the hierarchy are loaded first:
+```
+dump_proto(p)
+  foreach subp in p
+    dump_proto(subp)
+  dump proto content
+end
+```
+This results in any proto references now being backwards references to protos that are already loaded, and this in turn enables the Proto resources to be allocated as a sequential contiguous allocation units, so the same code can be used for loading LCs into RAM and into LFS.
+
+The standard Lua 5.3 dump format embeds string constants in each proto as a `len`+`byte string` definition. , NodeMCU needs to separate the collection of strings into an `ROstrt` for LFS loading, and this requires an extra processing pass either on dump or load.  By doing a preliminary Proto scan to collect tracking the strings used then dumping these as a prologue makes the load process on the ESP a single pass and avoids any need for string resolution tables in the ESP's RAM. The extra memory resources needed for this two-pass dump aren't a material issue in a PC environment.  
+
+Changes to `lundump.c` facilitate the addition of LFS mode. Writing to flash uses a record oriented write-once API. Once the flash cache has been flushed when updating the LFS region, this data can be directly accesses using the memory-mapped RO flash window, the resources are written directly to Flash without any allocation in RAM.
+
+Both the `dump.c` and `lundump.c` are compiled into both the ESP firmware and the host-based luac cross compiler.  Both the host and ESP targets use the same integer and float formats (e.g. 32 bit, 32-bit IEEE) which simplifies loading and unloading.  However one complication is that the host luac.cross application might be compiled on either a 32 or 64 bit environment and must therefore accommodate either 4 or 8 byte address constants.  This is not an issue with the compiled Lua format since this uses the grammatical structure of the file format to derive resource relationships, rather than offsets or pointers.
+
+We also have a requirement to generate binary compatible absolute LFS images for linking into firmware builds.  The host mode is tweaked to achieve this.  In this case the write buffer function returns the correct absolute ESP address which are 32-bit; this doesn't cause any execution issue in luac since these
+addressed are never used for access within `luac.cross`.  On 64-bit execution environments, it also repacks the Proto and other record formats on copy by discarding the top 32-bits of any address reference.
+
+#### Handling embedded integers in the dump format
+
+A typical dump contains a lot of integer fields, not only for Integer constants, but also for repeat count and lengths.  Most of these integers are small, so rather than using a fixed 4-byte field in the file stream all integers are unsigned and represented by a big-endian multi-byte encoding, 7 bits per byte, with the high-bit used as a continuation flag.  This means that integers 0..127 encode in 1 byte, 128..32,767 in 2 etc.  This multibyte scheme has minimal overhead but reduces the size of typical `.lc` and `.img` by 10% with minimal extra processing and less than the cost of reading that extra 10% of bytes from the file system.
+
+A separate dump type is used for negative integer constants where the constant `-x` is stored as `-(x+1)`.  Note that endianness isn't an issue since the stream is processed byte-wise, but using big-endian simpifies the load algorithm.
+
+#### Handling LFS-based strings
+
+The dump function for a individual protos hierachy for loading as an `.lc` file follows the standard convention of embedding strings inline as a `\<len><\byte sequence>`.  Any LFS image contains a dump of all of the strings used in the LFS image Protos as an "all-strings" prologue; the Protos are then dumped into the image with string references using an index into the all-strings header.  This approach enables a fast one-pass algorithm for loading the LFS image; it is also a compact encoding strategy as string references typically use 1 or 2 byte integer offset in the image file.
+
+One complication here is that in the standard Lua runtime start-up adds a set of special fixed strings to the `strt` that are also tagged to prevent GC. This could cause problems with the LFS image if any of these constants is used in the code.  To remove this conflict the LFS image loader _always_ automatically includes these fixed strings in the `ROstrt`. (This also moves an extra ~2Kb string constants from RAM to Flash as a side-effect.)  These fixed strings are omitted from the "all-strings prologue", even though the code itself can still use them.  The `llex.c` and `ltm.c` initialisers loop over internal `char *` lists to register these fixed strings. NodeMCU adds a couple of access methods to `llex.c` and `ltm.c` to enable the dump and load functions to process these lists and resolve strings against them.
+
+#### Handling LFS top level functions
+
+Lua functions in standard Lua 5.1 are represented by two variant Closure headers (for C and Lua functions).  In the case of Lua functions with upvals, the internal Protos can validly be bound to multiple function instances. `eLua` and Lua 5.3 introduced the concept of lightweight C functions as a separate function subtype that doesn't require a Closure record.  Note that a function variable in a Lua exists as a TValue referencing either the C funtion address or a Closure record; this Closure is not the same as the CallInfo records which are chained to track the current call chain and stack usage.
+
+Whilst lightweight C functions can be  declared statically as TValues in ROTables, There isn't a corresponding mechanism for declaring a ROTable containing LFS functions. This is because a Lua function TValue can only be created at runtime by executing a `CLOSURE` opcode within the Lua VM. Our Lua51 implementation avoids this issue by generating a top level Lua dispatch function that does the equivalent of emitting `if name == "moduleN" then return moduleN end` for each entry, and this takes 4 Lua opcodes per module entry. This lookup has an O(N) cost which becomes non-trivial as N grows large, and so Lua51 has a somewhat arbitrary limit of 50 for the maximum number modules in a LFS image.
+
+In the Lua53 LFS implementation the undump loader appends a `ROTable` to the LFS region which contains a set of entries `"module name"= Proto_address`.  These table values aren't directly acessible via Lua but the NodeMCU C function that does LFS lookup can still retrieve the required Proto address, execute the `CLOSURE` and return the corresponding Tvalue.  Since this approach uses the standard table access API, which is a lot more efficient that the 4×N opcode `if` chain implementation.
+
+### Garbage collection
+
+Lua51 includes the eLua emergency GC, plus the various EGC tuning parameters that seem to be rarely used. The default setting (which most users use) is `node.egc.ALWAYS` which triggers a full GC before every memory allocation so the VM spends maybe 90% of its time doing full GC sweeps.
+
+Standard Lua 5.3 has adopted the eLua EGC but without the EGC tuning parameters. (I have raised a separate GitHub issue to discuss this.) We extend the EGC with the functional equivalent of the `ON_MEM_LIMIT` setting with a negative parameter, that is only trigger the EGC with less than a preset free heap left. The runtime spends far less time in the GC and code will run perhaps 5× faster.  Since we will only support one ECG mode, we don't need to track this setting in G(L).
+
+### Panic Handling
+
+Standard Lua includes a throw / catch framework for handling errors.  (This has been slightly modified to enable yielding to work across C API calls, but this can be modification can ignored for the discussion of Panic handling.)  All calls to Lua execution are handled by `ldo.c` through one of two mechanisms:
+
+-  All protected calls are handled via `luaD_rawrunprotected()` which links its C stack frame into the  `struct lua_longjmp` chain updating the head pointer at `L->errorJmp`.  Any `luaD_throw()` will `longjmp` up to this entry in the C stack, hence as long as there is at least one protected call in the call chain, the C call stack can be properly unrolled to the correct frame.
+
+-  If no protected calls are on the Lua call stack, then `L->errorJmp` will be null and there is no established C stack level to unroll to.  In this case the `luaD_throw()` will directly call the `at_panic()` handler.  Since there is no valid stack frame to unroll to and execution cannot safely continue, so the only safe next step is to abort, which in our case restarts the processor.
+
+Any Lua calls directly initiated through `lua.c` interpreter loop or through `luac.cross` are protected.  However NodeMCU applications can also establish C callbacks which are called directly by the SDK / event dispatcher.  The current practice is that these invoke their associated Lua CB using an unprotected call and hence the only safe option is to restart the processor on error.  The Lua53 changes have introduced a new `luaL_pcallx()` call variant as a NodeMCU extension; This is new call is designed to be used within library CBs that execute Lua CB functions, and is argument compatible with `lua_call()`, except that in the case of caught errors it will also return a negative call status.   It establishes a default error handler which is invoked at the erroring stack level to provide a stack trace.  
+
+This handler posts a task to a panic error handler (with the error string as an upval) before returning control to the invoking routine.  If the Lua registry entry `onerror` exists and is set to a function, then the handler calls this with the error string as an argument otherwise it calls standard `print` function.  This function can return `false` in which case the handler exits, otherwise it restarts the processor.  The application can use `node.setonerror()` to override the default "always restart" action if wanted (for example to write an error to a logfile or to a network syslog before restarting).  Note that `print` returns `nil` and this has the effect of printing the full error traceback before restarting the processor.
+
+Currently all (bar 1) of the cases of such Lua callbacks within the NodeMCU C modules use a simple `lua_call()`, with the result that any runtime error executes a panic on error and reboots the processor. By replacing these calls with the `luaL_pcallx()`, control is always returned to the C routine, and a later post task can report the error.  Note that substituting library uses of `lua_call()` by `luaL_pcallx()` does changes processing paths in the case of thrown errors.  If the library CB function immediately returns control to the SDK/event scheduler after the call, then this is the correct behaviour.  However, in a few cases, the routine performs post-call clean-up and this adapt the logic depending on the return status.
+
+### The `luac.cross` execution environment
+
+As with Lua51, the Lua53 host-build `luac.cross` executable will extend the standard functionality by adding support for LFS image compilation and also include a Lua runtime execution environment that can be invoked with the `-e` option.  This environment was added primarily to facilitate in host testing (albeit with some limitations) of the NodeMCU.
+
+The make target `TEST=1` also adds the [Lua Test Suite](https://www.lua.org/tests/) to the `luac.cross -e` execution environment to enable this test support.  Due to NodeMCU extensions some changes were required to the Test suite so `app/lua53/host/tests` includes the version regressed against our current build.  Note that I planning to add some variant capability to the ESP target firmware build in the future.
+
+Enabling the test suite also disables some compiler optimisations and hence increases the size of compiled Lua files, so this test option is _not_ enabled by default in the `luac.cross` make.
+
+The test configuration has some variations from the standard suite:
+-  NodeMCU lua and luac.cross do not support dynamic loading and the related dynamic loading tests are omitted.
+-  The tests adopt the Lua compatibility modes implemented in our builds.
+-  The standard Lua VM supports the initiation of multiple VM environments and this feature is used in some tests.  Our firmware supports multiple Lua threads but only one `lua_newstate()` instance.  So the host `luac.cross` make with the `TEST=1` option set also supports multiple VM environments.
+
+This execution environment also emulates LFS loading and execution using the `-F` option to load an LFS image before running the `-e` script.  On POSIX environments this allocates the LFS region using kernel extension, a page-aligned allocator and also uses the kernel API to turning off write access to this region except during the simulated write to flash operations.  In this way unintended writes to the LFS region throw a H/W exception in a manner parallel to the ESP environment.
+
+### API Compatibility for NodeMCU modules
+
+The Lua public API has largely been preserved across both Lua versions.  Having done a difference analysis of the two API and in particular the `lua.h` and `lauxlib.h` headers which contain the public API as documented in the LRM 5.1 and 5.3, these differences can be grouped into the following categories:
+
+-  NodeMCU features that we will be adding to Lua53 as part of this migration.
+
+-  Differences (additions / removals / API changes) that we are not using in our modules and which can therefore be effectively ignored for the purposes of migration.
+
+-  Source differences which can be encapsulated through common macros will be be removed by updating module code to use this common macro set.  In a very small number of cases module functionality will be recoded to employ this common API base.
+
+Both the RM and PiL make quite clear that the public API for C modules is as documented in `lua.h` and all its definitions start with `lua_`. This API strives for economy and orthogonality. The supplementary functions provided by the auxiliary library (auxlib)  access Lua services and functions through the `lua.h` interface and without other reference to the internals of Lua; this is exposed through `lauxlib.h` and all its definitions start with `luaL_`;
+
+There are significant changes to internal APIs as exposed in the other "private" headers within the Lua source directory, and so any code using these APIs may fail to work across the two versions.
+
+One thing that this analysis has underline is that we've been lax about how we allow our modules to be implemented.  All existing modules have been modified to use only the public API.  If any new or changed module required any of the 'internal' Lua headers to compile, then it is implemented incorrectly.
+
+### Lua Language and Libary Compatibility for NodeMCU Lua modules
+
+For the immediate future we will be supporting both builds based on both language variants, so Lua module writers either:
+ -  Avoid using Lua 5.3 language features and implement their module in the common subset (this is currently our preferred approach);
+ -  Or explicitly state any language constraints and include a test for `_VERSION=='Lua.5.3'` (or 5.1) in the module startup and explicitly error if incompatible.
+
+### Other Implementation Notes
+
+-  **Use of Linker Magic**. Lua51 introduced a set of linker-aware macros to allow NodeMCU C library modules to be marshalled by the GNU linker for firmware builds; Lua53 target builds maintain these to ensuring cross-version compatibility. However, the lua53 `luac.cross` build does all library marshalling in `linit.c` and this removes the need to try to emulate this strategy on the diverse host toolchains that we support for compiling `luac.cross`.
+
+-  **Host / ESP interoperability**.  Our strategy is to build the firmware for the ESP target and `luac.cross` in the same make process.  This requires the host to use a little endian ANSI floating point host architecture such as x68, AMD64 or ARM, so that the LC binary formats are compatible.  This ain't a material constraint in practice.
+
+-  **Emergency GC.** The Lua VM takes a more aggressive stance than the standard Lua version on triggering a GC sweep on heap exhaustion.  This is because we run in a small RAM size environment. This means that any resource allocation within the Lua API can trigger a GC sweep which can call __GC metamethods which in turn can require to stack to be resized.
+
+-  **Enforcing `LUA_CORE`**.  Some of the Lua header files (e.g. `lua.h` and `lauxlib.h`) provide a public C API for the Lua runtime.  These provide a consistent cross-version API.  The remaining headers (e.g. `lstring.h`) are intended to be internal to the runtime implementation and these have significant differences between Lua 5.1 and 5.3; these should _not_ be include in C library modules.  Both Lua51 and Lua53 have a concept of Lua core files, and these set the `LUA_CORE` define.  In order to enforce limited access to the 'private' internal APIs, #ifdef LUA_CORE` guards have been added to all such Lua headers effectively hiding them from application library access.
+

--- a/docs/modules/node.md
+++ b/docs/modules/node.md
@@ -184,8 +184,8 @@ Returns the function reference for a function in the [LFS (Lua Flash Store)](../
 
 #### Returns
 -  In the case where the LFS in not loaded, `node.flashindex` evaluates to `nil`, followed by the flash mapped base addresss of the LFS, its flash offset, and the size of the LFS.
--  If the LFS is loaded and the function is called with the name of a valid module in the LFS, then the function is returned in the same way the `load()` and the other Lua load functions do.
--  Otherwise an extended info list is returned: the Unix time of the LFS build, the flash and mapped base addresses of the LFS and its current length, and an array of the valid module names in the LFS.
+-  If the LFS is loaded and the `modulename` is a string that is the name of a valid module in the LFS, then the function is returned in the same way the `load()` and the other Lua load functions do; if there isn't a matching module then `nil` is returned.
+-  If the parameter is omitted or `nil`then an extended info list is returned: the Unix time of the LFS build, the flash and mapped base addresses of the LFS and its current length, and an array of the valid module names in the LFS.
 
 #### Example
 

--- a/docs/nodemcu-lrm.md
+++ b/docs/nodemcu-lrm.md
@@ -1,0 +1,331 @@
+# NodeMCU Lua Reference
+
+## Introduction
+
+NodeMCU firmware is an IoT project ("the Project") which implements a Lua-based runtime for SoC modules based on the Espressif ESP8266 and ESP32 architectures.  This reference specifically addresses how the NodeMCU Lua implementation relates to standard Lua as described in the two versions of the Lua language that we currently support:
+
+-  The [Lua 5.1 Reference Manual]( https://www.lua.org/manual/5.1/) and
+-  The [Lua 5.3 Reference Manual]( https://www.lua.org/manual/5.3/) (**LRM**)
+
+Developers using the NodeMCU environment should familiarise themselves with the 5.3 LRM.  The Project provides a wide range of standard library modules written in both C and Lua to support many ESP hardware modules and chips, and these are documented in separation sections in our [online documentation](https://nodemcu.readthedocs.io/).
+
+This reference supplements LRM content and module documentation by focusing on the differences between NodeMCU Lua and standard Lua 5.3 in use.
+
+One goal in introducing Lua 5.3 support was to ensure the continuity of our existing C modules by ensuring that they can be successfully compiled and executed into both the Lua 5.1 and 5.3 environments.  This goal was achieved by combination of:
+-  enabling relevant compatibility options for standard Lua libraries
+-  regressing some Lua 5.3 API enhancements back into our Lua 5.1 implementation, and 
+-  making some small changes to the module source to ensure that incompatible API use is avoided.
+
+Further details are given in the [Lua compatibility](#lua-compatibility) section below.  Notwithstanding this, the Project has now deprecated Lua 5.1 and will soon be moving this version into frozen support.
+
+As well as providing the ability to building runtime firmware environments for ESP chipsets, the Project also offers a `luac.cross` cross compiler that can be built for common platforms such as Windows 10 and Linux, and this enables developers to compile source modules into a binary file format for download to ESP targets and loading from those targets.
+ 
+## Basic Concepts
+
+The NodeNCU runtime offers a full implementation of the [LRM §2](https://www.lua.org/manual/5.3/manual.html#2) core concepts, with the following adjustments:
+
+### Values and Types
+
+-  The firmware is compiled to use 32-bit integers and single-precision (32-bit) floats.  Address pointers are also 32-bit, and this allows all Lua variables to be encoded in RAM as an 8-byte "`TValue`" (compared to the 12-byte `Tvalue` used in Lua 5.1
+-  C modules can statically declare read-only tables known as a "`ROTable`".  There are some limitations to the types for ROTable keys and value, in order to ensure that these are consistent with static declaration.  ROTables are stored in code space (in flash memory on the ESPs), and hence do not take up RAM resources.  However these are still represented by the Lua type _table_ and a Lua application can treat them during execution the same as any other read-only table.  Any attempt to write to a `ROTable` or to set its metatable will throw an error.
+-  NodeMCU also introduces a concept known as **Lua Flash Store (LFS)**.  This enables Lua code (and any string constants used in this code) to be compiled and stored in code space, and hence without using RAM resources.  Such LFS functions are still represented by the type _function_ and can be executed just like any other Lua function.
+
+### Environments and the Global Environment
+
+These are implemented as per the LRM.  Note that the Lua 5.1 and Lua 5.3 language implementations are different and can introduce breaking incompatibilities when moving between versions, but this is a Lua issue rather than a NodeMCU one.
+
+### Garbage Collection
+
+-  All LFS functions, any string constants used in these functions, and any ROTables are stored in static code space.  These are ignored by the Lua Garbage collector (LGC).  The LGC only scans RAM-based resources and recovers unused ones.  The NodeMCU LGC has slightly modified configuration settings that increase its aggressiveness as heap usage approaches RAM capacity.
+
+### Coroutines
+
+-  The firmware includes a full coroutine implementation, but note that there are some slight differences between the standard Lua 5.1 and Lua 5.3 implementations.
+
+## Lua Language
+
+The NodeNCU runtime offers a full implementation of the Lua language as defined in [LRM §3](https://www.lua.org/manual/5.3/manual.html#3) and its subsections.
+
+## The Application Program Interface
+
+[LRM §4](https://www.lua.org/manual/5.3/manual.html#4) describes the C API for Lua.  This is used by NodeMCU modules written in the C source language to interface to the the Lua runtime.  The header file `lua.h` is used to define all API functions, together with their related types and constants.  This section 4 forms the primary reference, though the NodeMCU makes minor changes as detailed below to support LFS and ROTable resources.
+
+### Error Handling in C
+
+[LRM §4.6](https://www.lua.org/manual/5.3/manual.html#4.6) describes how errors are handled within the runtime. 
+
+The normal practice within the runtime and C modules is to throw any detected errors -- that is to unroll the call stack until the error is acquired by a routine that has declared an error handler.  Such an environment can be established by  [lua_pcall](https://www.lua.org/manual/5.3/manual.html#lua_pcall) and related API functions within C and by the Lua function [pcall](https://www.lua.org/manual/5.3/manual.html#pdf-pcall); this is known as a _protected environment_.  Errors which occur outside any protected environment are not caught by the Lua application and by default trigger a "panic". By default NodeMCU captures the error traceback and posts a new SDK task to print the error before restarting the processor.  However a `node` library call is available to override this default action.  For example developers might wish to print the error without restarting the processor) so that the circumstances which triggered the error can be investigated.
+
+The NodeMCU runtime implements a non-blocking threaded model that is similar to that of `node.js`, and hence most Lua execution is initiated from C event-triggered callback (CB) routines.  NodeMCU allow full error diagnostics to be recovered from CB unprotected errors by including an additional auxiliary library function that prints a full traceback before triggering processor restart.
+
+### Additional API Functions and Types
+
+These are available for developers coding new library modules in C.  Note that if you compare the standard and NodeMCU versions of `lua.h` you will find a small number of entries not listed below.  This is because the Lua 5.1 and Lua 5.3 variants are incompatible owing to architectural differences.  However, `laubxlib.h` includes equivalent wrapper version-compatible functions that may be used safely for both versions.
+
+#### ROTable and ROTable_entry
+
+Extra structure types used in `LROT` macros to declare static RO tables.  See detailed section below.
+
+#### lua_createrotable
+
+` void (lua_createrotable) (lua_State *L, ROTable *t, const ROTable_entry *e, ROTable *mt);`         [-0, +1, -]
+
+Create a RAM based `ROTable` pointing to the `ROTable_entry` vector `e`, and metatable `mt`.
+
+#### lua_debugbreak and ASSERT
+
+`  void (lua_debugbreak)(void);`
+
+`lua_debugbreak()` and `ASSERT(condtion)` are available for for development debugging.  If `DEVELOPMENT_USE_GDB` is defined then these will trigger a debugger break and evaluate a conditional assert prologue on the same.  If not, then these are effectively ignored and generate no executable code.
+
+#### lua_dump
+
+` int lua_dump (lua_State *L, lua_Writer writer, void *data, int strip);`         [-0, +0, –]
+
+Dumps function at the top of the stack function as a binary chunk as per LRM.  However the last argument is now an integer is in the range -1..2, rather a boolean as per standard Lua:
+- `strip`
+    - -1, use the current default strip level (which can be set by [`lua_striptdebug`](#lua_striptdebug))
+    - 0, keep all debug info
+    - 1, discard Local and Upvalue debug info; keep line number info
+    - 2, discard Local, Upvalue and line number debug info
+
+The internal NodeMCU `Proto` encoding of debug line number information is typically 15× more compact than in standard Lua; the intermediate `strip=1` argument allows the removal of must of the debug information whilst retaining the ability to produce a proper line number traceback on error. 
+
+#### lua_freeheap
+
+` int (lua_freeheap) (void);`         [-0, +0, –]
+
+returns the amount of free heap available to the Lua memory allocator.
+
+#### lua_gc
+
+`  int lua_gc (lua_State *L, int what, int data);`         [-0, +0, m]
+
+provides an option for 
+- `what`:
+    - `LUA_GCSETMEMLIMIT`  sets the available heap threshold (in bytes) at which aggressive sweeping starts.
+
+#### lua_getlfsconfig
+
+`  void lua_getlfsconfig (lua_State *L, int *conf);`         [-0, +0, -]
+
+if `conf` is not `NULL`, then this returns an int[5] summary of the LFS configuration.  The first 3 items are the mapped and flash address of the LFS region, and its allocated size.  If the LFS is loaded then the 4th is the current size used and the 5th (for Lua 5.3 only) the date-timestamp of loaded LFS image. 
+
+#### lua_getstate
+
+`  lua_State * lua_getstate();`         [-0, +0, -]
+
+returns the main thread `lua_State` record.  Used in CBs to initialise `L` for subsequent API call use.
+
+#### lua_pushrotable
+`  void lua_pushrotable (lua_State *L, ROTable *p);`         [-0, +1, -]
+
+Pushes a ROTable onto the stack.
+
+#### lua_pushstringsarray
+`  int lua_pushstringsarray (lua_State *L, int opt);`         [-0, +1, m]
+
+Pushes an array onto the stack containing all strings in the specified strings table. If `opt` = 0 then the RAM table is used, else if `opt` = 1 and LFS is loaded then the LFS  table is used, else `nil` is pushed onto the stack.
+
+Returns a status boolean 1 = table pushed. 
+
+#### lua_stripdebug
+`  int lua_stripdebug (lua_State *L, int level);`         [-1, +0, e]
+
+This function has two modes.  A value is popped off the stack.  
+-  If this value is `nil`, then the default strip level is set to this if `level` in the range 0 to 2, otherwise the current default level is returned.
+-  If this is a Lua function (in RAM rather than in LFS), then the prototype hierarchy within the function is stripped of debug information to the specified level.
+
+### lua_writestring
+
+`  void lua_writestring(const char *s, size_t l); /* macro */`
+
+Writes a string `s` of length `l` to `stdout`.  Note that any output redirection will be applied to the string.
+ 
+### lua_writestringerror
+
+`  void lua_writestringerror(const char *s, void *p).  /* macro */`
+
+Writes an error with Cstring format specifier `s` and parameter `p` to `stderr`.  Note on the ESP devices this error will always be sent to `UART0`; output redirection will not be applied.
+
+### The Debug Interface
+
+#### lua_getstrings
+
+`  int lua_getstrings (lua_State *L, int opt);`         [-0, +1, m]
+
+If the ROM string table is selected and no LFS is present then `nil` is pushed onto the stack.  Otherwise the specified string table is scanned to build a list of strings in it. The resulting table is pushed onto the stack.
+-  `opt` evaluated as a boolean; if `true` then the ROM string table is listed, else the RAM string table
+-  returns the number of strings in returned table.
+
+### Auxiliary Library Functions and Types 
+
+Note that the LRM defines an auxiliary library which contains a set of functions that assist in coding convenience and economy.  These are strictly built on top of the basic API, and are defined in `lauxlib.h`.  By convention all auxiliary functions have the prefix `luaL_` so module code should only contain `lua_XXXX()` and `luaL_XXXX()` data declarations and functions.  And since the `lauxlib.h` itself incudes `lua.h`, all C modules should only need to `#include "lauxlib.h"` in their include preambles.
+
+NodeMCU adds some extra auxiliary functions above those defined in the LRM.
+
+#### luaL_lfsreload
+
+`  int  lua_lfsreload (lua_State *L);`         [-1, +1, -]
+
+This function pops the LFS image name from the stack, and if it exists and contains the correct image header then it reloads LFS with the specified image file, and immediately restarts with the new LFS image loaded, so control it not returned to the calling function. If the image is missing or the header is invalid then an error message is pushed onto the stack and control is returned.  Note that if the image has a valid header but its contents are invalid then the result is undetermined.
+
+#### luaL_pcallx
+
+`  int luaL_pcallx (lua_State *L, int narg, int nresults);`         [-(nargs + 1), +(nresults|1), –]
+
+Calls a function in protected mode and providing a full traceback on error.
+
+Both `nargs` and `nresults` have the same meaning as in [lua_call](https://www.lua.org/manual/5.3/manual.html#lua_call). If there are no errors during the call, then `luaL_pcallx` behaves exactly like `lua_call`. However, if there is any error, `lua_pcallx` has already established an traceback error handler for the call that catches the error. It cleans up the stack and returns the negative error code.
+
+Any caught error is posted to a separate NodeMCU task which reports the error.  The error reporter is defined in the registry entry "`onerror`".  The default action is to print the error and then set a 1 sec one-shot timer to restart the CPU.  (One second is enough time to allow the error to be sent over the network if redirection to a telnet session is in place.)  If the `onerror` entry is set to `print` for example, then the error is simply printed without restarting the CPU.
+
+Note that the Lua runtime does not call the error handler if the error is an out-of memory one, so in this case the out-of-memory error is posted to the error reporter without a traceback.
+
+#### luaL_posttask
+
+`  int luaL_posttask (lua_State* L, int prio);`         [-1, +0, e]
+
+Posts a task to execute the function popped from the stack at the specified user task priority
+-  `prio` one of:
+   -  `LUA_TASK_LOW`
+   -  `LUA_TASK_MEDIUM`
+   -  `LUA_TASK_HIGH`
+
+Note that the function is invoked with the priority as its parameter.
+
+#### luaL_pushlfsmodule
+
+`  int luaL_pushlfsmodule ((lua_State *L);`         [-1, +1, -]
+
+This function pops a module name from the stack. If this is a string, LFS is loaded and it contains the named module then its closure is pushed onto the stack as a function value, otherwise `nil` is pushed.
+
+Returns the type of the pushed value.
+
+#### luaL_pushlfsmodules
+
+`  int luaL_pushlfsmodules (lua_State *L);`         [-0, +1, m]
+
+If LFS is loaded then an array of the names of all of the modules in LFS is pushed onto the stack as a function value, otherwise `nil` is pushed.
+
+Returns the type of the pushed value.
+
+#### luaL_pushlfsdts
+
+`  int luaL_pushlfsdts (lua_State *L);`         [-0, +1, m-]
+
+If LFS is loaded then the Unix-style date-timestamp for the compile time of the image is pushed onto the stack as a integer value, otherwise `nil` is pushed.  Note that the primary use of this stamp is to act as a unique identifier for the image version.
+
+Returns the type of the pushed value.
+
+#### luaL_reref
+`  void (luaL_reref) (lua_State *L, int t, int *ref);`         [-1, +0, m]
+
+Variant of [luaL_ref](https://www.lua.org/manual/5.3/manual.html#luaL_ref).  If `*ref` is a valid reference in the table at index t, then this is replaced by the object at the top of the stack (and pops the object), otherwise it creates and returns a new reference using the `luaL_ref` algorithm.
+
+#### luaL_rometatable
+
+`  int (luaL_rometatable) (lua_State *L, const char* tname, const ROTable *p);`         [-0, +1, e]
+
+Equivalent to `luaL_newmetatable()` for ROTable metatables.  Adds key / ROTable entry to the registry  `[tname] = p`, rather than using a new RAM table.
+
+#### luaL_unref2
+
+`  luaL_unref2(l,t,r)`
+
+This macro executes `luaL_unref(L, t, r)` and then assigns `r = LUA_NOREF`.
+
+### Declaring modules and ROTables in NodeMCU
+
+All NodeMCU C library modules should include the standard header "`module.h`".  This internally includes `lnodemcu.h` and these together provide the macros to enable declaration of NodeMCU modules and ROTables within them.  All ROtable support macros are wither prefixed by `LRO_` (Lua Read Only) or in the case of table entries `LROT_`. 
+
+#### NODEMCU_MODULE
+
+` NODEMCU_MODULE(sectionname, libraryname, map, initfunc)`
+
+This macro enables the module to be statically declared and linked in the `ROM` ROTable.  The global environment's metafield `__index=ROM` hence any entries in the ROM table are resolved as read-only entries in the global environment.
+-  `sectionname`. This is the linker section for the module and by convention this is the uppercased library name (e.g. `FILE`).  Behind the scenes `_module_selected` is appended to this section name if corresponding "use module" macro (e.g. `LUA_USE_MODULES_FILE`) is defined in the configuration.  Only the modules sections `*_module_selected` are linked into the firmware image ad those not selected are ignored.
+ -  `libraryname`.  This is the name of the module (e.g. `FILE`) and is the key for the entry in the `ROM` ROTable.
+-  `map`.  This is the ROTable defining the functions and constants for the module, and this is the corresponding value for the entry in the `ROM` ROTable.
+-  `initfunc`.  If this is not NULL, it should be a valid C function and is call during Lua initialisation to carry out one-time initialisation of the module.
+
+#### LROT_BEGIN and LROT_END
+
+`  LROT_BEGIN(rt,mt,flags)`
+`  LROT_END(rt,mt,flags)`
+These macros start and end a ROTable definition.  The three parameters must be the same in both declarations.
+-  `rt`.  ROTable name.
+-  `mt`.  ROTable's metatable.  This should be of the form `LROT_TABLEREF(tablename)` if the metatable is used and `NULL` otherwise.
+-  `flags`. The Lua VM table access routines use a `flags` field to short-circuit where the access needs to honour metamethods during access.  In the case of a static ROTable this flag bit mask must be declared statically during compile rather than cached dynamically at runtime.  Hence if the table is a metatable and it includes the metamethods `__index`, `__newindex`, `__gc`, `__mode`, `__len` or `__eq`, then the mask field should or-in the corresponding mask for example if `__index` is used then the flags should include `LROT_MASK_INDEX`.  Note than index and GC are a very common combination, so `LROT_MASK_GC_INDEX` is also defined to be `(LROT_MASK_GC | LROT_MASK_INDEX)`.
+
+#### LROT_xxxx_ENTRY
+
+ROTables only support static declaration of string keys and value types: C function, Lightweight userdata, Numeric, ROTable.  These are entries are declared by means of the  `LROT_FUNCENTRY`, `LROT_LUDENTRY`, `LROT_NUMENTRY`, `LROT_INTENTRY`, `LROT_FLOATENTRY` and `LROT_TABENTRY` macros.  All take two parameters: the name of the key and the value. For Lua 5.1 builds `LROT_NUMENTRY` and `LROT_INTENTRY` both generate a numeric `TValue`, but in the case of Lua 5.3 these are separate numeric subtypes so these macros generate the appropriate subtype.
+
+Note that ROTable entries can be declared in any order except that keys starting with "`_`" must be declared at the head of the list.  This is a pragmatic constraint for runtime efficiency.  A lookaside cache is used to optimise key searches and results in a direct table probe in over 95% of ROTable accesses.  A table miss (that is the key doesn't exist) still requires a full scan of the list, and the main source of table misses are scans for metafield values.  Forcing these to be at the head of the ROTable allows the scan to abort on reading the first non-"`_`" key.
+
+ROTables can still support other key and value types by using an index metamethod to point at an C index access function.  For example this technique is used in the `utf8` library to return `utf8.charpattern`
+
+```C
+LROT_BEGIN(utf8_meta, NULL, LROT_MASK_INDEX)
+  LROT_FUNCENTRY( __index, utf8_lookup )
+LROT_END(utf8_meta, NULL, LROT_MASK_INDEX)
+
+LROT_BEGIN(utf8, NULL, 0)
+  LROT_FUNCENTRY( offset, byteoffset )
+  LROT_FUNCENTRY( codepoint, codepoint )
+  LROT_FUNCENTRY( char, utfchar )
+  LROT_FUNCENTRY( len, utflen )
+  LROT_FUNCENTRY( codes, iter_codes )
+LROT_END(utf8, LROT_TABLEREF(utf8_meta), 0)
+```
+
+### Standard Libraries
+
+-  Basic Lua functions, coroutine support, Lua module support, string and table manipulation are as per the standard Lua implementation.  However, note that there are some breaking changes in the standard Lua string implementation as discussed in the LRM, e.g. the `\z` end-of-line separator; no string functions show a CString be behaviour (`"\0"` is no longer a special character).
+-  The modulus operator is implemented for string data types so `str % var` is a synonym for `string.format(str, var)` and `str % tbl` is a synonym for `string.format(str, table.unpack(tbl))`.  This python-like formatting functionality is a very common extension to the string library, but is awkward to implement with `string` being a `ROTable`.
+-  The `string.dump()` `strip` parameter can take integer values 1,2,3 (the [`lua_stripdebug`](#lua_stripdebug) strip parameter + 1).  `false` is synonymous to `1`, `true` to `3` and omitted takes the default strip level.
+-  The `string` library does not offer locale support. 
+-  The 5.3 `math` library is expanded compared to the 5.1 one, and specifically:
+    - Included: ` abs`, ` acos`, ` asin`, ` atan`, ` ceil`, ` cos`, ` deg`, ` exp`, ` tointeger`, ` floor`, ` fmod`, ` ult`, ` log`, ` max`, ` min`, ` modf`, ` rad`, ` random`, ` randomseed`, ` sin`, ` sqrt`, ` tan` and ` type`
+    -  Not implemented: ` atan2`, ` cosh`, ` sinh`, ` tanh`, ` pow`, ` frexp`, ` ldexp` and ` log10`
+ -  Input, output OS Facilities (the `io` and `os` libraries) are implement for firmware builds because of the minimal OS supported offered by the embedded run-time.  The separately documented `file` and `node` libraries provide functionally similar analogues.  The host execution environment implemented by `luac.cross` does support the `io` and `os` libraries.
+-  The full `debug` library is implemented less the `debug.debug()` function.  `debug.getstrings(type)`where type is one of `'ROM'`, or `'RAM'` (the default) returns a sorted array of the strings returned from the [`lua_getstrings`](#lua_getstrings) function.
+
+## Lua compatibility
+
+Standard Lua has a number of breaking incompatibilities that require conditional code to enable modules using these features to be compiled against both Lua 5.1 and Lua 5.3.  See [Lua 5.2 §8](https://www.lua.org/manual/5.2/manual.html#8) and [Lua 5.3 §8](https://www.lua.org/manual/5.3/manual.html#8) for incompatibilities with Lua 5.1.
+
+A key strategy in our NodeMCU migration to Lua 5.3 is that all NodeMCU application modules must be compilable and work under both Lua versions.  This has been achieved by three mechanisms
+-  The standard Lua build has conditionals to enable improved compatibility with earlier versions.  In general the Lua 5.1 compatibilities have been enabled in the Lua 5.3 builds.
+-  Regressing new Lua 5.3 features into the Lua 5.1 API.
+-  For a limited number of features the Project accepts that the two versions APIs are incompatible and hence modules should either avoid their use or use `#if LUA_VERSION_NUM == 501` conditional compilation.
+
+The following subsections detail how NodeMCU Lua versions deviate from standard Lua in order to achieve these objectives.
+
+### Enabling Compatibility modes
+
+The following Compatibility modes are enabled:
+-  `LUA_COMPAT_APIINTCASTS`.  These `ìnt`cast are still used within NodeMCU modules.
+-  `LUA_COMPAT_UNPACK`.  This retains `ROM.unpack` as a global synonym for `table.unpack` 
+-  `LUA_COMPAT_LOADERS`.  This keeps `package.loaders` as a synonym for `package.seachers`
+-  `LUA_COMPAT_LOADSTRING`.  This keeps `loadstring(s)` as a synonym for `load(s)`.
+
+### New Lua 5.3 features back-ported into the Lua 5.1 API
+
+-  Table access routines in Lua 5.3 are now type `int` rather than `void` and return the type of the value pushed onto the stack.  The 5.1 routines `lua_getfield`, `lua_getglobal`, `lua_geti`, `lua_gettable`, `lua_rawget`, `lua_rawgeti`, `lua_rawgetp` and `luaL_getmetatable` have been updated to mirror this behaviour and return the type of the value pushed onto the stack.
+-  There is a general numeric comparison API function `lua_compare()` with macros for `lua_equal()` and `lua_lessthan()` whereas 5.1 only support the `==` and `<` tests through separate API calls.  5.1 has been update to mirror the 5.3. implementation.
+-  Lua 5.3 includes a `lua_absindex(L, idx)` which converts ToS relative (e.g. `-1`) indices to stack base relative and hence independent of further push/pop operations.  This makes using down-stack indexes a lot simpler. 5.1 has been update to mirror this 5.3 function.
+ 
+### Feature breaks
+
+-  `\0` is now a valid pattern character in search patterns, and the `%z` pattern is no longer supported. We suggest that modules either limit searching to non-null strings or accept that the source will require version variants.
+
+-  The stack pseudo-index `LUA_GLOBALSINDEX` has been removed. Modules must either get the global environment from the registry entry `LUA_RIDX_GLOBALS` or use the `lua_getglobal` API call.  All current global references in the NodeMCU library modules now use `lua_getglobal` where necessary.
+
+-  Shared userdata and table upvalues.  Lua 5.3 now supports the sharing of GCObjects such as userdata and tables as upvalue between C functions using `lua_getupvalue` and `lua_setupvalue`.  This has changed from 5.1 and we suggest that modules either avoid using these API calls or accept that the source will require version variants.
+
+-  The environment support has changed from Lua 5.1 to 5.3.  We suggest that modules either avoid using these API calls or accept that the source will require version variants.
+
+  -  The corountine yield / resume API support has changed in Lua 5.3 to support yield and resume across C function calls.  We suggest that modules either avoid using these API calls or accept that the source will require version variants. 
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,6 +32,8 @@ pages:
     - Uploading code: 'upload.md'
     - Compiling code: 'compiling.md'
     - Support: 'support.md'
+- Reference:
+    - NodeMCU Language Refrence Manual: 'nodemcu-lrm.md'
 - FAQs:
     - Lua Developer FAQ: 'lua-developer-faq.md'
     - Extension Developer FAQ: 'extn-developer-faq.md'


### PR DESCRIPTION
This is a big PR encompassing #3152, #3165 (part), #3175, #3176 and #3180.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `release`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have ~~thoroughly~~ tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

### Overview of PR

This aims to sweep up most of the loose ends following the Alpha release of Lua 5.3 and as such is a _big_ PR.  Sorry but all of the interdependencies make this a difficult one to untangle.  So this encompasses:

-  #3152 **Emergency GC in Lua 5.3**.
-  #3165 **Additional documentation for Lua 5.3**.  See new `docs/` files for the NodeMCU LRM and the LFS Whitepaper.  This second is probably far too detailed for mode readers and needs culling, IMO.
-  #3170 **Implement Stripdebug feature for Lua 5.3**
-  #3176 **RFC: Tidy up node.flashindex interface**
-  #3180 **RFC: Tidy up the Lua C API / library code split and interface**.  To see how this works see for example `node.c:node_lfs_func()`

### Still TBD
-  I am still tuning the GC stuff. I will add this as a separate commit.
-  Review / implementation of `luac.cross` strip debug levels

### Caveat
Because of the size of this, I am expecting extra rework so lease don't merge until we've had this review cycle.
