### PR TITLE
On dev branch, fix method name encoder.fromBase64 in example code

### DIFF
--- a/docs/modules/encoder.md
+++ b/docs/modules/encoder.md
@@ -29,7 +29,7 @@ Decodes a Base64 representation of a (binary) Lua string back into the original 
 thrown if the string is not a valid base64 encoding.
 
 #### Syntax
-`binary_string = encoder.toBase64(b64)`
+`binary_string = encoder.fromBase64(b64)`
 
 #### Parameters
 `b64` Base64 encoded input string


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Obviously the example code in the fromBase64 section should demonstrate the fromBase64 method.