### PR TITLE
Fixes `net.ifinfo` failure

### DIFF
--- a/app/modules/net.c
+++ b/app/modules/net.c
@@ -983,7 +983,10 @@ field_from_ipaddr(lua_State *L, const char * field_name, ip_addr_t* addr) {
 
 static int net_ifinfo( lua_State* L ) {
   int ifidx = luaL_optint(L, 1, 0);
-
+  if (ifidx != 0 && ifidx != 1) {
+    return 0;
+  }
+  
   struct netif * nif = eagle_lwip_getif(ifidx);
   if (nif == NULL) {
     return 0;
@@ -1004,8 +1007,8 @@ static int net_ifinfo( lua_State* L ) {
     field_from_ipaddr(L, "server_ip" , &nif->dhcp->server_ip_addr  );
     field_from_ipaddr(L, "client_ip" , &nif->dhcp->offered_ip_addr );
     field_from_ipaddr(L, "ntp_server", &nif->dhcp->offered_ntp_addr);
+    lua_setfield(L, -2, "dhcp");
   }
-  lua_setfield(L, -2, "dhcp");
 
   return 1;
 }


### PR DESCRIPTION
Fixes #3249.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This seems to be an easy catch. Only 0 or 1 are eligible parameters to `eagle_lwip_getif` and `dhcp` table can be added to the resulting table only when `dhcp` table is created.
