### PR TITLE
Fixes broken `tmr.alarm`

### DIFF
--- a/docs/modules/tmr.md
+++ b/docs/modules/tmr.md
@@ -185,7 +185,8 @@ print( timeIt(function() tmr.ccount() end) )
 
 ### tobj:alarm()
 
-This is a convenience function combining [`tobj:register()`](#tobjregister) and [`tobj:start()`](#tobjstart) into a single call.
+This is a convenience function combining [`tobj:register()`](#tobjregister) and [`tobj:start()`](#tobjstart) into a single call. This is the reason why this method has the same parameters as `tobj:register()`.
+If `tobj:alarm()` is invoked on an already running timer the timer is stopped, new parameters are set and timer is (re)started (similar to call `tobj:start(true)`).
 
 To free up the resources with this timer when done using it, call [`tobj:unregister()`](#tobjunregister) on it. For one-shot timers this is not necessary, unless they were stopped before they expired.
 
@@ -282,7 +283,7 @@ Starts or restarts a previously configured timer. If the timer is running the ti
 - `restart` optional boolean parameter forcing to restart already running timer
 
 #### Returns
-`true` if the timer was started, `false` on error
+`true` if the timer was (re)started, `false` on error
 
 #### Example
 ```lua


### PR DESCRIPTION
Fixes #3261.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Fixes broken `tmr.alarm` following the commit [d72ea91](https://github.com/nodemcu/nodemcu-firmware/commit/d72ea91ed01518ef0779d7aa998c5c3a9c269d71).

The following code fragments now work correctly:
```Lua
if not tmr.create():alarm(5000, tmr.ALARM_SINGLE, function()
  print("hey there")
end)
then
  print("whoopsie")
end
```
```Lua
mytimer = tmr.create()
mytimer:register(5000, tmr.ALARM_SINGLE, function() print("hey there") end)
if not mytimer:start() then print("uh oh") end
```