### PR TITLE
tools/Makefile: remove stray whitespace from APP_DIR

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -7,7 +7,7 @@ LUASOURCE ?= ../local/lua
 FLASHSIZE ?= 4mb 32mb 8mb
 FLASH_SW = -S
 SUBDIRS =
-APP_DIR = ../app 
+APP_DIR = ../app
 OBJDUMP = $(or $(shell which objdump),xtensa-lx106-elf-objdump)
 
 #############################################################


### PR DESCRIPTION
Fixes expansion when used later.

There seem to be more issues with SPIFFS image generation which I wasn't able to tackle yet.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.
