### PR TITLE
Dht negative

### DIFF
--- a/app/dht/dht.c
+++ b/app/dht/dht.c
@@ -40,13 +40,12 @@
 #define HIGH    1
 #endif /* ifndef HIGH */
 
-#define COMBINE_HIGH_AND_LOW_BYTE(byte_high, byte_low)  (((byte_high) << 8) | (byte_low))
-
 static double dht_humidity;
 static double dht_temperature;
 
 static uint8_t dht_bytes[5];  // buffer to receive data
 static int dht_readSensor(uint8_t pin, uint8_t wakeupDelay);
+static int16_t getValue(uint8_t high_byte, uint8_t low_byte);
 
 /////////////////////////////////////////////////////
 //
@@ -119,12 +118,8 @@ int dht_read_universal(uint8_t pin)
     // Assume it is not DHT11
     // CONVERT AND STORE
     DHT_DEBUG("DHTxx method\n");
-    dht_humidity = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[0], dht_bytes[1]) * 0.1;
-    dht_temperature = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[2] & 0x7F, dht_bytes[3]) * 0.1;
-    if (dht_bytes[2] & 0x80)  // negative dht_temperature
-    {
-        dht_temperature = -dht_temperature;
-    }
+    dht_humidity = (double)getValue(dht_bytes[0], dht_bytes[1]) * 0.1;
+    dht_temperature = (double)getValue(dht_bytes[2], dht_bytes[3]) * 0.1;
 
     // TEST CHECKSUM
     uint8_t sum = dht_bytes[0] + dht_bytes[1] + dht_bytes[2] + dht_bytes[3];
@@ -179,12 +174,8 @@ int dht_read(uint8_t pin)
     }
 
     // CONVERT AND STORE
-    dht_humidity = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[0], dht_bytes[1]) * 0.1;
-    dht_temperature = (double)COMBINE_HIGH_AND_LOW_BYTE(dht_bytes[2] & 0x7F, dht_bytes[3]) * 0.1;
-    if (dht_bytes[2] & 0x80)  // negative dht_temperature
-    {
-        dht_temperature = -dht_temperature;
-    }
+    dht_humidity = (double)getValue(dht_bytes[0], dht_bytes[1]) * 0.1;
+    dht_temperature = (double)getValue(dht_bytes[2], dht_bytes[3]) * 0.1;
 
     // TEST CHECKSUM
     uint8_t sum = dht_bytes[0] + dht_bytes[1] + dht_bytes[2] + dht_bytes[3];
@@ -314,6 +305,13 @@ int dht_readSensor(uint8_t pin, uint8_t wakeupDelay)
 
     return DHTLIB_OK;
 }
+
+// Assembles the high and low byte in a signed 16bit value
+static int16_t getValue(uint8_t high_byte, uint8_t low_byte)
+{
+    return ((high_byte << 8) | low_byte);
+}
+
 //
 // END OF FILE
 //

--- a/app/dht/dht.c
+++ b/app/dht/dht.c
@@ -313,15 +313,17 @@ int dht_readSensor(uint8_t pin, uint8_t wakeupDelay)
 static double getValue(dht_Signal s)
 {
     uint8_t high=0, low=0;
+
+    // the '8' variants leave the low byte set to 0
     switch(s){
-        case Humidity8:
-            low = dht_bytes[1];
         case Humidity:
+            low = dht_bytes[1];
+        case Humidity8:
             high = dht_bytes[0];
             break;
-        case Temperature8:
-            low = dht_bytes[3];
         case Temperature:
+            low = dht_bytes[3];
+        case Temperature8:
             high = dht_bytes[2];
             break;
     }


### PR DESCRIPTION
Fixes #\<GitHub-issue-number\>.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Negative temperatures were handled like this:
```c
if (dht_bytes[2] & 0x80)  // negative dht_temperature {
  dht_temperature = -dht_temperature;
}
```
But negative values are using 1's complement encoding, so for instance -1 is represented as 0xFF and -1 was converted to -3276
I've changed the conversion to use signed arithmetic and now it works correctly.
I've also factored the checksum and values decoding to their own functions, to reduce duplication.
