### PR TITLE
Add support to set the clock rate and have sntp use it.

### DIFF
--- a/app/include/rtc/rtctime.h
+++ b/app/include/rtc/rtctime.h
@@ -63,6 +63,7 @@ struct rtc_tm{
 void TEXT_SECTION_ATTR rtctime_early_startup (void);
 void rtctime_late_startup (void);
 void rtctime_adjust_rate (int rate);
+int rtctime_get_rate (void);
 void rtctime_gettimeofday (struct rtc_timeval *tv);
 void rtctime_settimeofday (const struct rtc_timeval *tv);
 bool rtctime_have_time (void);

--- a/app/modules/rtctime.c
+++ b/app/modules/rtctime.c
@@ -57,6 +57,11 @@ void rtctime_late_startup (void)
   rtc_time_switch_system ();
 }
 
+int rtctime_get_rate (void)
+{
+  return rtc_time_get_rate();
+}
+
 void rtctime_adjust_rate (int rate)
 {
   rtc_time_set_rate (rate);
@@ -131,13 +136,15 @@ static int rtctime_set (lua_State *L)
   if (!rtc_time_check_magic ())
     rtc_time_prepare ();
 
-  uint32_t sec = luaL_checkinteger (L, 1);
-  uint32_t usec = 0;
-  if (lua_isnumber (L, 2))
-    usec = lua_tointeger (L, 2);
+  if (lua_isnumber(L, 1)) {
+    uint32_t sec = luaL_checkinteger (L, 1);
+    uint32_t usec = 0;
+    if (lua_isnumber (L, 2))
+      usec = lua_tointeger (L, 2);
 
-  struct rtc_timeval tv = { sec, usec };
-  rtctime_settimeofday (&tv);
+    struct rtc_timeval tv = { sec, usec };
+    rtctime_settimeofday (&tv);
+  }
 
   if (lua_isnumber(L, 3))
     rtc_time_set_rate(lua_tointeger(L, 3));

--- a/docs/modules/rtctime.md
+++ b/docs/modules/rtctime.md
@@ -139,7 +139,8 @@ It is highly recommended that the timestamp is obtained via NTP (see [SNTP modul
 
 Values very close to the epoch are not supported. This is a side effect of keeping the memory requirements as low as possible. Considering that it's no longer 1970, this is not considered a problem.
 
-You specify the seconds parameter with the optional microseconds (defaults to 0). Setting the rate is independant.
+Times are specified across two arguments, seconds and microseconds. If microseconds are not specified, the default is 0 (i.e., time is exactly at the boundary between two seconds).
+In addition to the time, a third argument specifies the local clock's drift rate estimate, as documented in `rtctime.get()`. If this argument is not given or is `nil`, the current rate estimate will not be altered, and the rate estimate may be set without changing the time by leaving the seconds and microseconds arguments `nil`. The rate is not (unfortunately) a fixed parameter for a particular nodemcu board. It varies with (at least) the temperature and the age of the board.
 
 #### Syntax
 `rtctime.set([seconds], [microseconds], [rate])`

--- a/docs/modules/rtctime.md
+++ b/docs/modules/rtctime.md
@@ -139,8 +139,10 @@ It is highly recommended that the timestamp is obtained via NTP (see [SNTP modul
 
 Values very close to the epoch are not supported. This is a side effect of keeping the memory requirements as low as possible. Considering that it's no longer 1970, this is not considered a problem.
 
+You specify the seconds parameter with the optional microseconds (defaults to 0). Setting the rate is independant.
+
 #### Syntax
-`rtctime.set(seconds, microseconds, [rate])`
+`rtctime.set([seconds], [microseconds], [rate])`
 
 #### Parameters
 - `seconds` the seconds part, counted from the Unix epoch


### PR DESCRIPTION
Fixes #3235


- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This just adds support to `rtctime.set` to allow it to be used with the first two args as nil. In this case, if the rate is supplied as argument 3, then it is set.

The sntp module also initializes the clock PLL from the current rate. 
