### PR TITLE
Fix of string.format("%.0f")

### DIFF
--- a/app/libc/stdio.c
+++ b/app/libc/stdio.c
@@ -642,6 +642,9 @@ vsprintf (char *d, const char *s, va_list ap)
 //static void dtoa (char *, double, int, int, int);
 void dtoa (char *dbuf, rtype arg, int fmtch, int width, int prec);
                     dbl = va_arg(ap, double);
+                    if (!haddot) {
+                      trunc = 6;
+                    }
                     dtoa(d, dbl, *s, width, trunc);
                     trunc = 0;
                 }
@@ -763,9 +766,7 @@ void dtoa (char *dbuf, rtype arg, int fmtch, int width, int prec)
         return;
     }
 
-    if (prec == 0)
-        prec = 6;
-    else if (prec > MAX_FRACT)
+    if (prec > MAX_FRACT)
         prec = MAX_FRACT;
 
     /* leave room for sign at start of buffer */


### PR DESCRIPTION
Fixes #3169.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This PR fixes the `string.format("%.0f")` to output float number without decimals after decimal point. At this same time it preserves 6 decimals when no format is specified (`%f`).

The default value needs to be set in the `vsprintf` function rather than in `dtoa` function of `app/libc/stdio.c`.

The following testing code gives results as expected (also for `%e` and `%g` formatting strings).
```Lua
local pi=3.14159265359
print(("%f"):format(pi)) 
for i=0,12 do print(("%"..i.."f"):format(pi)) end
for i=0,8 do print(("%."..i.."f"):format(pi)) end
for i=0,12 do print(("%"..i..".4f"):format(pi)) end
```
