### PR TITLE
mqtt: fix connfail callback

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -1329,9 +1329,9 @@ static int mqtt_socket_on( lua_State* L )
   if( sl == 7 && strcmp(method, "connect") == 0){
     luaL_unref(L, LUA_REGISTRYINDEX, mud->cb_connect_ref);
     mud->cb_connect_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-  }else if( sl == 7 && strcmp(method, "connfail") == 0){
+  }else if( sl == 8 && strcmp(method, "connfail") == 0){
     luaL_unref(L, LUA_REGISTRYINDEX, mud->cb_connect_fail_ref);
-    mud->cb_connect_ref = luaL_ref(L, LUA_REGISTRYINDEX);
+    mud->cb_connect_fail_ref = luaL_ref(L, LUA_REGISTRYINDEX);
   }else if( sl == 7 && strcmp(method, "offline") == 0){
     luaL_unref(L, LUA_REGISTRYINDEX, mud->cb_disconnect_ref);
     mud->cb_disconnect_ref = luaL_ref(L, LUA_REGISTRYINDEX);


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

----

I've not been able to get the mqtt `connfail` callback to work.

I'm consistently receiving `method not supported` errors:
```
application.lua:53: method not supported
stack traceback:
        [C]: in function 'on'
        application.lua:53: in main chunk
        [C]: in function 'dofile'
        init.lua:18: in function <init.lua:6>
```

Example code:
```
function on_connection_failed(client, reason)
    print("mqtt connection failed: " .. reason)
end

m:on("connfail", on_connection_failed)
```

I believed this to be caused by the incorrect length comparison for `connfail`
that is updated here.

Once I changed that, the error went away, however the callback was never called.

I believe the callback was never called because of an incorrect assignment.

However, I saw this somewhat confusing description in the docs so this
assignment may be expected?
> The second (failure) callback aliases with the "connfail" callback available through :on(). (The "offline" callback is only called after an already established connection becomes closed. If the connect() call fails to establish a connection, the callback passed to :connect() is called and nothing else.)
