### PR TITLE
LUA 5.1 luac.cross Makefile: Detect and refuse accidential invocation with LUA=53

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -16,10 +16,15 @@ TARGET = eagle
 FLAVOR = debug
 
 # Handle Lua Directory selector
-ifeq ("$(LUA)","53")
+ifeq ("$(LUA)","")
+  LUA_DIR := lua
+else ifeq ("$(LUA)","51")
+  LUA_DIR := lua
+else ifeq ("$(LUA)","53")
   LUA_DIR := lua53
 else
-  LUA_DIR := lua
+  $(error Unsupported value "$(LUA)" for variable "LUA", \
+    expected "51", "53" or unset/empty)
 endif
 
 ifndef PDIR # {
@@ -158,7 +163,7 @@ DDEFINES += 						\
 # Required for each makefile to inherit from the parent
 #
 INCLUDES := -I $(PDIR)libc -I $(PDIR)$(LUA_DIR) -I $(PDIR)platform \
-            $(INCLUDES) -I $(PDIR) -I $(PDIR)include 
+            $(INCLUDES) -I $(PDIR) -I $(PDIR)include
 PDIR := ../$(PDIR)
 
 sinclude $(PDIR)Makefile

--- a/app/lua/Makefile
+++ b/app/lua/Makefile
@@ -18,6 +18,20 @@ endif
 
 STD_CFLAGS=-std=gnu11 -Wimplicit -Wall
 
+
+# Validate LUA setting
+ifeq ("$(LUA)","")
+else ifeq ("$(LUA)","51")
+  # ok
+else ifeq ("$(LUA)","53")
+  $(error Your variable LUA="$(LUA)" looks like you probably want \
+    app/lua53/Makefile instead)
+else
+  $(error Unsupported value "$(LUA)" for variable "LUA", \
+    expected empty/unset (recommended) or "51")
+endif
+
+
 #############################################################
 # Configuration i.e. compile options etc.
 # Target specific stuff (defines etc.) goes in here!

--- a/app/lua/luac_cross/Makefile
+++ b/app/lua/luac_cross/Makefile
@@ -15,6 +15,20 @@ CCFLAGS += -Wall
 
 TARGET = host
 
+
+# Validate LUA setting
+ifeq ("$(LUA)","")
+else ifeq ("$(LUA)","51")
+  # ok
+else ifeq ("$(LUA)","53")
+  $(error Your variable LUA="$(LUA)" looks like you probably want \
+    app/lua53/host/Makefile instead)
+else
+  $(error Unsupported value "$(LUA)" for variable "LUA", \
+    expected empty/unset (recommended) or "51")
+endif
+
+
 VERBOSE ?=
 V ?= $(VERBOSE)
 ifeq ("$(V)","1")

--- a/app/lua53/Makefile
+++ b/app/lua53/Makefile
@@ -18,6 +18,18 @@ endif
 
 STD_CFLAGS=-std=gnu11 -Wimplicit -Wall
 
+
+# Validate LUA setting
+ifeq ("$(LUA)","53")
+  # ok
+else ifeq ("$(LUA)","51")
+  $(error Your variable LUA="$(LUA)" looks like you probably want \
+    app/lua/Makefile instead)
+else
+  $(error Expected environment variable "LUA" to be "53", not "$(LUA)")
+endif
+
+
 #############################################################
 # Configuration i.e. compile options etc.
 # Target specific stuff (defines etc.) goes in here!

--- a/app/lua53/host/Makefile
+++ b/app/lua53/host/Makefile
@@ -23,6 +23,18 @@ else
   # MAKEFLAGS += --silent -w
 endif  # $(V)==1
 
+
+# Validate LUA setting
+ifeq ("$(LUA)","53")
+  # ok
+else ifeq ("$(LUA)","51")
+  $(error Your variable LUA="$(LUA)" looks like you probably want \
+    app/lua/luac_cross/Makefile instead)
+else
+  $(error Expected environment variable "LUA" to be "53", not "$(LUA)")
+endif
+
+
 DEBUG ?=
 ifeq ("$(DEBUG)","1")
     FLAVOR         =   debug


### PR DESCRIPTION
Fixes half of #3268.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

When people accidentially run the Makefile for  LUA 5.1 luac.cross with LUA=53, detect their mistake and point them to the LUA 5.1 luac.cross.