### PR TITLE
Conditional vendor SDK download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ else
       GCCTOOLCHAIN      = linux-x86_64-$(TOOLCHAIN_VERSION)
       TOOLCHAIN_ROOT    = $(TOP_DIR)/tools/toolchains/esp8266-$(GCCTOOLCHAIN)
       GITHUB_TOOLCHAIN  = https://github.com/jmattsson/esp-toolchains
+      GITHUB_ESPRESSIF_SDK = yes
       export PATH:=$(PATH):$(TOOLCHAIN_ROOT)/bin
     endif
   endif

--- a/Makefile
+++ b/Makefile
@@ -316,6 +316,7 @@ $(TOP_DIR)/cache/esptool/v$(ESPTOOL_VER).tar.gz:
 	mkdir -p $(TOP_DIR)/cache/esptool/
 	$(WGET) $(GITHUB_ESPTOOL)/archive/v$(ESPTOOL_VER).tar.gz -O $@ || { rm -f "$@"; exit 1; }
 
+ifdef GITHUB_ESPRESSIF_SDK
 $(TOP_DIR)/sdk/.extracted-$(SDK_VER): $(TOP_DIR)/cache/$(SDK_FILE_VER).zip
 	mkdir -p "$(dir $@)"
 	$(summary) UNZIP $(patsubst $(TOP_DIR)/%,%,$<)
@@ -343,6 +344,13 @@ $(TOP_DIR)/cache/$(SDK_FILE_VER).zip:
 	$(summary) WGET $(patsubst $(TOP_DIR)/%,%,$@)
 	$(WGET) $(GITHUB_SDK)/archive/$(SDK_FILE_VER).zip -O $@ || { rm -f "$@"; exit 1; }
 	if test "$(SDK_FILE_SHA1)" != "NA"; then echo "$(SDK_FILE_SHA1)  $@" | sha1sum -c - || { rm -f "$@"; exit 1; }; fi
+else
+$(TOP_DIR)/sdk/.extracted-$(SDK_VER):
+	echo "SDK provided"
+	test -d $(dir $@)/esp_iot_sdk_v$(SDK_VER) || { echo "esp_iot_sdk_v$(SDK_VER) not found"; exit 1; };
+$(TOP_DIR)/sdk/.pruned-$(SDK_VER):
+	echo "SDK pruned"
+endif
 
 clean:
 	$(foreach d, $(SUBDIRS), $(MAKE) -C $(d) clean;)


### PR DESCRIPTION
Makes it possible to provide ESPRESSIF SDK externally instead of pulling it from GitHub.

```
GITHUB_ESPRESSIF_SDK = yes
```
is a bit weird, suggestions welcome. Marking as draft.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.