### PR TITLE
Makefile: Read user_config by path

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -20,14 +20,14 @@ SPIFFSFILES ?= $(patsubst $(FSSOURCE)/%,%,$(shell find $(FSSOURCE)/ -name '*' '!
 # Get the filesize of /bin/0x10000.bin and SPIFFS sizing
 #
 
-FLASH_FS_SIZE := $(shell $(CC) -E -dM - <$(APP_DIR)/include/user_config.h | grep SPIFFS_MAX_FILESYSTEM_SIZE| cut -d ' ' -f 3)
+FLASH_FS_SIZE := $(shell $(CC) -E -dM $(APP_DIR)/include/user_config.h | grep SPIFFS_MAX_FILESYSTEM_SIZE| cut -d ' ' -f 3)
 
 ifneq ($(strip $(FLASH_FS_SIZE)),)
 FLASHSIZE = $(shell printf "0x%x" $(FLASH_FS_SIZE))
 FLASH_SW = -c
 endif
 
-FLASH_FS_LOC := $(shell $(CC) -E -dM - <$(APP_DIR)/include/user_config.h | grep SPIFFS_FIXED_LOCATION| cut -d ' ' -f 3)
+FLASH_FS_LOC := $(shell $(CC) -E -dM $(APP_DIR)/include/user_config.h | grep SPIFFS_FIXED_LOCATION| cut -d ' ' -f 3)
 ifeq ($(strip $(FLASH_FS_LOC)),)
 FLASH_FS_LOC := $(shell printf "0x%x" $$((0x$(shell $(OBJDUMP) -t $(APP_DIR)/.output/eagle/debug/image/eagle.app.v6.out |grep " _flash_used_end" |cut -f1 -d" ") - 0x40200000)))
 else
@@ -36,7 +36,7 @@ endif
 
 LFSSOURCES := $(wildcard $(LUASOURCE)/*.lua)
 
-BUILD_TYPE := $(shell $(CC) $(EXTRA_CCFLAGS) -E -dM - <$(APP_DIR)/include/user_config.h | grep LUA_NUMBER_INTEGRAL | wc -l)
+BUILD_TYPE := $(shell $(CC) $(EXTRA_CCFLAGS) -E -dM $(APP_DIR)/include/user_config.h | grep LUA_NUMBER_INTEGRAL | wc -l)
 ifeq ($(BUILD_TYPE),0)
 LUAC_CROSS := ../luac.cross
 else


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

Disclosing the true path allows for relative includes in user_config.