### PR TITLE
Fixed esp-lwip breaking change on dns_getserver

### DIFF
--- a/components/modules/net.c
+++ b/components/modules/net.c
@@ -978,13 +978,13 @@ static int net_getdnsserver( lua_State* L ) {
   // ip_addr_t ipaddr;
   // dns_getserver(numdns,&ipaddr);
   // Bug fix by @md5crypt https://github.com/nodemcu/nodemcu-firmware/pull/500
-  ip_addr_t ipaddr = dns_getserver(numdns);
+  const ip_addr_t *ipaddr = dns_getserver(numdns);
 
-  if ( ip_addr_isany(&ipaddr) ) {
+  if ( ip_addr_isany(ipaddr) ) {
     lua_pushnil( L );
   } else {
     char temp[IP_STR_SZ];
-    ipstr (temp, &ipaddr);
+    ipstr (temp, ipaddr);
     lua_pushstring( L, temp );
   }
 


### PR DESCRIPTION
Fixes #3173

The dns_getserver function's return value was changed to a const pointer in commit https://github.com/espressif/esp-lwip/commit/da2740fa8d56b9b9e8a10602f38df1ea4dbd9b74 on 2.0.3-esp branch.
