### PR TITLE
First cut of new LFS for initial review

### DIFF
--- a/app/lua53/host/luac.c
+++ b/app/lua53/host/luac.c
@@ -18,38 +18,35 @@
 #include <time.h>
 
 #include "lua.h"
-#include "lualib.h"
-#include "lauxlib.h"
-#include "ldebug.h"
+#include "lualib.h"       // ??
+#include "ldebug.h"       // ??
 #include "lnodemcu.h"
 #include "lobject.h"
 #include "lstate.h"
-#include "lstring.h"
+#include "lstring.h"      // ???
 #include "lundump.h"
 
-static void PrintFunction(const Proto* f, int full);
-#define luaU_print	PrintFunction
+static void PrintFunction(const Proto *f, int full);
+#define luaU_print PrintFunction
 
-#define PROGNAME	"luac.cross"	/* default program name */
-#define OUTPUT		PROGNAME ".out"	/* default output file */
+#define PROGNAME "luac.cross" /* default program name */ 
+#define OUTPUT PROGNAME ".out" /* default output file */
 
-static int listing=0;			/* list bytecodes? */
-static int dumping=1;			/* dump bytecodes? */
-static int stripping=0;			/* strip debug information? */
-static char Output[]={ OUTPUT };	/* default output file name */
-static const char* output=Output;	/* actual output file name */
-static const char* progname=PROGNAME;	/* actual program name */
-static int flash = 0;			/* output flash image */
-static lu_int32 address = 0;		/* output flash image at absolute location */
-static lu_int32 maxSize = 0x40000;	/* maximuum uncompressed image size */
-static int lookup = 0;			/* output lookup-style master combination header */
-static const char *execute;		/* executed a Lua file */
+static int listing = 0;             /* list bytecodes? */
+static int dumping = 1;             /* dump bytecodes? */
+static int stripping = 0;           /* strip debug information? */
+static char Output[] = { OUTPUT };  /* default output file name */
+static const char *output = Output; /* actual output file name */
+static const char *progname = PROGNAME; /* actual program name */
+static lu_int32 address = 0;        /* output flash image at absolute location */
+static lu_int32 maxSize = 0x40000;  /* maximuum uncompressed image size */
+static const char *execute;         /* executed a Lua file */
 char *LFSimageName;
+
 
 #define IROM0_SEG    0x40200000ul
 #define IROM0_SEGMAX 0x00100000ul
-#define IROM_OFFSET(a) (cast(lu_int32, (a)) - IROM0_SEG)
-
+#define IROM_OFFSET(a)(((lu_int32) (a)) - IROM0_SEG)
 
 static void fatal(const char *message) {
   fprintf(stderr, "%s: %s\n", progname, message);
@@ -62,7 +59,7 @@ static void cannot(const char *what) {
 }
 
 static void usage(const char *message) {
-  if ( *message == '-')
+  if (*message == '-')
     fprintf(stderr, "%s: unrecognized option '%s'\n", progname, message);
   else
     fprintf(stderr, "%s: %s\n", progname, message);
@@ -72,100 +69,101 @@ static void usage(const char *message) {
     "  -l       list (use -l -l for full listing)\n"
     "  -o name  output to file 'name' (default is \"%s\")\n"
     "  -e name  execute a lua source file\n"
-    "  -f       output a flash image file\n"
     "  -F name  load a flash image file\n"
     "  -a addr  generate an absolute, rather than "
-               "position independent flash image file\n"
+    "position independent flash image file\n"
     "           (use with -F LFSimage -o absLFSimage to "
-               "convert an image to absolute format)\n"
-    "  -i       generate lookup combination master (default with option -f)\n"
+    "convert an image to absolute format)\n"
     "  -m size  maximum LFS image in bytes\n"
     "  -p       parse only\n"
-    "  -s       strip debug information\n"
+    "  -s n     strip debug information\n"
     "  -v       show version information\n"
     "  --       stop handling options\n"
     "  -        stop handling options and process stdin\n", progname, Output);
   exit(EXIT_FAILURE);
 }
 
-#define IS(s)	(strcmp(argv[i],s)==0)
+#define IS(s)(strcmp(argv[i], s) == 0)
 
 static int doargs(int argc, char *argv[]) {
   int i;
   int version = 0;
   lu_int32 offset = 0;
+  char *p;
   if (argv[0] != NULL && *argv[0] != 0) progname = argv[0];
   for (i = 1; i < argc; i++) {
-    if ( *argv[i] != '-') {                       /* end of options; keep it */
+    if (*argv[i] != '-') {     /* end of options; keep it */
       break;
-    } else if (IS("--")) {                         /* end of options; skip it */
+    } else if (IS("--")) {    /* end of options; skip it */
       ++i;
       if (version) ++version;
       break;
-    } else if (IS("-")) {                        /* end of options; use stdin */
+    } else if (IS("-")) {     /* end of options; use stdin */
       break;
-    } else if (IS("-e")) {                  /* execute a lua source file file */
+    } else if (IS("-e")) {    /* execute a lua source file file */
       execute = argv[++i];
       if (execute == NULL || *execute == 0 || *execute == '-')
         usage("\"-e\" needs a file argument");
-    } else if (IS("-F")) {                  /* execute a lua source file file */
+    } else if (IS("-F")) {    /* execute a lua source file file */
       LFSimageName = argv[++i];
       if (LFSimageName == NULL || *LFSimageName == 0 || *LFSimageName == '-')
         usage("\"-F\" needs an LFS image file argument");
-    } else if (IS("-f")) {                                /* Flash image file */
-      flash = lookup = 1;
-    } else if (IS("-a")) {                        /* Absolue flash image file */
-      flash = lookup = 1;
+    } else if (IS("-a")) {    /* Absolue flash image file */
+//      flash = lookup = 1;
       address = strtol(argv[++i], NULL, 0);
       offset = IROM_OFFSET(address);
       if (offset == 0 || offset > IROM0_SEGMAX)
         usage("\"-a\" absolute address must be valid flash address");
-    } else if (IS("-i")) {                                          /* lookup */
-      lookup = 1;
-    }  else if (IS("-l")) {                                           /* list */
+    } else if (IS("-l")) {    /* list */
       ++listing;
-    } else if (IS("-m")) {                    /* specify a maximum image size */
-      flash = lookup = 1;
+    } else if (IS("-m")) {    /* specify a maximum image size */
+//      flash = lookup = 1;
       maxSize = strtol(argv[++i], NULL, 0);
-      if (maxSize & 0xFFF)
+      if (maxSize &0xFFF)
         usage("\"-e\" maximum size must be a multiple of 4,096");
-    } else if (IS("-o")) {                                     /* output file */
+    } else if (IS("-o")) {    /* output file */
       output = argv[++i];
-      if (output == NULL || *output == 0 || ( *output == '-' && output[1] != 0))
+      if (output == NULL || *output == 0 || (*output == '-' && output[1] != 0))
         usage("'-o' needs argument");
       if (IS("-")) output = NULL;
-    } else if (IS("-p")) {                                      /* parse only */
+    } else if (IS("-p")) {    /* parse only */
       dumping = 0;
-    } else if (IS("-s")) {                         /* strip debug information */
-      stripping = 1;
-    } else if (IS("-v")) {                                    /* show version */
+    } else if (IS("-s")) {    /* strip debug information */
+      stripping = (unsigned) strtol(argv[i+1], &p, 0);
+      if (p == argv[i+1]) {
+        stripping = 1;        /* -s 1 if default if -s applied */
+        i++;
+      }
+      if (stripping > 2)
+        usage("'-s' level must be 0 - 2");
+    } else if (IS("-v")) {    /* show version */
       ++version;
-    } else {                                                /* unknown option */
+    } else {                  /* unknown option */
       usage(argv[i]);
     }
   }
 
-  if (offset>0 && (output == NULL || LFSimageName == NULL ||
-                   execute != NULL || i != argc))
+  if (version) {
+    printf("%s\n", LUA_COPYRIGHT);
+    if (version == argc - 1) exit(EXIT_SUCCESS);
+  }
+  if (offset > 0 && (output == NULL || LFSimageName == NULL ||
+      execute != NULL || i != argc))
     usage("'-a' also requires '-o' and '-f' options without lua source files");
 
   if (i == argc && (listing || !dumping)) {
     dumping = 0;
     argv[--i] = Output;
   }
-  if (version) {
-    printf("%s\n", LUA_COPYRIGHT);
-    if (version == argc - 1) exit(EXIT_SUCCESS);
-  }
   return i;
 }
 
-static const char *corename(lua_State *L, const TString *filename, int *len) {
+static const char *corename(lua_State *L, const TString *filename, size_t *len) {
   const char *fn = getstr(filename) + 1;
   const char *s = strrchr(fn, '/');
   if (!s) s = strrchr(fn, '\\');
   s = s ? s + 1 : fn;
-  while ( *s == '.') s++;
+  while (*s == '.') s++;
   const char *e = strchr(s, '.');
   if (len)
     *len = e ? e - s : strlen(s);
@@ -173,181 +171,93 @@ static const char *corename(lua_State *L, const TString *filename, int *len) {
 }
 
 /*
-** If the luac command line includes multiple files or has the -f option
-** then luac generates a main function to reference all sub-main prototypes.
-** This is one of two types:
-**   Type 0   The standard luac combination main
-**   Type 1   A lookup wrapper that is used for LFS image dumps
-*/
+ ** If the luac command line includes multiple files or has the -f option
+ ** then luac generates a main function to reference all sub-main prototypes.
+ ** This is one of two types:
+ **   Type 0   The standard luac combination main
+ **   Type 1   A lookup wrapper that is used for LFS image dumps
+ */
 #define toproto(L, i) getproto(L->top + (i))
 
-static const Proto *combine(lua_State *L, int n, int type) {
-  if (n == 1 && type == 0) {
-    return toproto(L, -1);
-  } else {
-    Proto *f;
-    int i, j;
-   /*
-    * Generate a minimal proto with 1 return, emtpy p, k & uv vectors
-    */
-    if (luaL_loadbuffer(L, "\n", strlen("\n"), "=("PROGNAME ")") != LUA_OK)
-      fatal(lua_tostring(L, -1));
-    f = toproto(L, -1);
-   /*
-    * Allocate the vector for and bind the sub-protos
-    */
-    luaM_reallocvector(L, f->p, f->sizep, n, Proto *);
-    f->sizep = n;
-    for (i = 0; i < n; i++) {
-      f->p[i] = toproto(L, i - n - 1);
-      if (f->p[i]->sizeupvalues > 0)
-        f->p[i]->upvalues[0].instack = 0;
-    }
-    f->numparams = 0;
-    f->maxstacksize = 1;
-    if (type == 1) {
-     /*
-      * For Type 1 main(), add a k vector of strings naming the corresponding
-      * protos with the Unixtime of the compile appended.
-      */
-      luaM_reallocvector(L, f->k, f->sizek, n+1, TValue);
-      f->sizek        = n + 1;
-      for (i = 0; i < n; i++) {
-        int len;
-        const char *name = corename(L, f->p[i]->source, &len);
-        TString* sname = luaS_newlstr(L, name, len);
-        for (j = 0; j < i; j++) {
-          if (tsvalue(f->k+j) == sname)
-            fatal(lua_pushfstring(L, "Cannot have duplicate files ('%s') in LFS", name));
-        }
-        setsvalue2n(L, f->k+i, sname);
-      }
-      setivalue(f->k+n, (lua_Integer) time(NULL));
-    }
-    return f;
-  }
-}
 
-static int writer(lua_State *L, const void *p, size_t size, void *u) {
+static int writer(lua_State *L,
+  const void *p, size_t size, void *u) {
   UNUSED(L);
-  return (fwrite(p, size, 1, ((FILE **)u)[0]) != 1) && (size != 0);
+  return (fwrite(p, size, 1, (FILE *) u) != 1) && (size != 0);
 }
 
-
-static int msghandler (lua_State *L) {
-  const char *msg = lua_tostring(L, 1);
-  if (msg == NULL)  /* is error object not a string? */
-    msg = lua_pushfstring(L, "(error object is a %s value)", luaL_typename(L, 1));
-  luaL_traceback(L, L, msg, 1);  /* append a standard traceback */
-  return 1;  /* return the traceback */
-}
-
-
-static int dofile (lua_State *L, const char *name) {
-  int status = luaL_loadfile(L, name);
-  if (status == LUA_OK) {
-    int base = lua_gettop(L);
-    lua_pushcfunction(L, msghandler);  /* push message handler */
-    lua_insert(L, base);  /* put it under function and args */
-    status = lua_pcall(L, 0, 0, base);
-    lua_remove(L, base);  /* remove message handler from the stack */
-  }
-  if (status != LUA_OK) {
-    fprintf(stderr, "%s: %s\n", PROGNAME, lua_tostring(L, -1));
-    lua_pop(L, 1);  /* remove message */
-  }
-  return status;
-}
-
-/*
-** This function is an inintended consequence of constraints in ltable.c
-** rotable_findentry().  The file list generates a ROTable in LFS and the
-** rule for ROTables is that metavalue entries must be at the head of the
-** ROTableentry list so argv file names with basenames starting with "__"
-** must be head of the list.  This is a botch. Sorry.
-*/
-static void reorderfiles(lua_State *L, int argc, char **list, char **argv) {
-  int i, j;
-  for (i = 0; i < argc; i++ ) {
-    TString *file = luaS_new(L,argv[i]);
-    if (strcmp("__", corename(L, file, NULL))) {
-      list[i] = argv[i]; /* add to the end of the new list */
-    } else {
-      for (j = 0; j < i; j++)
-        list[j+1] = list[j];
-      list[0] = argv[i];  /* add to the start of the new list */
-    }
-  }
-}
-
+#include "lauxlib.h"
+static int execfile(lua_State *L, const char *name);
 
 static int pmain(lua_State *L) {
   int argc = (int) lua_tointeger(L, 1);
-  char **argv = (char **) lua_touserdata(L, 2);
-  char **filelist = alloca(argc * sizeof(char *));
-  const Proto *f;
-  int i, status;
-  if (!lua_checkstack(L, argc + 1))
-    fatal("too many input files");
-  if (execute || address) {
-    luaL_openlibs(L);  /* the nodemcu open will throw to signal an LFS reload */
-    status = dofile(L, execute);
-    if (status != LUA_OK)
-      return 0;
-  }
-  if (argc == 0)
-    return 0;
-  reorderfiles(L, argc, filelist, argv);
+  const char **argv = (const char ** ) lua_touserdata(L, 2);
+  int i;
+  luaL_openlibs(L);
+  if (!lua_checkstack(L, argc + 1)) fatal("too many input files");
+  if (execute && (execfile(L, execute) != LUA_OK))
+    lua_error(L);
+  lua_createtable(L, argc, 0);
   for (i = 0; i < argc; i++) {
-    const char *filename = IS("-") ? NULL : filelist[i];
-    if (luaL_loadfile(L, filename) != LUA_OK)
+    size_t l;   
+    lua_pushstring(L, IS("-") ?  "stdin" : argv[i]);
+    const char *p = corename(L, tsvalue(L->top-1), &l);
+    lua_pushlstring(L, p, l);
+    lua_remove(L, -2);
+    if (luaL_loadfile(L, IS("-") ? NULL : argv[i]) != LUA_OK)
       fatal(lua_tostring(L, -1));
-//TODO: if strip = 2, replace proto->source by basename
+    lua_rawset(L, -3);
   }
-  f = combine(L, argc + (execute ? 1 : 0), lookup);
-  if (listing) luaU_print(f, listing > 1);
-  if (dumping) {
-    int result;
+//  if (listing) luaU_print(f, listing > 1);
+  (void)(PrintFunction);
+  if (dumping  && argc > 0) {
     FILE *D = (output == NULL) ? stdout : fopen(output, "wb");
     if (D == NULL) cannot("open");
     lua_lock(L);
-    if (flash) {
-      UNUSED(address);
-      UNUSED(maxSize);
-      result = luaU_DumpAllProtos(L, f, writer, &D, stripping);
-    } else {
-      result = luaU_dump(L, f, writer, cast(void *, &D), stripping);
-    }
+    luaU_dump(L, hvalue(L->top-1), writer, D, stripping);
     lua_unlock(L);
-    if (result == LUA_ERR_CC_INTOVERFLOW)
-      fatal("value too big or small for target integer type");
-    if (result == LUA_ERR_CC_NOTINTEGER)
-      fatal("target lua_Number is integral but fractional value found");
     if (ferror(D)) cannot("write");
     if (fclose(D)) cannot("close");
   }
   return 0;
 }
 
+int request_restart;
+
 int main(int argc, char *argv[]) {
   lua_State *L;
   int i = doargs(argc, argv);
-  int j, status;
-  argc -= i; argv += i;
+  int status;
+  const char *err;
+  argc -= i;
+  argv += i;
   if (argc <= 0 && execute == 0 && address == 0) usage("no input files given");
-  if (address)
-    luaN_setabsolute(address);
-  for (j = 0; j < 2 ; j++) {
+  //if (address)
+  //  luaN_setabsolute(address);
+
+  do {
+    request_restart = 0;
     L = luaL_newstate();
-    if (L == NULL) fatal("not enough memory for state");
+    if (L == NULL)
+      fatal("not enough memory for state");
     lua_pushcfunction(L, &pmain);
     lua_pushinteger(L, argc);
     lua_pushlightuserdata(L, argv);
     status = lua_pcall(L, 2, 0, 0);
+    err = (status != LUA_OK) ? strdup(lua_tostring(L, -1)) : NULL;
+    lua_gc(L, LUA_GCCOLLECT, 0);
+    lua_close(L);
+  } while (request_restart);
+  if (status != LUA_OK)
+    fatal(err);
+#if 0
+  for (j = 0; j < 2; j++) {
+    L = luaL_newstate();
     if (status != LUA_OK) {
-      if (lua_isboolean(L,-1) && lua_toboolean(L,-1)) {
+      if (lua_isboolean(L, -1) && lua_toboolean(L, -1)) {
         /*An LFS image has been loaded */
-        if (address) { /* write out as absolute image and exit */
+        if (address) {
+          /* write out as absolute image and exit */
           lu_int32 size = cast(LFSHeader *, LFSregion)->flash_size;
           FILE *af = fopen(output, "wb");
           if (af == NULL) cannot("open");
@@ -359,256 +269,286 @@ int main(int argc, char *argv[]) {
         lua_close(L);
         continue; /* and loop around once more simulating restart */
       }
-      char *err = strdup(lua_tostring(L, -1));
+      char *
       lua_close(L);
       fatal(err);
     }
     lua_close(L);
     break;
   }
+#endif
   return EXIT_SUCCESS;
+}
+/*
+**
+*/
+
+static int msghandler(lua_State *L) {
+  const char *msg = lua_tostring(L, 1);
+  if (msg == NULL) /* is error object not a string? */
+    msg = lua_pushfstring(L, "(error object is a %s value)", luaL_typename(L, 1));
+  luaL_traceback(L, L, msg, 1); /* append a standard traceback */
+  return 1; /* return the traceback */
+}
+
+static int execfile(lua_State *L, const char *name) {
+  int status = luaL_loadfile(L, name);
+  if (status == LUA_OK) {
+    int base = lua_gettop(L);
+    lua_pushcfunction(L, msghandler); /* push message handler */
+    lua_insert(L, base); /* put it under function and args */
+    status = lua_pcall(L, 0, 0, base);
+    lua_remove(L, base); /* remove message handler from the stack */
+  }
+  if (status != LUA_OK) {
+    const char *e = lua_tostring(L, -1);
+    if (!strncmp(e,"!LFS ",5))
+      lua_error(L);
+    fprintf(stderr, "%s: %s\n", PROGNAME, e);
+    lua_pop(L, 1); /* remove message */
+  }
+  return status;
 }
 
 /*
-** $Id: luac.c,v 1.76 2018/06/19 01:32:02 lhf Exp $
-** print bytecodes
-** See Copyright Notice in lua.h
-*/
+ ** $Id: luac.c,v 1.76 2018/06/19 01:32:02 lhf Exp $
+ ** print bytecodes
+ ** See Copyright Notice in lua.h
+ */
 
 #include <ctype.h>
 #include <stdio.h>
 
-#define luac_c
-#define LUA_CORE
-
 #include "ldebug.h"
-#include "lobject.h"
 #include "lopcodes.h"
 
-#define VOID(p)		((const void*)(p))
+#define VOID(p)((const void *)(p))
 
-static void PrintString(const TString* ts)
-{
- const char* s=getstr(ts);
- size_t i,n=tsslen(ts);
- printf("%c",'"');
- for (i=0; i<n; i++)
- {
-  int c=(int)(unsigned char)s[i];
-  switch (c)
-  {
-   case '"':  printf("\\\""); break;
-   case '\\': printf("\\\\"); break;
-   case '\a': printf("\\a"); break;
-   case '\b': printf("\\b"); break;
-   case '\f': printf("\\f"); break;
-   case '\n': printf("\\n"); break;
-   case '\r': printf("\\r"); break;
-   case '\t': printf("\\t"); break;
-   case '\v': printf("\\v"); break;
-   default:	if (isprint(c))
-   			printf("%c",c);
-		else
-			printf("\\%03d",c);
-  }
- }
- printf("%c",'"');
-}
-
-static void PrintConstant(const Proto* f, int i)
-{
- const TValue* o=&f->k[i];
- switch (ttype(o))
- {
-  case LUA_TNIL:
-	printf("nil");
-	break;
-  case LUA_TBOOLEAN:
-	printf(bvalue(o) ? "true" : "false");
-	break;
-  case LUA_TNUMFLT:
-	{
-	char buff[100];
-	sprintf(buff,LUA_NUMBER_FMT,fltvalue(o));
-	printf("%s",buff);
-	if (buff[strspn(buff,"-0123456789")]=='\0') printf(".0");
-	break;
-	}
-  case LUA_TNUMINT:
-	printf(LUA_INTEGER_FMT,ivalue(o));
-	break;
-  case LUA_TSHRSTR: case LUA_TLNGSTR:
-	PrintString(tsvalue(o));
-	break;
-  default:				/* cannot happen */
-	printf("? type=%d",ttype(o));
-	break;
- }
-}
-
-#define UPVALNAME(x) ((f->upvalues[x].name) ? getstr(f->upvalues[x].name) : "-")
-#define MYK(x)		(-1-(x))
-
-static void PrintCode(const Proto* f)
-{
- const Instruction* code=f->code;
- int pc,n=f->sizecode;
- for (pc=0; pc<n; pc++)
- {
-  Instruction i=code[pc];
-  OpCode o=GET_OPCODE(i);
-  int a=GETARG_A(i);
-  int b=GETARG_B(i);
-  int c=GETARG_C(i);
-  int ax=GETARG_Ax(i);
-  int bx=GETARG_Bx(i);
-  int sbx=GETARG_sBx(i);
-  int line=getfuncline(f,pc);
-  printf("\t%d\t",pc+1);
-  if (line>0) printf("[%d]\t",line); else printf("[-]\t");
-  printf("%-9s\t",luaP_opnames[o]);
-  switch (getOpMode(o))
-  {
-   case iABC:
-    printf("%d",a);
-    if (getBMode(o)!=OpArgN) printf(" %d",ISK(b) ? (MYK(INDEXK(b))) : b);
-    if (getCMode(o)!=OpArgN) printf(" %d",ISK(c) ? (MYK(INDEXK(c))) : c);
-    break;
-   case iABx:
-    printf("%d",a);
-    if (getBMode(o)==OpArgK) printf(" %d",MYK(bx));
-    if (getBMode(o)==OpArgU) printf(" %d",bx);
-    break;
-   case iAsBx:
-    printf("%d %d",a,sbx);
-    break;
-   case iAx:
-    printf("%d",MYK(ax));
-    break;
-  }
-  switch (o)
-  {
-   case OP_LOADK:
-    printf("\t; "); PrintConstant(f,bx);
-    break;
-   case OP_GETUPVAL:
-   case OP_SETUPVAL:
-    printf("\t; %s",UPVALNAME(b));
-    break;
-   case OP_GETTABUP:
-    printf("\t; %s",UPVALNAME(b));
-    if (ISK(c)) { printf(" "); PrintConstant(f,INDEXK(c)); }
-    break;
-   case OP_SETTABUP:
-    printf("\t; %s",UPVALNAME(a));
-    if (ISK(b)) { printf(" "); PrintConstant(f,INDEXK(b)); }
-    if (ISK(c)) { printf(" "); PrintConstant(f,INDEXK(c)); }
-    break;
-   case OP_GETTABLE:
-   case OP_SELF:
-    if (ISK(c)) { printf("\t; "); PrintConstant(f,INDEXK(c)); }
-    break;
-   case OP_SETTABLE:
-   case OP_ADD:
-   case OP_SUB:
-   case OP_MUL:
-   case OP_MOD:
-   case OP_POW:
-   case OP_DIV:
-   case OP_IDIV:
-   case OP_BAND:
-   case OP_BOR:
-   case OP_BXOR:
-   case OP_SHL:
-   case OP_SHR:
-   case OP_EQ:
-   case OP_LT:
-   case OP_LE:
-    if (ISK(b) || ISK(c))
-    {
-     printf("\t; ");
-     if (ISK(b)) PrintConstant(f,INDEXK(b)); else printf("-");
-     printf(" ");
-     if (ISK(c)) PrintConstant(f,INDEXK(c)); else printf("-");
+static void PrintString(const TString *ts) {
+  const char *s = getstr(ts);
+  size_t i, n = tsslen(ts);
+  printf("%c", '"');
+  for (i = 0; i < n; i++) {
+    int c = (int)(unsigned char) s[i];
+    switch (c) {
+    case '"':  printf("\\\""); break;
+    case '\\': printf("\\\\"); break;
+    case '\a': printf("\\a");  break;
+    case '\b': printf("\\b");  break;
+    case '\f': printf("\\f");  break;
+    case '\n': printf("\\n");  break;
+    case '\r': printf("\\r");  break;
+    case '\t': printf("\\t");  break;
+    case '\v': printf("\\v");  break;
+    default:
+      printf(isprint(c) ? "%c" : "\\%03d", c);
     }
+  }
+  printf("%c", '"');
+}
+
+static void PrintConstant(const Proto *f, int i) {
+  const TValue *o = &f->k[i];
+  switch (ttype(o)) {
+  case LUA_TNIL:
+    printf("nil");
     break;
-   case OP_JMP:
-   case OP_FORLOOP:
-   case OP_FORPREP:
-   case OP_TFORLOOP:
-    printf("\t; to %d",sbx+pc+2);
+  case LUA_TBOOLEAN:
+    printf(bvalue(o) ? "true" : "false");
     break;
-   case OP_CLOSURE:
-    printf("\t; %p",VOID(f->p[bx]));
+  case LUA_TNUMFLT:
+    {
+      char buff[100];
+      sprintf(buff, LUA_NUMBER_FMT, fltvalue(o));
+      printf("%s", buff);
+      if (buff[strspn(buff, "-0123456789")] == '\0') printf(".0");
+      break;
+    }
+  case LUA_TNUMINT:
+    printf(LUA_INTEGER_FMT, ivalue(o));
     break;
-   case OP_SETLIST:
-    if (c==0) printf("\t; %d",(int)code[++pc]); else printf("\t; %d",c);
+  case LUA_TSHRSTR:
+  case LUA_TLNGSTR:
+    PrintString(tsvalue(o));
     break;
-   case OP_EXTRAARG:
-    printf("\t; "); PrintConstant(f,ax);
-    break;
-   default:
+  default:
+    /* cannot happen */
+    printf("? type=%d", ttype(o));
     break;
   }
-  printf("\n");
- }
 }
 
-#define SS(x)	((x==1)?"":"s")
-#define S(x)	(int)(x),SS(x)
+#define UPVALNAME(x)((f->upvalues[x].name) ? getstr(f->upvalues[x].name) : "-")
+#define MYK(x)(-1 - (x))
 
-static void PrintHeader(const Proto* f)
-{
- const char* s=f->source ? getstr(f->source) : "=?";
- if (*s=='@' || *s=='=')
-  s++;
- else if (*s==LUA_SIGNATURE[0])
-  s="(bstring)";
- else
-  s="(string)";
- printf("\n%s <%s:%d,%d> (%d instruction%s at %p)\n",
- 	(f->linedefined==0)?"main":"function",s,
-	f->linedefined,f->lastlinedefined,
-	S(f->sizecode),VOID(f));
- printf("%d%s param%s, %d slot%s, %d upvalue%s, ",
-	(int)(f->numparams),f->is_vararg?"+":"",SS(f->numparams),
-	S(f->maxstacksize),S(f->sizeupvalues));
- printf("%d local%s, %d constant%s, %d function%s\n",
-	S(f->sizelocvars),S(f->sizek),S(f->sizep));
+static void PrintCode(const Proto *f) {
+  const Instruction *code = f->code;
+  int pc, n = f->sizecode;
+  for (pc = 0; pc < n; pc++) {
+    Instruction i = code[pc];
+    OpCode o = GET_OPCODE(i);
+    int a = GETARG_A(i);
+    int b = GETARG_B(i);
+    int c = GETARG_C(i);
+    int ax = GETARG_Ax(i);
+    int bx = GETARG_Bx(i);
+    int sbx = GETARG_sBx(i);
+    int line = getfuncline(f, pc);
+    printf("\t%d\t", pc + 1);
+    if (line > 0) printf("[%d]\t", line);
+    else printf("[-]\t");
+    printf("%-9s\t", luaP_opnames[o]);
+    switch (getOpMode(o)) {
+    case iABC:
+      printf("%d", a);
+      if (getBMode(o) != OpArgN) printf(" %d", ISK(b) ? (MYK(INDEXK(b))) : b);
+      if (getCMode(o) != OpArgN) printf(" %d", ISK(c) ? (MYK(INDEXK(c))) : c);
+      break;
+    case iABx:
+      printf("%d", a);
+      if (getBMode(o) == OpArgK) printf(" %d", MYK(bx));
+      if (getBMode(o) == OpArgU) printf(" %d", bx);
+      break;
+    case iAsBx:
+      printf("%d %d", a, sbx);
+      break;
+    case iAx:
+      printf("%d", MYK(ax));
+      break;
+    }
+    switch (o) {
+    case OP_LOADK:
+      printf("\t; ");
+      PrintConstant(f, bx);
+      break;
+    case OP_GETUPVAL:
+    case OP_SETUPVAL:
+      printf("\t; %s", UPVALNAME(b));
+      break;
+    case OP_GETTABUP:
+      printf("\t; %s", UPVALNAME(b));
+      if (ISK(c)) {
+        printf(" ");
+        PrintConstant(f, INDEXK(c));
+      }
+      break;
+    case OP_SETTABUP:
+      printf("\t; %s", UPVALNAME(a));
+      if (ISK(b)) {
+        printf(" ");
+        PrintConstant(f, INDEXK(b));
+      }
+      if (ISK(c)) {
+        printf(" ");
+        PrintConstant(f, INDEXK(c));
+      }
+      break;
+    case OP_GETTABLE:
+    case OP_SELF:
+      if (ISK(c)) {
+        printf("\t; ");
+        PrintConstant(f, INDEXK(c));
+      }
+      break;
+    case OP_SETTABLE:
+    case OP_ADD:
+    case OP_SUB:
+    case OP_MUL:
+    case OP_MOD:
+    case OP_POW:
+    case OP_DIV:
+    case OP_IDIV:
+    case OP_BAND:
+    case OP_BOR:
+    case OP_BXOR:
+    case OP_SHL:
+    case OP_SHR:
+    case OP_EQ:
+    case OP_LT:
+    case OP_LE:
+      if (ISK(b) || ISK(c)) {
+        printf("\t; ");
+        if (ISK(b)) PrintConstant(f, INDEXK(b));
+        else printf("-");
+        printf(" ");
+        if (ISK(c)) PrintConstant(f, INDEXK(c));
+        else printf("-");
+      }
+      break;
+    case OP_JMP:
+    case OP_FORLOOP:
+    case OP_FORPREP:
+    case OP_TFORLOOP:
+      printf("\t; to %d", sbx + pc + 2);
+      break;
+    case OP_CLOSURE:
+      printf("\t; %p", VOID(f->p[bx]));
+      break;
+    case OP_SETLIST:
+      if (c == 0) printf("\t; %d", (int) code[++pc]);
+      else printf("\t; %d", c);
+      break;
+    case OP_EXTRAARG:
+      printf("\t; ");
+      PrintConstant(f, ax);
+      break;
+    default:
+      break;
+    }
+    printf("\n");
+  }
 }
 
-static void PrintDebug(const Proto* f)
-{
- int i,n;
- n=f->sizek;
- printf("constants (%d) for %p:\n",n,VOID(f));
- for (i=0; i<n; i++)
- {
-  printf("\t%d\t",i+1);
-  PrintConstant(f,i);
-  printf("\n");
- }
- n=f->sizelocvars;
- printf("locals (%d) for %p:\n",n,VOID(f));
- for (i=0; i<n; i++)
- {
-  printf("\t%d\t%s\t%d\t%d\n",
-  i,getstr(f->locvars[i].varname),f->locvars[i].startpc+1,f->locvars[i].endpc+1);
- }
- n=f->sizeupvalues;
- printf("upvalues (%d) for %p:\n",n,VOID(f));
- for (i=0; i<n; i++)
- {
-  printf("\t%d\t%s\t%d\t%d\n",
-  i,UPVALNAME(i),f->upvalues[i].instack,f->upvalues[i].idx);
- }
+#define SS(x)((x == 1) ? "" : "s")
+#define S(x)(int)(x), SS(x)
+
+static void PrintHeader(const Proto *f) {
+  const char *s = f->source ? getstr(f->source) : "=?";
+  if (*s == '@' || *s == '=')
+    s++;
+  else if (*s == LUA_SIGNATURE[0])
+    s = "(bstring)";
+  else
+    s = "(string)";
+  printf("\n%s <%s:%d,%d> (%d instruction%s at %p)\n",
+    (f->linedefined==0)?"main":"function", 
+    s, f->linedefined, f->lastlinedefined,
+    S(f->sizecode), VOID(f));
+  printf("%d%s param%s, %d slot%s, %d upvalue%s, ",
+    (int)(f->numparams), f->is_vararg ? "+" : "", SS(f->numparams),
+    S(f->maxstacksize), S(f->sizeupvalues));
+  printf("%d local%s, %d constant%s, %d function%s\n",
+    S(f->sizelocvars), S(f->sizek), S(f->sizep));
 }
 
-static void PrintFunction(const Proto* f, int full)
-{
- int i,n=f->sizep;
- PrintHeader(f);
- PrintCode(f);
- if (full) PrintDebug(f);
- for (i=0; i<n; i++) PrintFunction(f->p[i],full);
+static void PrintDebug(const Proto *f) {
+  int i, n;
+  n = f->sizek;
+  printf("constants (%d) for %p:\n", n, VOID(f));
+  for (i = 0; i < n; i++) {
+    printf("\t%d\t", i + 1);
+    PrintConstant(f, i);
+    printf("\n");
+  }
+  n = f->sizelocvars;
+  printf("locals (%d) for %p:\n", n, VOID(f));
+  for (i = 0; i < n; i++) {
+    printf("\t%d\t%s\t%d\t%d\n",
+      i, getstr(f->locvars[i].varname), 
+      f->locvars[i].startpc + 1, f->locvars[i].endpc + 1);
+  }
+  n = f->sizeupvalues;
+  printf("upvalues (%d) for %p:\n", n, VOID(f));
+  for (i = 0; i < n; i++) {
+    printf("\t%d\t%s\t%d\t%d\n",
+      i, UPVALNAME(i), f->upvalues[i].instack, f->upvalues[i].idx);
+  }
+}
+
+static void PrintFunction(const Proto *f, int full) {
+  int i, n = f->sizep;
+  PrintHeader(f);
+  PrintCode(f);
+  if (full) PrintDebug(f);
+  for (i = 0; i < n; i++) PrintFunction(f->p[i], full);
 }

--- a/app/lua53/lauxlib.c
+++ b/app/lua53/lauxlib.c
@@ -768,8 +768,9 @@ static int skipcomment (LoadF *lf, int *cp) {
 
 
 LUALIB_API int luaL_loadfilex (lua_State *L, const char *filename,
-                                             const char *mode) {
+                                             const char *mode, int multi) {
   LoadF lf;
+  (void)(multi);  ////  TODO
   int status, readstatus;
   int c;
   int fnameindex = lua_gettop(L) + 1;  /* index of filename on the stack */
@@ -1153,6 +1154,8 @@ static int errhandler_aux (lua_State *L) {
 ** to convert into an error message which it handles in a separate posted task.
 */
 static int errhandler (lua_State *L) {
+  if (!strncmp(lua_tostring(L, -1), "!LFS reload!", sizeof("!LFS reload!") - 1))
+    return 0;
   lua_getglobal(L, "debug");
   lua_getfield(L, -1, "traceback");
   if (lua_isfunction(L, -1)) {

--- a/app/lua53/lauxlib.h
+++ b/app/lua53/lauxlib.h
@@ -86,9 +86,9 @@ LUALIB_API void (luaL_unref) (lua_State *L, int t, int ref);
 LUALIB_API void (luaL_reref) (lua_State *L, int t, int *ref);
 
 LUALIB_API int (luaL_loadfilex) (lua_State *L, const char *filename,
-                                               const char *mode);
+                                               const char *mode, int multi);
 
-#define luaL_loadfile(L,f)	luaL_loadfilex(L,f,NULL)
+#define luaL_loadfile(L,f)	luaL_loadfilex(L,f,NULL, 0)
 
 LUALIB_API int (luaL_loadbufferx) (lua_State *L, const char *buff, size_t sz,
                                    const char *name, const char *mode);

--- a/app/lua53/lbaselib.c
+++ b/app/lua53/lbaselib.c
@@ -287,7 +287,7 @@ static int luaB_loadfile (lua_State *L) {
   const char *fname = luaL_optstring(L, 1, NULL);
   const char *mode = luaL_optstring(L, 2, NULL);
   int env = (!lua_isnone(L, 3) ? 3 : 0);  /* 'env' index or 0 if no 'env' */
-  int status = luaL_loadfilex(L, fname, mode);
+  int status = luaL_loadfilex(L, fname, mode, 0);
   return load_aux(L, status, env);
 }
 
@@ -460,6 +460,19 @@ static int luaB_unpack (lua_State *L) {
 }
 #endif
 
+#ifdef LUA_CROSS_COMPILER
+static int lfsreload (lua_State *L) {
+  lua_settop(L, 1);
+  luaL_lfsreload(L);
+  return 1;
+}
+
+static int lfsindex (lua_State *L) {
+  lua_settop(L, 1);
+  luaL_pushlfsmodule(L);
+  return 1;
+}
+#endif
 
 /*
 ** ESP builds use specific linker directives to marshal all the ROTable entries
@@ -507,6 +520,8 @@ LROT_ENTRIES_IN_SECTION(base_func, rotable)
 #endif
   LROT_FUNCENTRY(xpcall,         luaB_xpcall)
 #ifdef LUA_CROSS_COMPILER
+  LROT_FUNCENTRY(lfsreload,      lfsreload)
+  LROT_FUNCENTRY(lfsindex,       lfsindex)
 LROT_END(base_func, NULL, 0)
 #else
 LROT_BREAK(base_func)

--- a/app/lua53/ldblib.c
+++ b/app/lua53/ldblib.c
@@ -421,8 +421,11 @@ static int db_debug (lua_State *L) {
         strcmp(buffer, "cont\n") == 0)
       return 0;
     if (luaL_loadbuffer(L, buffer, strlen(buffer), "=(debug command)") ||
-        lua_pcall(L, 0, 0, 0))
+        lua_pcall(L, 0, 0, 0)) {
+      if (!strncmp(lua_tostring(L, -1),"!LFS ",5))
+        lua_error(L);
       lua_writestringerror("%s\n", lua_tostring(L, -1));
+    }
     lua_settop(L, 0);  /* remove eventual returns */
   }
 }

--- a/app/lua53/ldo.c
+++ b/app/lua53/ldo.c
@@ -768,19 +768,20 @@ static void checkmode (lua_State *L, const char *mode, const char *x) {
 
 
 static void f_parser (lua_State *L, void *ud) {
-  LClosure *cl;
   struct SParser *p = cast(struct SParser *, ud);
   int c = zgetc(p->z);  /* read first character */
   if (c == LUA_SIGNATURE[0]) {
     checkmode(L, p->mode, "binary");
-    cl = luaU_undump(L, p->z, p->name);
+    /* Successful undump returns a closure or array of closures at ToS */ 
+    luaU_undump(L, p->z, p->name); /* luaU_undump initialises upvals */
   }
   else {
+    LClosure *cl;
     checkmode(L, p->mode, "text");
     cl = luaY_parser(L, p->z, &p->buff, &p->dyd, p->name, c);
+    lua_assert(cl->nupvalues == cl->p->sizeupvalues);
+    luaF_initupvals(L, cl);
   }
-  lua_assert(cl->nupvalues == cl->p->sizeupvalues);
-  luaF_initupvals(L, cl);
 }
 
 

--- a/app/lua53/linit.c
+++ b/app/lua53/linit.c
@@ -7,7 +7,6 @@
 
 #define linit_c
 #define LUA_LIB
-#define LUA_CORE
 
 /*
 ** NodeMCU uses RO segment based static ROTable declarations for library
@@ -38,7 +37,6 @@
 #include "lua.h"
 #include "lualib.h"
 #include "lauxlib.h"
-#include "lstate.h"
 #include "lnodemcu.h"
 
 extern LROT_TABLE(strlib);

--- a/app/lua53/llex.c
+++ b/app/lua53/llex.c
@@ -82,7 +82,7 @@ void luaX_init (lua_State *L) {
 }
 
 /* Access method to expose luaX_fixed strings */
-const char *luaX_getstr (unsigned int i, int *extra) {
+const char *luaX_getstr (unsigned int i, lu_byte *extra) {
   if (i == sizeof(luaX_tokens)/sizeof(*luaX_tokens))
     return NULL;
   if (extra)

--- a/app/lua53/llex.h
+++ b/app/lua53/llex.h
@@ -73,7 +73,7 @@ typedef struct LexState {
 
 
 LUAI_FUNC void luaX_init (lua_State *L);
-LUAI_FUNC const char *luaX_getstr (unsigned int i, int *extra);
+LUAI_FUNC const char *luaX_getstr (unsigned int i, lu_byte *extra);
 LUAI_FUNC void luaX_setinput (lua_State *L, LexState *ls, ZIO *z,
                               TString *source, int firstchar);
 LUAI_FUNC TString *luaX_newstring (LexState *ls, const char *str, size_t l);

--- a/app/lua53/lnodemcu.c
+++ b/app/lua53/lnodemcu.c
@@ -12,26 +12,23 @@
 #include "lauxlib.h"
 #include "lfunc.h"
 #include "lgc.h"
+#include "llex.h"
 #include "lstring.h"
 #include "ltable.h"
 #include "ltm.h"
 #include "lnodemcu.h"
 #include "lundump.h"
+#include "lvm.h"
 #include "lzio.h"
 
-#ifdef LUA_USE_ESP
-#include "platform.h"
-#include "user_interface.h"
-#include "vfs.h"
-#endif
-
 /*
-** This is a mixed bag of NodeMCU additions broken into the following sections:
-**    *  POSIX vs VFS file API abstraction
-**    *  Emulate Platform_XXX() API
-**    *  ESP and HOST lua_debugbreak() test stubs
+** This is a mixed bag of NodeMCU-specfic additions that will probably need
+** modification for other IoT targets.  It is split into the following sections:
+**
+**    *  POSIX vs VFS file and Platform abstraction
 **    *  NodeMCU lua.h LUA_API extensions
 **    *  NodeMCU lauxlib.h LUALIB_API extensions
+**    *  ESP and HOST lua_debugbreak() test stubs
 **    *  NodeMCU bootstrap to set up and to reimage LFS resources
 **
 ** Just search down for //== or ==// to flip through the sections.
@@ -42,34 +39,38 @@
 #define byteoffset(p,q) ((int) cast(ptrdiff_t, (byteptr(p) - byteptr(q))))
 #define wordptr(p)      cast(lu_int32 *, p)
 #define wordoffset(p,q) (wordptr(p) - wordptr(q))
+#define max(a,b)        ((a)>(b) ? (a) : (b))
 
-
-//====================== Wrap POSIX and VFS file API =========================//
+//=============== POSIX vs VFS file and Platform abstraction =================//
+/*
+** The NodeMCU firmware includes a platform abstraction layer and a virtual
+** file system (VFS).  The following HOST and ESP variants define a set vfs
+** macros and emulation calls so the following source compiles and functions
+** on both platform variants.
+*/
 #ifdef LUA_USE_ESP
-int luaopen_file(lua_State *L);
+
+#include "platform.h"
+#include "user_interface.h"
+#include "vfs.h"
+
+#  define l_mountfs() vfs_mount("/FLASH", 0)
 #  define l_file(f)   int f
+#  define l_zero(f)   f = 0
 #  define l_open(f)   vfs_open(f, "r")
 #  define l_close(f)  vfs_close(f)
 #  define l_feof(f)   vfs_eof(f)
 #  define l_read(f,b) vfs_read(f, b, sizeof (b))
 #  define l_rewind(f) vfs_lseek(f, 0, VFS_SEEK_SET)
-#else
-#  define l_file(f)   FILE *f
-#  define l_open(n)   fopen(n,"rb")
-#  define l_close(f)  fclose(f)
-#  define l_feof(f)   feof(f)
-#  define l_read(f,b) fread(b, 1, sizeof (b), f)
-#  define l_rewind(f) rewind(f)
-#endif
 
-#ifdef LUA_USE_ESP
-
+int luaopen_file(lua_State *L);
 extern void dbg_printf(const char *fmt, ...);                // DEBUG
 #undef printf
 #define printf(...) dbg_printf(__VA_ARGS__)                  // DEBUG
 
 #define FLASH_PAGE_SIZE INTERNAL_FLASH_SECTOR_SIZE
-/* Erasing the LFS invalidates ESP instruction cache,  so doing a block 64Kb */
+
+/* Erasing the LFS invalidates ESP instruction cache,  so doing a block 32Kb */
 /* read is the simplest way to flush the icache, restoring cache coherency */
 #define flush_icache(F) \
   UNUSED(memcmp(F->addr, F->addr+(0x8000/sizeof(*F->addr)), 0x8000));
@@ -78,9 +79,17 @@ extern void dbg_printf(const char *fmt, ...);                // DEBUG
 
 #else // LUA_USE_HOST
 
-//==== Emulate Platform_XXX() API within host luac.cross -e environement =====//
-
 #include<stdio.h>                                             // DEBUG
+
+#  define l_mountfs()
+#  define l_file(f)   FILE *f
+#  define l_zero(f)   f = NULL
+#  define l_open(n)   fopen(n,"rb")
+#  define l_close(f)  fclose(f)
+#  define l_feof(f)   feof(f)
+#  define l_read(f,b) fread(b, 1, sizeof (b), f)
+#  define l_rewind(f) rewind(f)
+
 /*
 ** The ESP implementation use a platform_XXX() API to provide a level of
 ** H/W abstraction.  The following functions and macros emulate a subset
@@ -100,7 +109,6 @@ extern void dbg_printf(const char *fmt, ...);                // DEBUG
 ** images are solely intended for ESP execution and any attempt to execute
 ** them in a host execution environment will result in an address exception.
 */
-#define PLATFORM_RCR_FLASHLFS  4
 #define LFS_SIZE         0x40000
 #define FLASH_PAGE_SIZE   0x1000
 #define FLASH_BASE       0x90000           /* Some 'Random' but typical value */
@@ -109,29 +117,38 @@ extern void dbg_printf(const char *fmt, ...);                // DEBUG
 void         *LFSregion = NULL;
 static void  *LFSaddr   = NULL;
 static size_t LFSbase   = FLASH_BASE;
-extern char  *LFSimageName;
+
+extern int request_restart;
+#define system_restart()   request_restart = 1
 
 #ifdef __unix__
 /* On POSIX systems we can toggle the "Flash" write attribute */
-#include <sys/mman.h>
-#define aligned_malloc(a,n) posix_memalign(&a, FLASH_PAGE_SIZE, (n))
-#define unlockFlashWrite() mprotect(LFSaddr, LFS_SIZE, PROT_READ| PROT_WRITE)
-#define lockFlashWrite() mprotect(LFSaddr, LFS_SIZE, PROT_READ)
+# include <sys/mman.h>
+# define aligned_malloc(a,n) posix_memalign(&a, FLASH_PAGE_SIZE, (n))
+# define unlockFlashWrite() mprotect(LFSaddr, LFS_SIZE, PROT_READ| PROT_WRITE)
+# define lockFlashWrite() mprotect(LFSaddr, LFS_SIZE, PROT_READ)
 #else
-#define aligned_malloc(a,n) ((a = malloc(n)) == NULL)
-#define unlockFlashWrite()
-#define lockFlashWrite()
-#endif
+# define aligned_malloc(a,n) ((a = malloc(n)) == NULL)
+# define unlockFlashWrite()
+# define lockFlashWrite()
+#endif /* __unix__ defined */
 
-#define platform_rcr_write(id,rec,l) (128)
+#define PLATFORM_RCR_FLASHLFS  4
 #define platform_flash_phys2mapped(n) \
     ((ptrdiff_t)(((size_t)LFSaddr) - LFSbase) + (n))
 #define platform_flash_mapped2phys(n) \
     ((size_t)(n) - ((size_t)LFSaddr) + LFSbase)
 #define platform_flash_get_sector_of_address(n) ((n)>>12)
-#define platform_rcr_delete(id) LFSimageName = NULL
+
+/* Emulate platform RCR for FLASHLFS command */
+static int reboot_request = 0;
 #define platform_rcr_read(id,s) \
-  (*s = LFSimageName, (LFSimageName) ? strlen(LFSimageName) : ~0);
+  ((id)==PLATFORM_RCR_FLASHLFS && reboot_request) ? 0 : ~0
+#define platform_rcr_write(id,rec,l) \
+  reboot_request = ((id)==PLATFORM_RCR_FLASHLFS) ? 1 : reboot_request;
+
+#define platform_rcr_delete(id) \
+  reboot_request = ((id)==PLATFORM_RCR_FLASHLFS) ? 0 : reboot_request;
 
 void luaN_setabsolute(lu_int32 addr) {
   LFSaddr = cast(void *, cast(size_t, addr));
@@ -166,47 +183,69 @@ static void platform_s_flash_write(const void *from, lu_int32 to, lu_int32 len) 
   memcpy(byteptr(LFSregion) + (to-LFSbase), from, len);
   lockFlashWrite();
 }
-
 #define flush_icache(F)   /* not needed */
 
-#endif
+#endif /* LUA_USE_HOST or LUA_USE_ESP */
 
-//============= ESP and HOST lua_debugbreak() test stubs =====================//
 
-#ifdef DEVELOPMENT_USE_GDB
+//================= NodeMCU LFS header and FLash State types =================//
 /*
- * lua_debugbreak is a stub used by lua_assert() if DEVELOPMENT_USE_GDB is
- * defined.  On the ESP, instead of crashing out with an assert error, this hook
- * starts the GDB remote stub if not already running and then issues a break.
- * The rationale here is that when testing the developer might be using screen /
- * PuTTY to work interactively with the Lua Interpreter via UART0.  However if
- * an assert triggers, then there is the option to exit the interactive session
- * and start the Xtensa remote GDB which will then sync up with the remote GDB
- * client to allow forensics of the error.  On the host it is an stub which can
- * be set as a breakpoint in the gdb debugger.
- */
-extern void gdbstub_init(void);
-extern void gdbstub_redirect_output(int);
+** The LFSHeader uses offsets rather than pointers to avoid 32 vs 64 bit issues
+** during host compilation.  The offsets are in units of lu_int32's and NOT
+** size_t, though clearly any internal pointers are of the size_t for the
+** executing architectures: 4 or 8 byte.  Likewise recources are size_t aligned
+** so LFS regions built for 64-bit execution will have 4-byte alignment packing
+** between resources.
+*/
 
-LUALIB_API void lua_debugbreak(void) {
-#ifdef LUA_USE_HOST
-  /* allows debug backtrace analysis of assert fails */
-  lua_writestring(" lua_debugbreak ", sizeof(" lua_debugbreak ")-1);
-#else
-  static int repeat_entry = 0;
-  if  (repeat_entry == 0) {
-    dbg_printf("Start up the gdb stub if not already started\n");
-    gdbstub_init();
-    gdbstub_redirect_output(1);
-    repeat_entry = 1;
-  }
-  asm("break 0,0" ::);
-#endif
-}
-#endif
+typedef struct LFSHeader LFSHeader;
+
+struct LFSHeader{
+  lu_int32 flash_sig;     /* a standard fingerprint identifying an LFS image */
+  lu_int32 flash_size;    /* Size of LFS image in bytes */
+  lu_int32 seed;          /* random number seed used in LFS */
+  lu_int32 timestamp;     /* timestamp of LFS build */
+  lu_int32 nROuse;        /* number of elements in ROstrt */
+  lu_int32 nROsize;       /* size of ROstrt */
+  lu_int32 oROhash;       /* offset of TString ** ROstrt hash */
+  lu_int32 protoROTable;  /* offset of master ROTable for proto lookup */
+  lu_int32 protoHead;     /* offset of linked list of Protos in LFS */
+  lu_int32 shortTShead;   /* offset of linked list of short TStrings in LFS */
+  lu_int32 longTShead;    /* offset of linked list of long TStrings in LFS */
+  short    nFiles;
+  short    nPVs;
+};
+
+
+typedef struct LFSflashState {
+  lua_State  *L;
+  LoadState  *S;
+  int         pass;               /* 1 or 2; also 0 implies 1 */
+  lu_int32    seed;
+  LFSHeader  *hdr;
+  l_file(f);
+  lu_int32   *addr;
+  lu_int32    oNdx;               /* in size_t units */
+  lu_int32    oChunkNdx;          /* in size_t units */
+  lu_int32   *oBuff;              /* FLASH_PAGE_SIZE bytes */
+  lu_int32    inNdx;              /* in bytes */
+  lu_int32    addrPhys;
+  lu_int32    size;
+  lu_int32    allocmask;
+  stringtable ROstrt;
+  GCObject   *pLTShead;
+  const char **saveStr;
+  int         nSave;
+  lu_byte     inBuff[BUFSIZ];
+} LFSflashState;
+
 
 //===================== NodeMCU lua.h API extensions =========================//
-
+/*
+** These are LUA_CORE components that extend the core C API for Lua and publicly
+** declared in lua.h.  These are written using the same implementation rules as
+** lapi.c
+*/
 LUA_API int lua_freeheap (void) {
 #ifdef LUA_USE_HOST
   return MAX_INT;
@@ -218,7 +257,7 @@ LUA_API int lua_freeheap (void) {
 LUA_API int lua_pushstringsarray(lua_State *L, int opt) {
   stringtable *strt = NULL;
   int i, j = 1;
- 
+
   lua_lock(L);
   if (opt == 0)
     strt = &G(L)->strt;
@@ -258,6 +297,8 @@ LUA_API void lua_createrotable (lua_State *L, ROTable *t,
   int i, j;
   lu_byte flags = ~0;
   const char *plast = (char *)"_";
+
+  lua_lock(L);
   for (i = 0; e[i].key; i++) {
     if (e[i].key[0] == '_' && strcmp(e[i].key,plast)) {
       plast = e[i].key;
@@ -278,11 +319,12 @@ LUA_API void lua_createrotable (lua_State *L, ROTable *t,
   t->lsizenode = i;
   t->metatable = cast(Table *, mt);
   t->entry     = cast(ROTable_entry *, e);
+  lua_unlock(L);
 }
 
 LUA_API void lua_getlfsconfig (lua_State *L, int *config) {
   global_State *g = G(L);
-  LFSHeader *l = g->l_LFS;  
+  LFSHeader *l = g->l_LFS;
   if (!config)
     return;
   config[0] = (int) (size_t) l;                  /* LFS region mapped address */
@@ -291,12 +333,12 @@ LUA_API void lua_getlfsconfig (lua_State *L, int *config) {
   if (g->ROstrt.hash) {
     config[3] = l->flash_size;                             /* LFS region used */
     config[4] = l->timestamp;                         /* LFS region timestamp */
-  } else { 
+  } else {
     config[3] = config[4] = 0;
   }
 }
 
-LUA_API int  (lua_pushlfsindex) (lua_State *L) {
+LUA_API int  lua_pushlfsindex (lua_State *L) {
   lua_lock(L);
   setobj2n(L, L->top, &G(L)->LFStable);
   api_incr_top(L);
@@ -305,17 +347,17 @@ LUA_API int  (lua_pushlfsindex) (lua_State *L) {
 }
 
 /*
- * In Lua 5.3 luac.cross generates a top level Proto for each source file with 
+ * In Lua 5.3 luac.cross generates a top level Proto for each source file with
  * one upvalue that must be the set to the _ENV variable when its closure is
  * created, and as such this parallels some ldo.c processing.
  */
-LUA_API int  (lua_pushlfsfunc) (lua_State *L) {
+LUA_API int  lua_pushlfsfunc (lua_State *L) {
   lua_lock(L);
   const TValue *t = &G(L)->LFStable;
   if (ttisstring(L->top-1) && ttistable(t)) {
-    const TValue *v = luaH_getstr (hvalue(t), tsvalue(L->top-1));
-    if (ttislightuserdata(v)) {
-      Proto *f = pvalue(v);   /* The pvalue is a Proto * for the Lua function */
+    luaV_gettable(L, t, L->top-1, L->top-1);
+    if (ttislightuserdata(L->top-1)) {
+      Proto *f = pvalue(L->top-1);  /* The pvalue is Proto * for Lua function */
       LClosure *cl = luaF_newLclosure(L, f->sizeupvalues);
       setclLvalue(L, L->top-1, cl);
       luaF_initupvals(L, cl);
@@ -327,6 +369,7 @@ LUA_API int  (lua_pushlfsfunc) (lua_State *L) {
         setobj(L, val, luaH_getint(hvalue(&G(L)->l_registry), LUA_RIDX_GLOBALS));
         luaC_upvalbarrier(L, uv1);
       }
+      lua_unlock(L);
       return 1;
     }
   }
@@ -335,13 +378,62 @@ LUA_API int  (lua_pushlfsfunc) (lua_State *L) {
   return 0;
 }
 
+/*
+** The undump processing can throw errors on out-of-memory and file corruption
+** problems.  However, the historic convention is that any recoverable error
+** during flash reload is caught and returns an error message on failure. If
+** the validation pass is successful, then control is not returned but instead
+** the CPU is restarted and the second pass of the flash load occurs during
+** Lua startup.
+**
+** Hence the main load functionality is executed in a protected call.  See
+** LFS section below
+*/
+  static void protectedLFSload (lua_State *L, void *ud);
+  static void P1epilogue (LFSflashState *F);
+
+LUA_API void lua_lfsreload (lua_State *L) {
+  LFSflashState F = {0};
+  LFSHeader hdr;
+  memset(&hdr, ~0, sizeof(hdr));
+  F.L    = L;
+  F.size = G(L)->LFSsize;
+  F.hdr  = &hdr;
+  lua_lock(L);
+  int status = luaD_pcall(L, protectedLFSload, &F, savestack(L, L->top-2), 0);
+  if (status == LUA_OK) {
+    P1epilogue( &F);
+    luaM_freearray(L, F.saveStr, F.nSave);
+    system_restart();
+    luaO_pushfstring(L, "!LFS reload%s",
+                        (status == LUA_OK) ? "! start phase 2": " aborted" );
+    luaD_throw(L, LUA_ERRRUN);
+  } else { /* Cleanup resources and return error string as ToS */
+    if (F.f)
+      l_close(F.f);
+    luaM_freearray(L, F.saveStr, F.nSave);
+    luaU_closeLoadState(F.S, NULL, NULL);   /* TODO:  sysLFS chaining */
+  }
+  lua_unlock(L);
+}
+
 
 //================ NodeMCU lauxlib.h LUALIB_API extensions ===================//
 
 /*
- * Return an array of functions in LFS
- */
-LUALIB_API int  (luaL_pushlfsmodules) (lua_State *L) {
+** These are auxiliary library function extending those implemented in lauxlib.c
+** and publicly declared in lauxlib.h.  They are written using the same LUA_LIB
+** implementation rules as lauxlib.c and only access Lua core services through
+** the lua.h C API.  Whilst the core implementations are different for Lua 5.1
+** and Lua 5.3, the lauxlib.h is (with specific documented exceptions) is common
+** and this allow any application modules to be compiled against both versions.
+*/
+
+/*
+** Return an array of functions in LFS  TODO:
+*/
+// TODO: EXTEND to check for __index meta and add sysLFS entries <<<<<<<<
+LUALIB_API int luaL_pushlfsmodules (lua_State *L) {
   int i = 1;
   if (lua_pushlfsindex(L) == LUA_TNIL)
     return 0;                                 /* return nil if LFS not loaded */
@@ -357,12 +449,74 @@ LUALIB_API int  (luaL_pushlfsmodules) (lua_State *L) {
   return 1;
 }
 
-LUALIB_API int  (luaL_pushlfsdts) (lua_State *L) {
+
+LUALIB_API int  luaL_pushlfsdts (lua_State *L) {
   int config[5];
   lua_getlfsconfig(L, config);
   lua_pushinteger(L, config[4]);
   return 1;
 }
+
+LUALIB_API void luaL_lfsreload (lua_State *L) {
+ /*
+  * Do some type checking on files array then call lua_lfsreload() to drop
+  * into LUA_CORE and do the pass 1 load.
+  */
+  int gcrunning = lua_gc(L, LUA_GCISRUNNING, 0);
+  lua_settop(L, 1);
+  if (lua_isstring(L, 1)) { /* convert string entry to single entry array */
+    lua_createtable(L, 1, 0);
+    lua_insert(L, 1);
+    lua_rawseti(L, 1, 1);
+  }
+  luaL_argcheck(L, lua_type(L, 1) == LUA_TTABLE, 1, "Invalid file (list)");
+  int n = luaL_len(L, 1);
+  for (int i = 0; i < n; i++) {
+    luaL_argcheck(L, lua_rawgeti(L, 1, i+1) == LUA_TSTRING, 1, "Invalid file (list)");
+    lua_pop(L, 1);
+  }
+  lua_newtable(L);
+  lua_gc(L, LUA_GCSTOP, 0);
+  lua_lfsreload(L);     /* does not return if reload successful */
+  if (gcrunning)
+    lua_gc(L, LUA_GCRESTART, 0);
+}
+
+
+//============= ESP and HOST lua_debugbreak() test stubs =====================//
+
+#ifdef DEVELOPMENT_USE_GDB
+/*
+ * lua_debugbreak is a stub used by lua_assert() if DEVELOPMENT_USE_GDB is
+ * defined.  On the ESP, instead of crashing out with an assert error, this hook
+ * starts the GDB remote stub if not already running and then issues a break.
+ * The rationale here is that when testing the developer might be using screen /
+ * PuTTY to work interactively with the Lua Interpreter via UART0.  However if
+ * an assert triggers, then there is the option to exit the interactive session
+ * and start the Xtensa remote GDB which will then sync up with the remote GDB
+ * client to allow forensics of the error.  On the host it is an stub which can
+ * be set as a breakpoint in the gdb debugger.
+ */
+extern void gdbstub_init(void);
+extern void gdbstub_redirect_output(int);
+
+LUALIB_API void lua_debugbreak(void) {
+#ifdef LUA_USE_HOST
+  /* allows debug backtrace analysis of assert fails */
+  lua_writestring(" lua_debugbreak ", sizeof(" lua_debugbreak ")-1);
+#else
+  static int repeat_entry = 0;
+  if  (repeat_entry == 0) {
+    dbg_printf("Start up the gdb stub if not already started\n");
+    gdbstub_init();
+    gdbstub_redirect_output(1);
+    repeat_entry = 1;
+  }
+  asm("break 0,0" ::);
+#endif
+}
+#endif
+
 
 //======== NodeMCU bootstrap to set up and to reimage LFS resources ==========//
 /*
@@ -385,34 +539,36 @@ LUALIB_API int  (luaL_pushlfsdts) (lua_State *L) {
 */
 
 
-typedef struct LFSflashState {
-  lua_State  *L;
-  LFSHeader   hdr;
-  l_file(f);
-  const char *LFSfileName;
-  lu_int32   *addr;
-  lu_int32    oNdx;               /* in size_t units */
-  lu_int32    oChunkNdx;          /* in size_t units */
-  lu_int32   *oBuff;              /* FLASH_PAGE_SIZE bytes */
-  lu_byte    *inBuff;             /* FLASH_PAGE_SIZE bytes */
-  lu_int32    inNdx;              /* in bytes */
-  lu_int32    addrPhys;
-  lu_int32    size;
-  lu_int32    allocmask;
-  stringtable ROstrt;
-  GCObject   *pLTShead;
-} LFSflashState;
+#define FLASH_FORMAT_VERSION ( 3 << 8)
+#define FLASH_FORMAT_MASK    0xF00
+#define FLASH_SIG_PASS_MASK   0x0F
+/* PASS_1 Start through to Pass 2 Done can be updated using NAND overwrite */
+#define FLASH_SIG_PASS_1START 0x07
+#define FLASH_SIG_PASS_1DONE  0x03
+#define FLASH_SIG_PASS_2START 0x01
+#define FLASH_SIG_PASS_2DONE  0x00
+#define FLASH_SIG_B2_MASK     0x04
+#define FLASH_SIG_IN_PROGRESS 0x08
+#define FLASH_SIG  (0xfafaa050 | FLASH_FORMAT_VERSION)
+
+
 #define WORDSIZE sizeof(lu_int32)
+
 #define OSIZE (FLASH_PAGE_SIZE/WORDSIZE)
-#define ISIZE (FLASH_PAGE_SIZE)
 #ifdef LUA_USE_ESP
 #define ALIGN(F,n) (n + WORDSIZE - 1) / WORDSIZE;
 #else
 #define ALIGN(F,n) ((n + F->allocmask) & ~(F->allocmask)) / WORDSIZE;
 #endif
 
-/* This conforms to the ZIO lua_Reader spec, hence the L parameter */
-static const char *readF (lua_State *L, void *ud, size_t *size) {
+#define MODE_RAM      0   /* Loading into RAM */
+#define MODE_LFS      1   /* Loading into a locally executable LFS */
+#define MODE_LFSA     2   /* (Host only) Loading into a shadow ESP image */
+
+/*
+** ZIO lua_Reader spec, hence the L parameter
+*/
+static const char *ZIOreadF (lua_State *L, void *ud, size_t *size) {
   UNUSED(L);
   LFSflashState *F = cast(LFSflashState *, ud);
   if (F->inNdx > 0) {
@@ -425,60 +581,70 @@ static const char *readF (lua_State *L, void *ud, size_t *size) {
   return cast(const char *,F->inBuff);
 }
 
+/*
+** LFS routines for output to Flash ROM
+*/
 static void eraseLFS(LFSflashState *F) {
   lu_int32 i;
   printf("\nErasing LFS from flash addr 0x%06x", F->addrPhys);
-  unlockFlashWrite();
   for (i = 0; i < F->size; i += FLASH_PAGE_SIZE) {
     size_t *f = cast(size_t *, F->addr + i/sizeof(*f));
     lu_int32 s = platform_flash_get_sector_of_address(F->addrPhys + i);
     /* it is far faster not erasing if you don't need to */
-#ifdef LUA_USE_ESP
-    if (*f == ~0 && !memcmp(f, f + 1, FLASH_PAGE_SIZE - sizeof(*f)))
-      continue;
-#endif
-    platform_flash_erase_sector(s);
-    printf(".");
+    if (*f != ~0 || memcmp(f, f + 1, FLASH_PAGE_SIZE - sizeof(*f))) {
+      platform_flash_erase_sector(s); printf(".");
+    }
   }
   printf(" to 0x%06x\n", F->addrPhys + F->size-1);
   flush_icache(F);
-  lockFlashWrite();
 }
 
-LUAI_FUNC void  luaN_setFlash(void *F, unsigned int o) {
-  luaN_flushFlash(F);  /* flush the pending write buffer */
-  lua_assert((o & (WORDSIZE-1))==0);
-  cast(LFSflashState *,F)->oChunkNdx = o/WORDSIZE;
-}
-
-LUAI_FUNC void luaN_flushFlash(void *vF) {
+static void flushtoLFS(void *vF) {
   LFSflashState *F = cast(LFSflashState *, vF);
   lu_int32 start   = F->addrPhys + F->oChunkNdx*WORDSIZE;
   lu_int32 size    = F->oNdx * WORDSIZE;
   lua_assert(start + size < F->addrPhys + F->size); /* is write in bounds? */
-//printf("Flush Buf: %6x (%u)\n", F->oNdx, size);                      //DEBUG
   platform_s_flash_write(F->oBuff, start, size);
   F->oChunkNdx += F->oNdx;
   F->oNdx = 0;
 }
 
-LUAI_FUNC void *luaN_writeFlash(void *vF, const void *rec, size_t n) {
+static void setLFSaddr(void *F, unsigned int o) {
+  flushtoLFS(F);  /* flush the pending write buffer */
+  lua_assert((o & (WORDSIZE-1))==0);
+  cast(LFSflashState *,F)->oChunkNdx = o/WORDSIZE;
+}
+
+static void *writeLFSrec(void *vF, const void *rec, size_t n) {
   LFSflashState *F = cast(LFSflashState *, vF);
   lu_byte *p   = byteptr(F->addr + F->oChunkNdx + F->oNdx);
-//int i; printf("writing %4u bytes:", (lu_int32) n); for (i=0;i<n;i++){printf(" %02x", byteptr(rec)[i]);} printf("\n");
-  if (n==0)
+  if (rec == NULL) {  /* dummy call to flush or to get current flash position */
+    if (n == ~0) {
+      /* Flush Flash buffer and icache so LFS ROM reads are coherent */
+      flushtoLFS(F);
+      flush_icache(F);
+    }
     return p;
-  while (1) {
+  }
+#if 0  /* Host only debugging */
+/*DEBUG*/  /* catch any non-LFSregion address references */
+/*DEBUG*/ for (int i = 0; i < n/sizeof(void *); i++) {
+/*DEBUG*/   size_t w = cast(size_t *, rec)[i]; size_t w24 = w>>24;
+/*DEBUG*/   if (w24 == 0x555555 || w24 == 0x7fffff)
+/*DEBUG*/     lua_assert((size_t)(byteptr(LFSregion) - byteptr(w)) < 262144);
+/*DEBUG*/ }
+#endif
+   while (1) {
     int nw  = ALIGN(F, n);
     if (F->oNdx + nw > OSIZE) {
       /* record overflows the buffer so fill buffer, flush and repeat */
       int rem = OSIZE - F->oNdx;
       if (rem)
         memcpy(F->oBuff+F->oNdx, rec, rem * WORDSIZE);
-      rec     = cast(void *, cast(lu_int32 *, rec) + rem);
+      rec     = wordptr(rec) + rem;
       n      -= rem * WORDSIZE;
       F->oNdx = OSIZE;
-      luaN_flushFlash(F);
+      flushtoLFS(F);
     } else {
       /* append remaining record to buffer */
       F->oBuff[F->oNdx+nw-1] = 0;       /* ensure any trailing odd byte are 0 */
@@ -487,10 +653,213 @@ LUAI_FUNC void *luaN_writeFlash(void *vF, const void *rec, size_t n) {
       break;
     }
   }
-//int i; for (i=0;i<(rem * WORDSIZE); i++) {printf("%c%02x",i?' ':'.',*((lu_byte*)rec+i));}
-//for (i=0;i<n; i++) printf("%c%02x",i?' ':'.',*((lu_byte*)rec+i));
-//printf("\n");
   return p;
+}
+
+/*
+** Routines for constructing an LFS using the luaU undump functions to generate
+** the various Proto, TString records etc. along with LHS header.  Note that
+** the LFS is created in two passes
+**
+** -  Pass 1 is a dummy run to validate input file formats and computes the
+**    size of string table index. The actual writes are dummied and so leave
+**    the LFS region unchanged on error. This pass be executed within a normal
+**    Lua VM context, and is protected so errors are thrown and returned by the
+**    caller. If load scan completes successfully then a P1epilogue erases the
+**    LFS and writes out a set of TStrings for use by pass 2; the caller then
+**    restarts the CPU.
+**
+** -  Pass 2 reads these strings and uses this list to reload the LC files,
+**    this time writing the Protos, etc. to LFS.  The CPU is restarted a second
+**    time to load the new LFS.
+*/
+
+extern void _ResetHandler(void);
+
+static void P1epilogue (LFSflashState *F) {
+  UTString dummy;    /* UTString (not TString) for Test Suite compatibility */
+  memset(&dummy, ~0, sizeof(dummy));
+
+  eraseLFS(F);
+  setLFSaddr(F, 0);
+  F->hdr->flash_sig = FLASH_SIG | FLASH_SIG_PASS_1START; /* minimal Pass 1 header */
+  writeLFSrec(F, F->hdr, sizeof(*F->hdr));
+ /*
+  * Now dump out the list of files and the list of Proto names as a dummy
+  * TStrings header + the CString constant of the field.  The actual headers
+  * will be overwritten in pass 2 which works fine because of NAND writing
+  * rules.
+  */
+  for (int i = 0; i < F->nSave; i++) {
+    writeLFSrec(F, &dummy, sizeof(dummy));
+    writeLFSrec(F, F->saveStr[i], strlen(F->saveStr[i])+1);
+  }
+  writeLFSrec(F, NULL, ~0);  /* Flush to LFS and flush cache */
+
+  F->hdr->flash_sig = FLASH_SIG | FLASH_SIG_PASS_1DONE;
+  setLFSaddr(F, 0);
+  writeLFSrec(F, &F->hdr->flash_sig, sizeof(F->hdr->flash_sig));
+  writeLFSrec(F, NULL, ~0);  /* Flush to LFS and flush cache */
+  platform_rcr_write(PLATFORM_RCR_FLASHLFS, NULL, 0); /* do phase 2 on reboot */
+#ifdef LUA_USE_ESP
+ /*
+  * Things can get very problematic if the LFS has disappeared.  For example we
+  * can't guarantee that the caller hasn't invoked the reload as a protected 
+  * call from an LFS function than now no longer exists.  It's just unsafe to
+  * unroll the stack, so the easiest approach is to invoke the reset handler.
+  */
+  ets_delay_us(5000);
+  _ResetHandler();      /* Trigger reset; Phase 2 will be entered on reboot */
+#endif
+  G(F->L)->ROstrt.hash = NULL;    /* Disable any resolutions against ROstrt */
+}
+
+static Table *P2prologue (LFSflashState *F) {
+  int i,j,k,n;
+  LFSHeader *hdr = cast(LFSHeader *,F->addr);  /* The Pass 1 header in LFS */
+  lu_int32 *w = wordptr(hdr + 1);
+ /*
+  * Independent of the TStrings defined in the Protos themselves, the ROstrt
+  * always contains some standard TStrings to avoid their being creating in RAM:
+  * -  the names of the LC files to be loaded;
+  * -  the names of the Protos in the LFS;
+  * -  the fixed strings defined in ltm.c and llex.c.
+  *
+  * The first two sets have already been to LFS at the end of pass 1 but with
+  * dummy TStrings, so overwriting then works fine under NAND rules.
+  *
+  * The fixed strings are exposed through the luaX_getstr() and luaT_getstr()
+  * functions.
+  */
+  for (j = 0; luaX_getstr(j, NULL); j++) {}       /* count LEX strings */
+  for (k = 0; luaT_getstr(k); k++) {}   /* count TM strings */
+
+  n = max(max(j,k), hdr->nFiles+hdr->nPVs) + 1;
+  const char **p = cast(const char **, malloc(n * sizeof(*p) + j));
+  lu_byte *e = cast(lu_byte *, p + n);
+  lua_assert(p);
+
+  for (i = 0; i < hdr->nFiles+hdr->nPVs; i++) { /* add LFS P1 strings */
+    w += sizeof(UTString)/sizeof(lu_int32);
+    p[i] = cast(const char *, w);
+    while (*++w != ~0) {}
+  }
+  p[i] = NULL;
+  setLFSaddr(F, sizeof(*hdr));  /* skip over the LFS header */
+  luaU_addstrings(F->S, p, NULL);
+
+  /* Add now addressable files TStrings to Files table */
+  Table *t = luaH_new(F->L);
+  luaH_resize(F->L, t, hdr->nFiles, 0);
+  for (i = 0, w = wordptr(hdr + 1); i < hdr->nFiles; i++) {
+    TValue v;
+    TString *ts = cast(TString *, cast(UTString *, p[i]) - 1);
+    setsvalue(F->L, &v, ts);
+    luaH_setint(F->L, t, i + 1, &v);
+  }
+  for (i = 0; i<j; i++)
+    p[i] = luaX_getstr(i, e+i);
+  p[j] = NULL;
+  luaU_addstrings(F->S, p, e);
+
+  for (i = 0; i<k; i++)
+    p[i] = luaT_getstr(i);
+  p[k] = NULL;
+  luaU_addstrings(F->S, p, NULL);
+
+  free(p);
+  return t;
+}
+
+#define FOFFSET(p) wordoffset(p,F->addr)
+
+static void protectedLFSload (lua_State *L, void *ud) {
+  LFSflashState *F = cast(LFSflashState *, ud);
+
+  int pass = (F->pass == 2) ? 2 : 1;
+  unsigned int seed = 1234512345;  // << TODO: this needs Randomizing
+  Table *files, *pvs;
+  int    nFiles, nPVs;
+  ZIO z;
+
+#ifdef LUA_USE_HOST
+  int mode = MODE_LFS;             // << TODO: this needs acquiring for LFSA
+  /* Writes to LFS are size_t or lu_int32 aligned depending on mode */
+  F->allocmask = (mode == MODE_LFS) ? sizeof(size_t) - 1 : sizeof(lu_int32) - 1;
+#endif
+  if (pass == 1) {
+    pvs   = hvalue(L->top-1);
+    F->S  = luaU_LoadState(L, pvs, 0,  NULL, NULL, MODE_LFS, seed);
+    files = hvalue(L->top-2);
+  } else { /* pass == 2 */
+    l_mountfs();
+    pvs   = luaH_new(L);
+    F->S  = luaU_LoadState(L, pvs, F->ROstrt.size, &writeLFSrec, F, MODE_LFS, seed);
+    files = P2prologue(F);
+  }
+
+  nFiles = luaH_getn(files);
+  for (int i = 1; i <= nFiles; i++) {
+    const char *fname = svalue(luaH_getint(files, i));
+    char b1[1];
+
+#ifdef DEVELOPMENT_USE_GDB  /* For GDB builds, check for dummy break filename */
+    if (fname[0] == '!') {      /* "!1" and "!2" break on passes 1 and 2 resp */
+      if (fname[1] & pass) lua_debugbreak();
+    continue;
+    }
+#endif
+    F->f = fname ? l_open(fname) : 0;
+    if (!F->f || l_read(F->f, b1) != 1 || *b1 != LUA_SIGNATURE[0]) {
+      L->top -= 2;
+      luaO_pushfstring(F->L, "Invalid or missing file %s", fname);
+      luaD_throw(L, LUA_ERRRUN);
+    }
+    luaZ_init(L, &z, ZIOreadF, F);
+    luaU_undumpx(L, &z, fname, F->S);  /* This can throw an error */
+    l_close(F->f); l_zero(F->f);
+  }
+
+  if (pass == 1) {
+    luaU_data res;
+    int i;
+    TValue tv[2];
+    memset(&res, 0, sizeof(res));
+    setnilvalue(tv);                     /* loop around the pvs to count them */
+    for (nPVs = 0; luaH_next(F->L, pvs, tv); nPVs++) {}
+    F->saveStr = luaM_newvector(L, nFiles + nPVs, const char *);
+    F->nSave = nFiles + nPVs;
+    luaU_closeLoadState(F->S, &res, NULL);
+    F->hdr->seed = seed;
+    F->hdr->nROsize = 1 << luaO_ceillog2(res.tsTot+30);
+    F->hdr->nFiles = nFiles;
+    F->hdr->nPVs = nPVs;
+    lua_unlock(L);
+    lua_gc(L, LUA_GCRESTART, 0);
+    lua_gc(L, LUA_GCCOLLECT, 0);
+    lua_lock(L);
+    F->oBuff = calloc(OSIZE, sizeof(lu_int32));
+    F->addr  = wordptr(G(L)->l_LFS);
+    F->addrPhys = platform_flash_mapped2phys(cast(size_t, F->addr));
+   /*
+    * Some of the file and PV names might be in LFS so these need to be copied
+    * into RAM before the LFS can be erased and rewritten. The CPU is restarted
+    * on completion of this stage so memory leakage isn't really an issue.
+    */
+    for (i = 0; i < nFiles; i++)
+      F->saveStr[i] = svalue(luaH_getint(files, i+1));
+    setnilvalue(tv);
+    while(luaH_next(F->L, pvs, tv))
+      F->saveStr[i++] = svalue(tv);
+
+    for (i = 0; i < F->nSave; i++) {
+      if ((FOFFSET(F->saveStr[i])) < (F->size/sizeof(lu_int32))) {
+        /* Dup the string into RAM if it is LFS */
+        if ((F->saveStr[i] = strdup(F->saveStr[i])) == NULL)
+          luaD_throw(L, LUA_ERRMEM);
+      }
+    }
+  }
 }
 
 
@@ -499,128 +868,98 @@ LUAI_FUNC void *luaN_writeFlash(void *vF, const void *rec, size_t n) {
 */
 LUAI_FUNC int luaN_init (lua_State *L) {
   static LFSflashState *F = NULL;
-  int n;
   static LFSHeader *fh;
  /*
   * The first entry is called from lstate.c:f_luaopen() before modules
   * are initialised.  This is detected because F is NULL on first entry.
   */
   if (F == NULL) {
-    size_t Fsize = sizeof(LFSflashState) + OSIZE*WORDSIZE + ISIZE;
-    /* outlining the buffers just makes debugging easier.  Sorry */
-    F = calloc(Fsize, 1);
-    F->oBuff = wordptr(F + 1);
-    F->inBuff = byteptr(F->oBuff + OSIZE);
-    n = platform_rcr_read(PLATFORM_RCR_FLASHLFS, cast(void**, &F->LFSfileName));
-    F->size = platform_flash_get_partition (NODEMCU_LFS0_PARTITION, &F->addrPhys);
+    F = calloc(1, sizeof(LFSflashState));
+    F->L = L;
+     F->size = platform_flash_get_partition(NODEMCU_LFS0_PARTITION, &F->addrPhys);
     if (F->size) {
-      F->addr  = cast(lu_int32 *, platform_flash_phys2mapped(F->addrPhys));
-      fh = cast(LFSHeader *, F->addr);
-      if (n < 0) {
-        global_State *g = G(L);
-        g->LFSsize     = F->size;
-        g->l_LFS       = fh;
+      global_State *g = G(L);
+      g->LFSsize      = F->size;
+      F->addr         = wordptr(platform_flash_phys2mapped(F->addrPhys));
+      fh              = cast(LFSHeader *, F->addr);
+     /* Pass 2 requires RCR flag and Pass 1 completed, else normal startup */
+      if ((fh->flash_sig != (FLASH_SIG | FLASH_SIG_PASS_1DONE)) ||
+          (platform_rcr_read(PLATFORM_RCR_FLASHLFS, NULL) == ~0)) {
       /* Set up LFS hooks on normal Entry */
-        if (fh->flash_sig   == FLASH_SIG) {
+        g->l_LFS       = fh;
+        if (fh->flash_sig == FLASH_SIG) {
           g->seed        = fh->seed;
           g->ROstrt.hash = cast(TString **, F->addr + fh->oROhash);
           g->ROstrt.nuse = fh->nROuse ;
           g->ROstrt.size = fh->nROsize;
           sethvalue(L, &g->LFStable, cast(Table *, F->addr + fh->protoROTable));
-           lua_writestringerror("LFS image %s\n", "loaded");
-        } else if ((fh->flash_sig != 0 && fh->flash_sig != ~0)) {
+          lua_writestringerror("LFS image %s\n", "loaded");
+        } else if (fh->flash_sig != ~0) {
+lua_debugbreak();
           lua_writestringerror("LFS image %s\n", "corrupted.");
           eraseLFS(F);
         }
-      }
+      } else {
+        F->pass = 2;           /* flash LFS command read and pass 1 completed */
+     }
     }
     return 0;
-  } else {  /* hook 2 called from protected pmain, so can throw errors. */
+  } else {
     int status = 0;
-    if (F->LFSfileName) {                         /* hook == 2 LFS image load */
-      ZIO z;
-     /*
-      * To avoid reboot loops, the load is only attempted once, so we
-      * always deleted the RCR record if we enter this path. Also note
-      * that this load process can throw errors and if so these are
-      * caught by the parent function in lua.c
-      */
-#ifdef DEVELOPMENT_USE_GDB
-/* For GDB builds,  prefixing the filename with ! forces a break in the hook */
-      if (F->LFSfileName[0] == '!') {
-        lua_debugbreak();
-        F->LFSfileName++;
-      }
-#endif
+   /*
+    * Hook 2 called from protected pmain, so can throw errors. (Actually from
+    * luaL_openlibs() within pmain after opening the base, package and string
+    * libraries, that is before loading any application libraries.  LFS pass 2
+    * always throws an error forcing a restart.  Note that the RCR record is
+    * deleted on entering this path, so the load is only attempted once/
+    */
+    if (F->pass == 2) {                           /* hook == 2 LFS image load */
+      LFSHeader fh2;
+      luaU_data res;
       platform_rcr_delete(PLATFORM_RCR_FLASHLFS);
-#ifdef LUA_USE_ESP
-     luaopen_file(L);
-#endif
-      if (!(F->f = l_open(F->LFSfileName))) {
-        free(F);
-        return luaL_error(L, "cannot open %s", F->LFSfileName);
-      }
-      eraseLFS(F);
-      luaZ_init(L, &z, readF, F);
+//*DEBUG*/ lua_debugbreak();
+      F->oBuff = calloc(OSIZE, WORDSIZE);
+      F->ROstrt.size = fh->nROsize;
       lua_lock(L);
-#ifdef LUA_USE_HOST
-      F->allocmask = (LFSaddr == LFSregion) ? sizeof(size_t) - 1 :
-                                              sizeof(lu_int32) - 1;
-      status = luaU_undumpLFS(L, &z, LFSaddr != LFSregion);
-#else
-      status = luaU_undumpLFS(L, &z, 0);
-#endif
-      lua_unlock(L);
-      l_close(F->f);
-      free(F);
-      F = NULL;
-      if (status == LUA_OK)
-        lua_pushstring(L, "!LFSrestart!");                /* Signal a restart */
-      lua_error(L);                          /* throw error / restart request */
+      fh2.flash_sig =  FLASH_SIG | FLASH_SIG_PASS_2START; /* minimal Pass 1 header */
+      writeLFSrec(F, &fh2.flash_sig, sizeof(fh2.flash_sig));
+
+      int status = luaD_pcall(L, protectedLFSload, F, savestack(L, L->top-2), 0);
+      luaU_closeLoadState(F->S, &res, NULL);
+      if (status == LUA_OK) {
+        /* Create final header and write to LFS */
+        fh2.flash_sig    = FLASH_SIG;
+        fh2.seed         = fh->seed;
+        fh2.timestamp    = 0;
+        fh2.nROuse       = res.ROstrt.nuse;
+        fh2.nROsize      = res.ROstrt.size;
+        fh2.oROhash      = FOFFSET(res.ROstrt.hash);
+        fh2.protoROTable = FOFFSET(res.protoROTable);
+        fh2.protoHead    = FOFFSET(res.protoHead);
+        fh2.shortTShead  = FOFFSET(res.shortTShead);
+        fh2.longTShead   = FOFFSET(res.longTShead);
+        fh2.nFiles       = fh->nFiles;
+        fh2.nPVs         = fh->nPVs;
+        fh2.flash_size   = byteoffset(writeLFSrec(F, NULL, 0), F->addr);
+        setLFSaddr(F, 0);
+        writeLFSrec(F, &fh2, sizeof(fh2));
+        flushtoLFS(F);
+      }
+      if (F->f) l_close(F->f);
+      free(F->oBuff); F->oBuff = NULL;
+      free(F); F = NULL;
+      system_restart();
+      luaO_pushfstring(L, (status == LUA_OK) ? "!LFS restart" :
+                                               "!LFS phase 2 aborted");
+      luaD_throw(L, LUA_ERRRUN);
     } else {                                     /* hook == 2, Normal startup */
-      free(F);
-      F = NULL;
+      free(F); F = NULL;
     }
     return status;
   }
 }
 
-
 // =============================================================================
-#define getfield(L,t,f) \
-  lua_getglobal(L, #t); luaL_getmetafield( L, 1, #f ); lua_remove(L, -2);
-
-LUALIB_API void luaL_lfsreload (lua_State *L) {
-#ifdef LUA_USE_ESP
-  int n = 0;
-  size_t l;
-  int off = 0;
-  const char *img = lua_tolstring(L, 1, &l);
-#ifdef DEVELOPMENT_USE_GDB
-  if (*img == '!')   /* For GDB builds, any leading ! is ignored for checking */
-    off = 1;         /* existence. This forces a debug break in the init hook */
-#endif
-  lua_settop(L, 1);
-  lua_getglobal(L, "file");
-  if (lua_isnil(L, 2)) {
-    lua_pushstring(L, "No file system mounted");
-    return;
-  }
-  lua_getfield(L, 2, "exists");
-  lua_pushstring(L, img + off);
-  lua_call(L, 1, 1);
-  if (G(L)->LFSsize == 0 || lua_toboolean(L, -1) == 0) {
-    lua_pushstring(L, "No LFS partition allocated");
-    return;
-  }
-  n = platform_rcr_write(PLATFORM_RCR_FLASHLFS, img, l+1);/* incl trailing \0 */
-  if (n>0) {
-    system_restart();
-    luaL_error(L, "system restarting");
-  }
-#endif
-}
-
 
 #ifdef LUA_USE_ESP
 extern void lua_main(void);

--- a/app/lua53/lnodemcu.h
+++ b/app/lua53/lnodemcu.h
@@ -68,15 +68,17 @@
 
 #define LUA_MAX_ROTABLE_NAME 32  /* Maximum length of a rotable name and of a string key*/
 
-#ifdef LUA_CORE
+#if defined(LUA_CORE) || defined(LUA_LIB)
 
 #include "lstate.h"
 #include "lzio.h"
 
 LUAI_FUNC int luaN_init (lua_State *L);
-LUAI_FUNC void *luaN_writeFlash (void *data, const void *rec, size_t n);
-LUAI_FUNC void luaN_flushFlash (void *);
-LUAI_FUNC void luaN_setFlash (void *, unsigned int o);
+
+#ifdef LUA_USE_HOST
+extern void *LFSregion;
+LUAI_FUNC void luaN_setabsolute(lu_int32 addr);
+#endif
 
 #endif
 #endif

--- a/app/lua53/lstate.h
+++ b/app/lua53/lstate.h
@@ -143,7 +143,7 @@ typedef KeyCache KeyCacheLine[KEYCACHE_M];
 ** 'global state', shared by all threads of this state
 */
 
-typedef struct FlashHeader LFSHeader;
+typedef struct LFSHeader LFSHeader;
 
 typedef struct global_State {
   lua_Alloc frealloc;  /* function to reallocate memory */

--- a/app/lua53/lua.c
+++ b/app/lua53/lua.c
@@ -198,6 +198,8 @@ static void dojob (lua_State *L) {
       status = docall(L, 0);
     /* print any returned results or error message */
     if (status && !lua_isnil(L, -1)) {
+      if (!strncmp(lua_tostring(L, -1), "!LFS reload!", sizeof("!LFS reload!") - 1))
+        return;
       lua_pushliteral(L, "Lua error: ");
       lua_insert(L , -2);
     }

--- a/app/lua53/luaconf.h
+++ b/app/lua53/luaconf.h
@@ -41,6 +41,9 @@
 #else
 # define LUA_USE_HOST
 # define LUA_CROSS_COMPILER
+# if INTPTR_MAX > INT32_MAX
+#  define LUA_USE_HOST64
+# endif
 #endif
 
 #if !defined(LUA_USE_C89) && defined(_WIN32) && !defined(_WIN32_WCE)

--- a/app/lua53/lundump.c
+++ b/app/lua53/lundump.c
@@ -1,637 +1,876 @@
-/*---
-** $Id: lundump.c,v 2.44.1.1 2017/04/19 17:20:42 roberto Exp $
-** load precompiled Lua chunks
-** See Copyright Notice in lua.h
-*/
-#define lundump_c
-#define LUA_CORE
-#include "lprefix.h"
-#include <string.h>
-#include "lua.h"
-#include "ldebug.h"
-#include "ldo.h"
-#include "lfunc.h"
-#include "llex.h"
-#include "lmem.h"
-#include "lnodemcu.h"
-#include "lobject.h"
-#include "lstring.h"
-#include "lundump.h"
-#include "lzio.h"
 /*
-** Unlike the standard Lua version of lundump.c, this NodeMCU version must be
-** able to store the dumped Protos into one of two targets:
-**
-** (A)  RAM-based heap.  This in the same way as standard Lua, where the
-**      Proto data structures can be created by direct in memory addressing,
-**      with any references complying with Lua GC assumptions, so that all
-**      storage can be collected in the case of a thrown error.
-**
-** (B)  Flash programmable ROM memory. This can only be written to serially,
-**      using a write API, it can be subsequently but accessed and directly
-**      addressable through a memory-mapped address window after cache flush.
-**
-** Mode (B) also know as LFS (Lua FLash Store) enables running Lua apps
-** on small-memory IoT devices which support programmable flash storage such
-** as the ESP8266 SoC. In the case of this chip, the usable RAM heap is
-** roughly 45Kb, so the ability to store an extra 128Kb, say, of program into
-** LFS can materially increase the size of application that can be executed
-** and leave most of the heap for true R/W application data.
-**
-** The changes to this source file enable the addition of LFS mode. In mode B,
-** the resources aren't allocated in RAM but are written to Flash using the
-** write API which returns the corresponding Flash read address is returned;
-** also data can't be immediately read back using these addresses because of
-** cache staleness.
-**
-** Handling the Proto record has been reordered to avoid interleaved resource
-** writes in mode (B), with the f->k being cached in RAM and the Proto
-** hierarchies walked bottom-up in a way that still maintains GC compliance
-** conformance for mode (A).  This no-interleave constraint also complicates
-** the writing of TString resources into flash, so the flashing process
-** circumvents this issue for LFS loads by header by taking two passes to dump
-** the hierarchy. The first dumps all strings that needed to load the Protos,
-** with the subsequent Proto loads use an index to any TString references.
-** This enables all strings to be loaded into an LFS-based ROstrt before
-** starting to load the Protos.
-**
-** Note that this module and ldump.c are compiled into both the ESP firmware
-** and a host-based luac cross compiler.  LFS dump is currently only supported
-** in the compiler, but both the LFS and standard loads are supported in both
-** the target (lua.c) and the host (luac.cross -e)environments. Both
-** environments are built with the same integer and float formats (e.g. 32 bit,
-** 32-bit IEEE).
-**
-** Dumps can either be loaded into RAM or LFS depending on the load format. An
-** extra complication is that luac.cross supports two LFS modes, with the
-** first loading into an host process address space and using host 32 or 64
-** bit address references.  The second uses shadow ESP 32 bit addresses to
-** create an absolute binary image for direct provisioning of ESP images.
+** $Id: ldump.c,v 2.37.1.1 2017/04/19 17:20:42 roberto Exp $
+** save precompiled Lua chunks
+** See Copyright Notice in lua.h
+
+This NodeMCU version of undump is a reimplementation of the standard Lua
+version,and significantly extends the standard functionality by supporting
+a number of load targets:
+
+  (A)  RAM heap space. This is essentially standard Lua functionality where
+       the Proto data structures and TStrings are created directly in RAM and
+       comply with Lua GC assumptions, so the GC will collect unused storage
+       in the case of a thrown error.
+
+  (B)  LFS memory. This can be accessed programmatically during VM execution
+       as ROM, and so in not writeable in this mode; however it can updated
+       through a block erase + a serial write API.
+
+Lua Flash Store (LFS) is design to support running Lua applications on IoT-
+class processors which typically employ a modified Hardward architecture with
+limited RAM and the ability to execute code and fetch constant data from flash
+memory.  It is described in detail in a separate LFS whitepaper.
+
+In the case of mode B, the load must support sub-variants:
+
+-  Multi target execution. Though this LFS functionality is primarily aimed at
+   IoT-class chipsets, it must also be capable of being executed on a standard
+   CPU architecture (mainly for testing purposes).
+
+-  Cross-target support.  Here the load is executed on, say, a PC-class. host
+   CPU, but the generated LFS is designed to be loaded onto an IoT firmware
+   build as part of provisioning.  Here any generated address references relate
+   to the target environment, and are therefore invalid if executed in the host
+   context.  This is further complicated in the case of 64-bit hosts, where any
+   structures must be repacked to reflect the 32-bit target architecture.
+
+-  Multi-pass loading. Because of IoT RAM limitations during IoT, LFS loading
+   is done using two passes:
+
+   -  The first validates that the file formats and computes some sizing
+      parameters. The actual writes are dummies and so leave the LFS region
+      unchanged. This can be executed within a normal Lua VM context. The
+      process is protected so errors are returned to the caller.
+
+   -  The second pass executes within the clean environment of the Lua RTS
+      startup, that is before any library modules have been initialised or
+      applications code executed.  Any errors will result in start-up being
+      aborted.
+
+A single largely unified source code base is used to support these two modes
+and all sub-variants. It's scope is the creation of the Proto and TStrings
+records and the other Lua internal data structures used to represent the Proto
+hierarchies to be loaded.
+
+The actual details of the LFS format are left to the calling function, and
+likewise the implementation of the erase and serial R/W API are encapsulated
+in a CB function provided by the caller.
+
+The dump and undump functions now support both single top level function (TLF)
+and multi-TLF dump streams.
+
+All of this code complies with LUA_CODE module coding conventions.
+
+LFS encoding add some extra design constraints:
+
+-  It uses a simple serial allocation scheme where each separate resource (for
+   example a Proto record or TString) is written atomically to the LFS at the
+   next available location. Since these writes are both serial and atomic, all
+   address references must be backward and therefore well determined when
+   writing each object. This isn't the case with the standard Lua dump format,
+   but this has been achieved with some simple reordering.
+
+-  Proto records and the ROstrt reference other record hierarchies and these
+   must therefore be cached in RAM in a way that can be collected on thrown
+   error (for example allocation of heap resources can throw an out-of-memory
+   (E:M) error). In RAM mode, all discarded resources are GC compliant and are
+   recovered by normal Lua GC. For LFS modes, stack allocations are used where
+   practical (e.g. Protos); other resources such as the ROstrt are maintained
+   in the LoadState structure and these resources can be freed outside the
+   protected call to the loader.
+
+-  Resources written to LFS cannot then be reliably read programmatically until
+   a cache flush has been carried out to ensure read coherence.  The actual
+   flush call is encapsulated the the flash write CB, but the code logic must
+   honour this before-and-after dependency.
+
+-  The ROstrt uses chain linking to handle hash table overflow; TStrings with
+   the same hash index are chained. The chains are dependent on ROstrt size,
+   so the hash must be statically sized because TString links can't be updated
+   in LFS modes. A two-pass approach circumvents this issue: the first pass
+   undump computes the ROstrt size, the second pass using this calculated
+   size to build the ROstrt with the TString records using this fixed size.
+
+-  LFS supports the assembly of multiple load files into a single LFS region.
+   The details of this assembly are largely deferred to the calling process,
+   with this module limiting its scope to the output of the record hierarchies.
+   However the API has been extended to separate out the new and close state
+   calls as bookends to multiple undump calls, one per load stream.
 */
+
+#define ldump_c
+#define LUA_CORE
+
+#include "lprefix.h"
+
+#include <stddef.h>
+#include <string.h>
+#include <alloca.h>
+#include <stdio.h> /*DEBUG*/
+
+#include "lua.h"
+#include "lapi.h"
+#include "lgc.h"
+#include "lmem.h"
+#include "lobject.h"
+#include "lfunc.h"
+#include "lstate.h"
+#include "lstring.h"
+#include "ltable.h"
+#include "lundump.h"
+#include "lvm.h"
+
+static TString *LFS_newlstr (LoadState *S, const char *s, size_t l, int extra);
+static ROTable *LFS_createIndex (LoadState *S, const ROTable *indexMeta);
+static void     LFS_flushcache (LoadState *S);
+static Proto   *LoadFunction (LoadState *S, TString *psource);
+
+typedef struct LoadState {
+/* Set by initialisation */
+  lua_State   *L;               /* lua_State for this undump */
+  luaU_Writer  flashWriter;     /* Parameter usage slightly different */
+  void        *flashWriterData; /* from standard writer; see lundump.h */
+  int          mode;            /* Load mode: one of RAM, LFS or LFSA */
+  int          pass;            /* Set for LFS modes 1 or 2 */
+  unsigned int seed;
+/* Set by undump call */
+  ZIO*         Z;           /* ZIO block for source reader */
+  const char  *name;        /* name of undump for error reporting */
+  int          strip;       /* Debug strip level = 0, 1 or 2 */
+/* Parameters to be exported on close */
+  Table       *t;           /* Table caching future contents of LFS ROTable */
+  int          nt;          /* Number of entries in t */
+  Proto       *protoHead;   /* (LFS) Head of Proto linked list */
+  TString     *shortTShead; /* (LFS) Head of short TS linked list */
+  TString     *longTShead;  /* (LFS) Head of long TS linked list */
+  TString     *rTSbarrier;  /* (LFS) TS below this are safe to read */
+  stringtable  ROstrt;      /* RAM-cached version of ROstrt used for LFS load */
+/* Internal State */
+  unsigned int crc;       /* CRC of file content read so far */
+  TString    **ts;        /* ts[0:tsLen] is the vector of TStrings referenced */
+  int          tsLen;     /* in the current file being undumped. ts[0] = NULL */
+  int          tsTot;     /* Sum of tsLen counts */
+  char        *str;       /* Scratch string buffer uses to build LFS TStrings */
+  size_t       strLen;    /* maximum string length in current module */
+  struct protomap {
+  TString     *name;
+  Proto       *p;
+  }           *pv;        /* Named Protos in current input stream */
+  int          pvLen;     /* Length of pv */
+  struct strtlink {
+  TString     *nfTShead;
+  TString     *rTShead;
+ }            *map;       /* used to resolve cross image TString duplications */
+  int        mapNdx;      /* growvector index and doubling size */
+  int        mapLen;
+  void      *dummyROaddr;
+#ifdef LUA_USE_HOST
+  Table      *ROstrtMap;  /* LFSA mode map of string -> RO TString addr */
+#endif
+} LoadState;
+
 #define MODE_RAM      0   /* Loading into RAM */
 #define MODE_LFS      1   /* Loading into a locally executable LFS */
 #define MODE_LFSA     2   /* (Host only) Loading into a shadow ESP image */
-typedef struct {
-  lua_State  *L;           /* cache L to drop parameter list */
-  ZIO        *Z;           /* ZIO context */
-  const char *name;        /* Filename of the LFS image being loaded */
-  LFSHeader  *fh;          /* LFS flash header block */
-  void       *startLFS;    /* Start address of LFS region */
-  TString   **TS;          /* List of TStrings being used in the image */
-  lu_int32    TSlen;       /* Length of the same */
-  lu_int32    TSndx;       /* Index into the same */
-  lu_int32    TSnFixed;    /* Number of "fixed" TS */
-  char        *buff;       /* Working buffer for assembling a TString */
-  lu_int32    buffLen;     /* Maximum length of TS used in the image */
-  TString   **list;        /* TS list used to index the ROstrt */
-  lu_int32    listLen;     /* Length of the same */
-  Proto     **pv;          /* List of Protos in LFS */
-  lu_int32    pvLen;       /* Length of the same */
-  GCObject   *protogc;     /* LFS proto linked list */
-  lu_byte     useStrRefs;  /* Flag if set then TStings are a index into TS */
-  lu_byte     mode;        /* Either LFS or RAM */
-} LoadState;
+#define inRAM(S) ((S)->mode == MODE_RAM)
+
 static l_noret error(LoadState *S, const char *why) {
-  luaO_pushfstring(S->L, "%s: %s precompiled chunk", S->name, why);
+  luaO_pushfstring(S->L, "%s (compiled): %s", S->name, why);
   luaD_throw(S->L, LUA_ERRSYNTAX);
 }
-#define wordptr(p)      cast(lu_int32 *, p)
-#define byteptr(p)      cast(lu_byte *, p)
-#define wordoffset(p,q) (wordptr(p) - wordptr(q))
-#define FHaddr(S,t,f)   cast(t, wordptr(S->startLFS) + (f))
-#define FHoffset(S,o)   wordoffset((o), S->startLFS)
-#define NewVector(S, n, t)  cast(t *,NewVector_(S, n, sizeof(t)))
-#define StoreGetPos(S) luaN_writeFlash((S)->Z->data, NULL, 0)
-static void *NewVector_(LoadState *S, int n, size_t s) {
-  void *v;
-  if (S->mode == MODE_RAM) {
-    v = luaM_reallocv(S->L, NULL, 0, n, s);
-    memset (v, 0, n*s);
-  } else {
-    v = StoreGetPos(S);
-  }
-  return v;
-}
-static void *Store_(LoadState *S, void *a, int ndx, const void *e, size_t s
-#ifdef LUA_USE_HOST
-                    , const char *format
-#endif
-                    ) {
-  if (S->mode == MODE_RAM) {
-    lu_byte *p = byteptr(a) + ndx*s;
-    if (p != byteptr(e))
-      memcpy(p, e, s);
-    return p;
-  }
-#ifdef LUA_USE_HOST
-  else if (S->mode == MODE_LFSA && format) {             /* do a repack move */
-    void *p = StoreGetPos(S);
-    const char *f = format;
-    int o;
-    for (o = 0; *f; o++, f++ ) {
-      luaN_writeFlash(S->Z->data, wordptr(e)+o, sizeof(lu_int32));
-      if (*f == 'A' || *f == 'W') /* Addr or word followed by alignment fill */
-        o++;
-    }
-    lua_assert(o*sizeof(lu_int32) == s);
-    return p;
-  }
-#endif
-  /* mode == LFS or 32bit  build */
-  return luaN_writeFlash(S->Z->data, e, s);
-}
-#ifdef LUA_USE_HOST
-#include <stdio.h>
-/* These compression maps must match the definitions in lobject.h etc. */
-#  define OFFSET_TSTRING (2*(sizeof(lu_int32)-sizeof(size_t)))
-#  define FMT_TSTRING   "AwwA"
-#  define FMT_TVALUE    "WA"
-#  define FMT_PROTO     "AwwwwwwwwwwAAAAAAAA"
-#  define FMT_UPVALUE   "AW"
-#  define FMT_LOCVAR    "Aww"
-#  define FMT_ROTENTRY  "AWA"
-#  define FMT_ROTABLE   "AWAA"
-#  define StoreR(S,a, i, v, f) Store_(S, (a), i, &(v), sizeof(v), f)
-#  define Store(S, a, i, v)    StoreR(S, (a), i, v, NULL)
-#  define StoreN(S, v, n)      Store_(S, NULL, 0, (v), (n)*sizeof(*(v)), NULL)
-static void *StoreAV (LoadState *S, void *a, int n) {
-  void **av = cast(void**, a);
-  if (S->mode == MODE_LFSA) {
-    void *p = StoreGetPos(S);
-    int i; for (i = 0; i < n; i ++)
-      luaN_writeFlash(S->Z->data, wordptr(av++), sizeof(lu_int32));
-    return p;
-  } else {
-    return Store_(S, NULL, 0, av, n*sizeof(*av), NULL);
-  }
-}
-#else // LUA_USE_ESP
-#  define OFFSET_TSTRING (0)
-#  define Store(S, a, i, v)      Store_(S, (a), i, &(v), sizeof(v))
-#  define StoreN(S, v, n)        Store_(S, NULL, 0, (v), (n)*sizeof(*(v)))
-  #  define StoreR(S, a, i, v, f)  Store(S, a, i, v)
-#  define StoreAV(S, p, n)       StoreN(S, p, n)
-#  define OPT_FMT
-#endif
-#define StoreFlush(S)    luaN_flushFlash((S)->Z->data);
-#define LoadVector(S,b,n)	LoadBlock(S,b,(n)*sizeof((b)[0]))
+
+/*
+** Byte stream Load functions
+*/
 static void LoadBlock (LoadState *S, void *b, size_t size) {
   lu_int32 left = luaZ_read(S->Z, b, size);
   if ( left != 0)
-    error(S, "truncated");
+    error(S, "file truncated");
+  S->crc = luaU_zlibcrc32(b, size, S->crc);
+//*DEBUG*/ static size_t n = 0; n+=size; printf("Block:%8zu %8zu 0x%08x\n",size,n,S->crc);
 }
-#define LoadVar(S,x)		LoadVector(S,&x,1)
-static lu_byte LoadByte (LoadState *S) {
+
+static inline lu_byte LoadByte (LoadState *S) {
   lu_byte x;
-  LoadVar(S, x);
+  LoadBlock(S, &x, 1);
   return x;
 }
-static lua_Integer LoadInt (LoadState *S) {
-  lu_byte b;
-  lua_Integer x = 0;
-  do { b = LoadByte(S); x = (x<<7) + (b & 0x7f); } while (b & 0x80);
-  return x;
-}
-static lua_Number LoadNumber (LoadState *S) {
-  lua_Number x;
-  LoadVar(S, x);
-  return x;
-}
-static lua_Integer LoadInteger (LoadState *S, lu_byte tt_data) {
+
+/* (Unsigned) integers are typically small so are multi-byte encoded */
+/* a single 0NNNNNNN or a multibyte (1NNNNNNN)* 0NNNNNNN */
+static lua_Integer LoadIntTT (LoadState *S, lu_byte tt_data) {
   lu_byte b;
   lua_Integer x = tt_data & LUAU_DMASK;
   if (tt_data & 0x80) {
     do { b = LoadByte(S); x = (x<<7) + (b & 0x7f); } while (b & 0x80);
   }
-  return (tt_data & LUAU_TMASK) == LUAU_TNUMNINT ? -x-1 : x;
+  return x;
 }
-static TString *LoadString_ (LoadState *S, int prelen) {
-  TString *ts;
-  char buff[LUAI_MAXSHORTLEN];
-  int n = LoadInteger(S, (prelen < 0 ? LoadByte(S) : prelen)) - 1;
-  if (n < 0)
-    return NULL;
-  if  (S->useStrRefs)
-    ts = S->TS[n];
-  else if (n <= LUAI_MAXSHORTLEN) {  /* short string? */
-    LoadVector(S, buff, n);
-    ts = luaS_newlstr(S->L, buff, n);
-  } else {                      /* long string */
-    ts = luaS_createlngstrobj(S->L, n);
-    LoadVector(S, getstr(ts), n);             /* load directly in final place */
-  }
-  return ts;
+
+static lua_Integer LoadCount (LoadState *S) {
+  int x = LoadIntTT(S, 0x80);
+//*DEBUG*/ printf("Count:%u\n",x);
+  return x;
 }
-#define LoadString(S) LoadString_(S,-1)
-#define LoadString2(S,pl) LoadString_(S,(pl))
-static void LoadCode (LoadState *S, Proto *f) {
-  Instruction *p;
-  f->sizecode = LoadInt(S);
-  f->code = luaM_newvector(S->L, f->sizecode, Instruction);
-  LoadVector(S, f->code, f->sizecode);
-  if (S->mode != MODE_RAM) {
-    p = StoreN(S, f->code, f->sizecode);
-    luaM_freearray(S->L, f->code, f->sizecode);
-    f->code = p;
-  }
+
+static TString *LoadString (LoadState *S) {
+  lu_byte tt = LoadByte(S);
+  if ((tt & LUAU_TMASK) != LUAU_TSTRING)
+    luaD_throw(S->L, LUA_ERRSYNTAX);
+  lua_Integer i = LoadIntTT(S, tt);
+//*DEBUG*/ printf("String:%u:%s\n",i, (i && S->ts[i]) ? getstr(S->ts[i]):"NULL");
+  return S->ts[i];
 }
-static void *LoadFunction(LoadState *S, Proto *f, TString *psource);
-static void LoadConstants (LoadState *S, Proto *f) {
+
+
+static void LoadConstant (LoadState *S, TValue *o) {
+  lu_byte tt = LoadByte(S);
   int i;
-  f->sizek = LoadInt(S);
-  f->k = NewVector(S, f->sizek, TValue);
-  for (i = 0; i < f->sizek; i++) {
-    TValue o;
-   /*
-    * tt is formatted 0bFTTTDDDD where TTT is the type; the F and the DDDD
-    * fields are used by the integer decoder as this often saves a byte in
-    * the endcoding.
-    */
-    lu_byte tt = LoadByte(S);
-    switch (tt & LUAU_TMASK) {
-    case LUAU_TNIL:
-      setnilvalue(&o);
-      break;
-    case LUAU_TBOOLEAN:
-      setbvalue(&o, !(tt == LUAU_TBOOLEAN));
-      break;
-    case LUAU_TNUMFLT:
-      setfltvalue(&o, LoadNumber(S));
-      break;
-    case LUAU_TNUMPINT:
-    case LUAU_TNUMNINT:
-      setivalue(&o, LoadInteger(S, tt));
-      break;
-    case LUAU_TSSTRING:
-      o.value_.gc = cast(GCObject *, LoadString2(S, tt));
-      o.tt_ = ctb(LUA_TSHRSTR);
-      break;
-    case LUAU_TLSTRING:
-      o.value_.gc = cast(GCObject *, LoadString2(S, tt));
-      o.tt_ = ctb(LUA_TLNGSTR);
-      break;
-    default:
-      lua_assert(0);
+  switch (tt & LUAU_TMASK) {
+  case LUAU_TNIL:
+    setnilvalue(o);
+    break;
+  case LUAU_TBOOLEAN:
+    setbvalue(o, (tt != LUAU_TBOOLEAN));
+    break;
+  case LUAU_TNUMFLT : {
+    lua_Number fv;
+    LoadBlock(S, &fv, sizeof(fv));
+    setfltvalue(o, fv);
+    break;
     }
-    StoreR(S, f->k, i, o, FMT_TVALUE);
+  case LUAU_TNUMPINT:
+    setivalue(o, LoadIntTT(S, tt));
+    break;
+  case LUAU_TNUMNINT:
+    setivalue(o, -LoadIntTT(S, tt)-1);
+    break;
+  case LUAU_TSTRING:
+    i = LoadIntTT(S, tt); /* always need to read this int */
+   /* Only S->ts[1] points a valid TS on dummy pass 1 */
+    setsvalue(S->L, o, S->ts[(S->pass==1) ? 1: i]);
+    break;
+  default:
+      luaD_throw(S->L, LUA_ERRSYNTAX);
   }
 }
+
 /*
-** The handling of Protos has support both modes, and in the case of flash
-** mode, this requires some care as any writes to a Proto f must be deferred
-** until after all of the writes to its sub Protos have been completed; so
-** the Proto record and its p vector must be retained in RAM until stored to
-** flash.
-**
-** Recovery of dead resources on error handled by the Lua GC as standard in
-** the case of RAM loading.  In the case of loading an LFS image into flash,
-** the error recovery could be done through the S->protogc list, but given
-** that the immediate action is to restart the CPU, there is little point
-** in adding the extra functionality to recover these dangling resources.
+** The flash API is encapsulated in the FLASH_WRITE(S, b, l) macro, where `b`
+** is the buffer to be written and `l` is the length to be written (this points
+** to a dummy function on pass 1). These lengths are word aligned, except in
+** the case of 64 bit host builds in LFS mode when these are size_t aligned.
+** Unlike the standard dump usage, this writer returns a void * value which
+** is the flash location written to.
 */
-static void LoadProtos (LoadState *S, Proto *f) {
-  int i, n = LoadInt(S);
-  Proto **p = luaM_newvector(S->L, n, Proto *);
-  f->p = p;
-  f->sizep = n;
-  memset (p, 0, n * sizeof(*p));
-  for (i = 0; i < n; i++)
-    p[i] = LoadFunction(S, luaF_newproto(S->L), f->source);
-  if (S->mode != MODE_RAM) {
-    f->p = StoreAV(S, cast(void **, p), n);
-    luaM_freearray(S->L, p, n);
-  }
-}
-static void LoadUpvalues (LoadState *S, Proto *f) {
-  int i, nostripnames = LoadByte(S);
-  f->sizeupvalues = LoadInt(S);
-  if (f->sizeupvalues) {
-    f->upvalues = NewVector(S, f->sizeupvalues, Upvaldesc);
-    for (i = 0; i < f->sizeupvalues ; i++) {
-      TString *name = nostripnames ? LoadString(S) : NULL;
-      Upvaldesc uv = {name, LoadByte(S), LoadByte(S)};
-      StoreR(S, f->upvalues, i, uv, FMT_UPVALUE);
+
+#define FLASH_WRITE(S,b,l) S->flashWriter(S->flashWriterData, b, l)
+#define FLASH_SYNC(S) FLASH_WRITE(S, NULL, ~(size_t)0)
+#define FLASH_CURR(S) FLASH_WRITE(S, NULL, 0)
+
+/*
+** The following compression maps are used in Store() ONLY in the case of
+** 64-bit hosts to repack structs to adjust for 64-bit->32-bit points in
+** absolute mode LFS creation.  These must match the definitions in lobject.h
+*/
+typedef Proto *pProto;
+#ifdef LUA_USE_HOST64
+# define FMT_DECL   , const char *pack
+# define FMT_PACK   , pack
+# define FMT_ARG(t) , FMT_ ## t
+# define LFS_ABS_MODE(S)  (S->mode == MODE_LFSA)
+# define FMT_LocVar        "Aww"
+# define FMT_NULL          NULL
+# define FMT_Instruction   "w"
+# define FMT_Proto         "AwwwwwwwwwwAAAAAAAAA"
+# define FMT_pProto        "A"
+# define FMT_ROTable       "AWAA"
+# define FMT_ROTable_entry "AWA"
+# define FMT_TString       "AwwA"
+# define FMT_UTString      ((sizeof(TString) == sizeof(UTString) || \
+                             S->mode == MODE_LFSA) ? FMT_TString : \
+                                                     FMT_TString "SSSSS")
+# define FMT_pTString      "A"
+# define FMT_TValue        "WA"
+# define FMT_Upvaldesc     "AW"
+#else
+# define FMT_DECL
+# define FMT_PACK
+# define FMT_ARG(t)
+# define LFS_ABS_MODE(S)  (0)
+#endif
+
+static void *Store (LoadState *S,
+                    void *vec, int ndx,     /* dest is vec[ndx] in len chunks */
+                    const void *src, size_t len           /* src in len chunk */
+                    FMT_DECL) {   /* One of above pack formats on HOST builds */
+  lu_byte *dest;                              /* returns addr of dest element */
+  if (inRAM(S)) {
+    dest = cast(lu_byte *, vec) + (ndx*len);
+    if (dest != src)
+      memcpy(dest, src, len);
+#ifdef LUA_USE_HOST64
+  } else if (S->mode == MODE_LFSA && pack) {
+   /*
+    * 64-bit hosts have two LFS modes. The default LFS mode is for writing to a
+    * when writing to native LFS where the address pointers are 64 bit and any
+    * pointers are word aligned.  LFSA mode is use to build "shadow" 32 bit LFS
+    * based at an ESP absolute address. In this case, only the LS 32 bits of a
+    * pointer are used (and never for actual addressing in host execution).
+    */
+    lu_int32 *w;
+    const char *f = pack;
+    dest = FLASH_CURR(S);
+    for (w = (lu_int32 *)src; *f; w++, f++ ) {
+      FLASH_WRITE(S, w, sizeof(*w));
+      if (*f == 'A' || *f == 'W') /* Addr or word followed by alignment fill */
+        w++;
     }
+    lua_assert((w - (lu_int32 *)src) * sizeof(*w) == len);
+#endif
+  } else {
+    dest = FLASH_WRITE(S, src, len);
   }
+  return dest;
 }
-static void LoadDebug (LoadState *S, Proto *f) {
+
+#define STOREI(s,t,v,o)    ((t *) Store(s, (v), i, &(o), sizeof(t) FMT_ARG(t)))
+#define STORE(s,t,po,o)    ((t *) Store(s, &(po), 0, &(o), sizeof(t) FMT_ARG(t)))
+#define STOREBUF(s,po,o,n) ((lu_byte *) Store(s, (po), 0, (o), n FMT_ARG(NULL)))
+#define STORENEXT(s)       FLASH_CURR(s)
+
+static void LoadStrings (LoadState *S) {
   int i;
-  f->sizelineinfo = LoadInt(S);
-  if (f->sizelineinfo) {
-    lu_byte *li = luaM_newvector(S->L, f->sizelineinfo, lu_byte);
-    LoadVector(S, li, f->sizelineinfo);
-    if (S->mode == MODE_RAM) {
-      f->lineinfo = li;
-    } else {
-      f->lineinfo = StoreN(S, li, f->sizelineinfo);
-      luaM_freearray(S->L, li, f->sizelineinfo);
-    }
+  i         = LoadCount(S) + 1;  /* buffer just in case luaM_newvector throws */
+  S->str    = luaM_newvector(S->L, i, char);
+  S->strLen = i;
+  i         = LoadCount(S) + 1;
+  S->ts     = luaM_newvector(S->L, i, TString *);
+  S->tsLen  = i;
+  S->tsTot += i;
+  S->ts[0]  = NULL;
+  for (int i = 1; i < S->tsLen; i++) {
+    size_t l = LoadCount(S)-1;
+    lua_assert(l < S->strLen);
+    LoadBlock(S, S->str, l);
+    S->str[l] = '\0';
+    S->ts[i] = inRAM(S) ? luaS_newlstr(S->L, S->str, l) :
+                           LFS_newlstr(S, S->str, l, 0);
+    if (i <= S->pvLen)
+      S->pv[i-1].name = (S->pass == 1) ? luaS_newlstr(S->L, S->str, l) :
+                                         S->ts[i];
+//*DEBUG*/ printf("%5u:%4zu:%s\n",i,l, S->str);
   }
-  f->sizelocvars = LoadInt(S);
-  f->locvars = NewVector(S, f->sizelocvars, LocVar);
-  for (i = 0; i < f->sizelocvars; i++) {
-    LocVar lv = {LoadString(S), LoadInt(S), LoadInt(S)};
-    StoreR(S, f->locvars, i, lv, FMT_LOCVAR);
+  if (!inRAM(S)) {
+    if (S->pass == 1)
+      S->ts[1] = G(S->L)->tmname[0]; /* just need 1 valid TS for algo to work */
+    LFS_flushcache(S);
   }
 }
-static void *LoadFunction (LoadState *S, Proto *f, TString *psource) {
+
+
+static Proto **LoadSubProtos (LoadState *S, int n, TString *source) {
  /*
-  * Main protos have f->source naming the file used to create the hierarchy;
-  * subordinate protos set f->source != NULL to inherit this name from the
-  * parent.  In LFS mode, the Protos are moved from the GC to a local list
-  * in S, but no error GC is attempted as discussed in LoadProtos.
+  * The p vector must be cached in RAM to avoid p[i] stores being interleaved
+  * with the Proto stores; so store the Protos, then store the p[i] entry.
+  * In RAM mode, then the vector is allocated from heap and will become the
+  * f->k vector, otherwise it is allocated on the stack, copied to LFS and
+  * dropped on return.
   */
-  Proto *p;
-  global_State *g = G(S->L);
-  if (S->mode != MODE_RAM) {
-    lua_assert(g->allgc == obj2gco(f));
-    g->allgc = f->next;                    /* remove object from 'allgc' list */
-    f->next = S->protogc;         /* push f into the head of the protogc list */
-    S->protogc = obj2gco(f);
+  Proto **p = (inRAM(S)) ? luaM_newvector(S->L, n, Proto *)
+                         : alloca(n*sizeof(p[0]));
+  int i;
+  for (i = 0; i< n; i++)
+    p[i] = LoadFunction(S, source);           /* load and store the sub-Proto */
+  if (inRAM(S))
+    return p;
+  Proto **q = (Proto **) STORENEXT(S );
+  for (i = 0; i< n; i++)                             /* Send p[0..n-1] to LFS */
+    STOREI(S, pProto, p, p[i]);      /* This repacks in the case of LFSA mode */
+  return q;
+}
+
+static void LoadLineInfo (LoadState *S, int n, Proto *f) {
+  char *b = (inRAM(S)) ? luaM_newvector(S->L, n, lu_byte) : alloca(n);
+  LoadBlock(S, b, n);
+  f->lineinfo = STOREBUF(S, b, b, n);
+  f->sizelineinfo = n;
+}
+
+static int aux_newvector (LoadState *S, size_t len, void **v) {
+  int n = LoadCount(S);
+  if (inRAM(S)) {
+    *v = luaM_reallocv(S->L, NULL, 0, n, len);
+    memset(*v, 0, n * len);
+  } else {
+    *v = (void *)STORENEXT(S );
   }
+  return n;
+}
+
+#define OVER(t,v) \
+  f->size ## v = n = aux_newvector(S, sizeof(t), (void**)&(f->v)); \
+  for (i = 0; i< (n); i++)
+
+static Proto *LoadFunction (LoadState *S, TString *source) {
+  /* This function MUST be aligned to ldump.c:DumpFunction() */
+//*DEBUG*/ static int cnt = 0; cnt++;
+  int i, n;
+  Proto F = {0};
+  Proto *f = (inRAM(S)) ? luaF_newproto(S->L) : &F;
   f->source = LoadString(S);
-  if (f->source == NULL)  /* no source in dump? */
-    f->source = psource;  /* reuse parent's source */
-  f->linedefined = LoadInt(S);
-  f->lastlinedefined = LoadInt(S);
-  f->numparams = LoadByte(S);
-  f->is_vararg = LoadByte(S);
-  f->maxstacksize = LoadByte(S);
-  LoadProtos(S, f);
-  LoadCode(S, f);
-  LoadConstants(S, f);
-  LoadUpvalues(S, f);
-  LoadDebug(S, f);
-  if (S->mode != MODE_RAM) {
-    GCObject *save = f->next;
-    if (f->source != NULL) {
-      setLFSbit(f);
-      /* cache the RAM next and set up the next for the LFS proto chain */
-      f->next = FHaddr(S, GCObject *, S->fh->protoHead);
-      p = StoreR(S, NULL, 0, *f, FMT_PROTO);
-      S->fh->protoHead = FHoffset(S, p);
-    } else {
-      p = StoreR(S, NULL, 0, *f, FMT_PROTO);
-    }
-    S->protogc = save;  /* pop f from the head of the protogc list */
-    luaM_free(S->L, f);  /* and collect the dead resource */
-    f = p;
+  if (!f->source)
+    f->source = source;
+  f->sizep           = LoadCount(S);
+  f->p               = LoadSubProtos(S, f->sizep, f->source);
+  f->linedefined     = LoadCount(S);
+  f->lastlinedefined = LoadCount(S);
+//*DEBUG*/ printf("Function from %u to %u\n", f->linedefined, f->lastlinedefined);
+  f->numparams       = LoadByte(S);
+  f->is_vararg       = LoadByte(S);
+  f->maxstacksize    = LoadByte(S);
+
+  OVER(Instruction, code) {
+    Instruction o;
+    LoadBlock(S, &o, sizeof(o));
+    STOREI(S, Instruction, f->code, o);
+  }
+  OVER(TValue, k) {
+    TValue o;
+    LoadConstant(S, &o);
+    STOREI(S, TValue, f->k, o);
+  }
+  OVER(Upvaldesc, upvalues) {
+    Upvaldesc uv = {LoadString(S), LoadByte(S), LoadByte(S)};
+    STOREI(S, Upvaldesc, f->upvalues, uv);
+  }
+  OVER(LocVar, locvars) {
+    LocVar lv = {LoadString(S), LoadCount(S), LoadCount(S)};
+    STOREI(S, LocVar, f->locvars, lv);
+  }
+  LoadLineInfo(S, LoadCount(S), f);
+
+  if (!inRAM(S)) {
+    f->next = (GCObject *)S->protoHead;
+    f = STORE(S, Proto, F, F);
+    S->protoHead = f;
+   /* Note that f is correctly located in RAM mode so no STORE needed. */
+  } else if (S->strip > 0) {
+   /* In RAM mode metadata stripping is also honoured to save memory. */
+    luaU_stripdebug (S->L, f, S->strip, 0);
   }
   return f;
 }
-static void checkliteral (LoadState *S, const char *s, const char *msg) {
-  char buff[sizeof(LUA_SIGNATURE) + sizeof(LUAC_DATA)]; /* larger than both */
-  size_t len = strlen(s);
-  LoadVector(S, buff, len);
-  if (memcmp(s, buff, len) != 0)
+
+#define MAX_LITERAL (sizeof(LUA_SIGNATURE) + sizeof(LUAC_DATA))
+static void checkBuffer (LoadState *S, const char *s, size_t l, const char *msg) {
+  char buff[MAX_LITERAL];
+  LoadBlock(S, buff, l);
+  if (memcmp(s, buff, l) != 0)
     error(S, msg);
 }
-static void fchecksize (LoadState *S, size_t size, const char *tname) {
-  if (LoadByte(S) != size)
-    error(S, luaO_pushfstring(S->L, "%s size mismatch in", tname));
-}
-#define checksize(S,t)	fchecksize(S,sizeof(t),#t)
+
+#define checkLiteral(S,s,m) checkBuffer(S,s,strlen(s),m)
+#define checkbyte(S,v,e) if (LoadByte(S)!=(v)) error(S, e)
 static void checkHeader (LoadState *S, int format) {
-  checkliteral(S, LUA_SIGNATURE + 1, "not a");  /* 1st char already checked */
-  if (LoadByte(S) != LUAC_VERSION)
-    error(S, "version mismatch in");
-  if (LoadByte(S) != format)
-    error(S, "format mismatch in");
-  checkliteral(S, LUAC_DATA, "corrupted");
-  checksize(S, int);
- /*
-  * The standard Lua VM does a check on the sizeof size_t and endian check on
-  * integer; both are dropped as the former prevents dump files being shared
-  * across 32 and 64 bit machines, and we use multi-byte coding of ints.
-  */
-  checksize(S, Instruction);
-  checksize(S, lua_Integer);
-  checksize(S, lua_Number);
-  LoadByte(S);  /* skip number tt field */
-  if (LoadNumber(S) != LUAC_NUM)
-    error(S, "float format mismatch in");
+  TValue num;
+  checkLiteral(S, LUA_SIGNATURE+1, "not a Lua compiled file");
+  checkbyte(S, LUAC_VERSION, "Lua version mismatch");
+  checkbyte(S, format, "format version mismatch");
+  checkLiteral(S, LUAC_DATA, "file corrupted");
+  checkbyte(S, sizeof(int), "int size mismatch");
+  checkbyte(S, sizeof(Instruction), "Instruction size mismatch");
+  checkbyte(S, sizeof(lua_Integer), "lua_Integer size mismatch");
+  checkbyte(S, sizeof(lua_Number), "lua_Number size mismatch");
+/* Note that we multi-byte encoded integers so no need to check size_t or endian */
+  LoadConstant(S, &num);
+  if (nvalue(&num) != LUAC_NUM)
+    error(S, "float format mismatch");
 }
+
 /*
-** Load precompiled chunk to support standard LUA_API load functions. The
-** extra LFS functionality is effectively NO-OPed out on this MODE_RAM path.
+** Load precompiled chunk(s) to support standard LUA_API load functions. This
+** supports both single top level funciton (TLF) and multi-TLF dump streams.  In
+** the case of a single TLF a Closure is added to ToS else an array of Closures.
+** Note that this protected call is used to recover all working resources even
+** if an error is thrown.
 */
-LClosure *luaU_undump(lua_State *L, ZIO *Z, const char *name) {
-  LoadState S = {0};
-  LClosure *cl;
-  if (*name == '@' || *name == '=')
-    S.name = name + 1;
-  else if (*name == LUA_SIGNATURE[0])
-    S.name = "binary string";
-  else
-    S.name = name;
-  S.L = L;
-  S.Z = Z;
-  S.mode = MODE_RAM;
-  S.fh = NULL;
-  S.useStrRefs = 0;
-  checkHeader(&S, LUAC_FORMAT);
-  cl = luaF_newLclosure(L, LoadByte(&S));
-  setclLvalue(L, L->top, cl);
+static void protectedLoad (lua_State *L, void *ud) {
+  LoadState *S = (LoadState *) ud;
+  checkHeader(S, LUAC_FORMAT);
+  int n = LoadByte(S);
+  S->pv = luaM_newvector(L, n, struct protomap);
+  memset(S->pv, 0, n*sizeof(struct protomap));
+  S->pvLen = n;
+  LoadStrings(S);
+  checkLiteral(S, LUA_PROTO_SIG, "string table corrupted");
+  for (int i = 0; i < n; i++) {
+    S->pv[i].p = LoadFunction(S, NULL);
+  }
+  unsigned int crc = ~S->crc;
+  checkBuffer(S, (char *)&crc, sizeof(crc), "CRC mismatch");
+  if (inRAM(S) && n == 1) {
+    /* return LCLosure on ToS if single TLF in RAM mode */
+    LClosure *cl = luaF_newLclosure(L, S->pv[0].p->sizeupvalues);
+    cl->p = S->pv[0].p;
+    luaF_initupvals(L, cl);
+    setclLvalue(L, L->top, cl);
+  } else {
+    /* return Array on ToS; values are LClosures in RAM mode */
+    /*                      values are LwUD of Proto* in LFS modes */
+    TValue key, *node;
+    if (S->t == NULL)
+      S->t = luaH_new(S->L);
+    luaH_resize(L, S->t, 0, S->nt + n);
+    for (int i = 0; i < n; i++) {
+      setsvalue(L, &key, S->pv[i].name);
+      node = luaH_set(L, S->t, &key);
+      if(!ttisnil(node))
+        S->nt++;  /* Allow for duplicated names */
+      if (inRAM(S)) {
+        LClosure *cl = luaF_newLclosure(L, S->pv[i].p->sizeupvalues);
+        cl->p = S->pv[i].p;
+        luaF_initupvals(L, cl);
+        setclLvalue(L, node, cl);
+
+      } else { /*LFS modes */
+        setpvalue(node, S->pv[i].p);
+      }
+    }
+    sethvalue(L, L->top, S->t);   /* Set ToS to array of Closures */
+  }
   luaD_inctop(L);
-  cl->p = luaF_newproto(L);
-  LoadFunction(&S, cl->p, NULL);
-  lua_assert(cl->nupvalues == cl->p->sizeupvalues);
-  return cl;
 }
-/*============================================================================**
-** NodeMCU extensions for LFS support and Loading.  Note that this funtionality
-** is called from a hook in the lua startup within a lua_lock() (as with
-** LuaU_undump),  so luaU_undumpLFS() cannot use the external Lua API. It does
-** uses the Lua stack, but staying within LUA_MINSTACK limits.
-**
-** The in-RAM Protos used to assemble proto content prior to writing to LFS
-** need special treatment since these hold LFS references rather than RAM ones
-** and will cause the Lua GC to error if swept.  Rather than adding complexity
-** to lgc.c for this one-off process, these Protos are removed from the allgc
-** list and fixed in a local one, and collected inline.
-**============================================================================*/
+
 /*
-** Write a TString to the LFS. This parallels the lstring.c algo but writes
-** directly to the LFS buffer and also append the LFS address in S->TS. Seeding
-** is based on the seed defined in the LFS image, rather than g->seed.
+** luaU_undump() preserves standard Lua functionality by returning a Lua
+** closure at ToS if single TLF dump stream is loaded and returning a Proto
+** at ToS. Used by  lua_dofile() etc.  The dump stream can also contain a
+** multiple TLF in which case an array of {name=closure} is returned at ToS.
 */
-static void addTS(LoadState *S, int l, int extra) {
-  LFSHeader *fh   = S->fh;
-  TString *ts     = cast(TString *, S->buff);
-  char *s         = getstr(ts);
-  lua_assert (sizelstring(l) <= S->buffLen);
-  s[l] = '\0';
-  /* The collectable and LFS bits must be set; all others inc the whitebits clear */
+void luaU_undumpx (lua_State *L, ZIO *Z, const char *name, LoadState *S) {
+  int init = (S == NULL);
+
+  if (init)
+    S = luaU_LoadState(L, NULL, 0, NULL, NULL, MODE_RAM, 0);
+  S->name = (*name == '@' || *name == '=') ? name + 1 :
+            ((*name == LUA_SIGNATURE[0]) ? "binary string" : name);
+  S->Z    = Z;
+  S->crc = luaU_zlibcrc32(LUA_SIGNATURE, sizeof(char), ~0);
+
+
+  /* Protected of call of Load Proto to tidy up allocs on error */
+  int status = luaD_pcall(L, protectedLoad, S, savestack(L, L->top), 0);
+  S->pv   = luaM_freearray(S->L, S->pv,  S->pvLen);  S->pvLen  = 0;
+  S->str  = luaM_freearray(S->L, S->str, S->strLen); S->strLen = 0;
+  S->ts   = luaM_freearray(S->L, S->ts,  S->tsLen);  S->tsLen  = 0;
+  S->map  = luaM_freearray(S->L, S->map, S->mapLen); S->mapLen  = 0; S->mapNdx  = 0;
+  if (init)
+    luaU_closeLoadState(S, NULL, NULL);
+  if (status != LUA_OK)    /* error while running protectedSave? */
+    luaD_throw(L, status); /* re-throw error */
+}
+
+
+void luaU_addstrings(LoadState *S, const char **s, lu_byte *extra) {
+  for (; *s; s++) {
+    S->tsTot++;
+    LFS_newlstr(S, *s, strlen(*s), (extra ? *extra++ : 0));
+  }
+  LFS_flushcache(S);
+}
+
+static void *dummyWriter (void *ud, const void *b, size_t sz) {
+  char **p = (char **) ud;
+  sz = (sz + sizeof(size_t) - 1) & (~(sizeof(size_t)-1));
+  *p += sz;
+  return *p;
+}
+
+/*
+** In the case of LFS loads, these can be multi-file so some load state must
+** be passed between calls to luaU_undumpx, hence this state creation and the
+** companion close. LFS load is two pass with the ROstrtSize set on pass 2.
+*/
+LoadState *luaU_LoadState (lua_State *L, Table *t, int ROstrtSize,
+                           luaU_Writer fw, void *fwd,
+                           int mode, unsigned int seed) {
+
+  LoadState *S = luaM_new(L, LoadState);
+  memset(S, 0, sizeof(LoadState));
+  S->mode = mode;
+  S->L    = L;
+  S->seed = seed;
+  S->t    = t;
+  if (!inRAM(S)) {            /* S->pass etc defaults to 0 for    */
+    if (ROstrtSize == 0) {
+      S->pass = 1;
+      S->flashWriter     = &dummyWriter;
+      S->flashWriterData = &(S->dummyROaddr);
+      S->dummyROaddr     = NULL;
+    } else {
+      S->pass = 2;
+      S->ROstrt.size  = ROstrtSize;
+      S->ROstrt.nuse  = 0;
+      S->ROstrt.hash  = luaM_newvector(L, ROstrtSize, TString *);
+      memset(S->ROstrt.hash, 0, ROstrtSize*sizeof(TString *));
+      S->flashWriter  = fw;
+      S->flashWriterData = fwd;
+      S->rTSbarrier   = STORENEXT(S);
+  #ifdef LUA_USE_HOST
+      if (S->mode == MODE_LFSA)
+        S->ROstrtMap = luaH_new(L); /* GC must be stopped to prevent GC */
+  #endif
+    }
+  }
+  return S;
+}
+
+typedef struct TString *pTString;
+
+void luaU_closeLoadState (LoadState *S, luaU_data *res, const ROTable *indexMeta) {
+  if (!inRAM(S)) {
+    ROTable *pt = NULL;
+    TString **index = NULL;
+    if (S->pass == 2) {
+      pt = LFS_createIndex(S, indexMeta);
+      index = cast(TString **, STORENEXT(S));
+      for (int i = 0; i < S->ROstrt.size; i++)
+        STOREI(S, pTString, NULL,S->ROstrt.hash[i]);
+      S->ROstrt.hash = luaM_freearray(S->L, S->ROstrt.hash, S->ROstrt.size);
+    }
+    if(res) {
+      res->ROstrt.hash  = index;
+      res->ROstrt.size  = S->ROstrt.size;
+      res->ROstrt.nuse  = S->ROstrt.nuse;
+      res->protoROTable = pt;
+      res->protoHead    = S->protoHead;
+      res->shortTShead  = S->shortTShead;
+      res->longTShead   = S->longTShead;
+      res->tsTot        = S->tsTot;
+     }
+  }
+  luaM_free(S->L, S);
+}
+
+
+LUAI_FUNC const char *luaU_getbasename (lua_State *L, const TString *filename,
+                                        size_t *len) {
+  const char *fn = getstr(filename);
+  const char *s = strrchr(fn, '/');
+  s = s ? s :  strrchr(fn, '\\');
+  s = s ? s + 1 : fn;
+  while (*s == '.') s++;
+  const char *e = strchr(s, '.');
+  if (len)
+    *len = e ? e - s : strlen(s);
+  return s;
+}
+
+
+/*============================================================================**
+** NodeMCU extensions for LFS support and Loading.
+**============================================================================*/
+
+/*
+** Building TStrings in RAM essentially uses standard Lua core functionality.
+** LFS is a more complex implementation because:
+**
+** 1)  Unlike core RAM-based TStrings which support flexible R/W access, any
+**     written TStrings can't be reread until after cache-flush barrier allows
+**     coherent read access to written LFS resources.  LFS supports multi-file
+**     load, and this flush occurs after each file load.
+**
+** 2)  Each file contains a preamble list of *unique* TStrings used in the
+ **     Protos in the file; however the TString might already exist, loaded from
+ **     a previous file, hence any TString hash chain (ordered latest first) can
+ **     contain non-flushed TS (nfTS) followed by readable TS (rTS).  Any
+**     potential match can only be in the rTS linked chain, so the resolution
+**     must skip over the nfTS, and these skip links must be cached in RAM.
+**
+**     This could have been implemented by having a second nfTS vector, but
+**     this would double the RAM needed to hold the RAM-cached ROstrt hash
+**     vector. The number of mixed nfTS + rTS chains is small and can be
+**     handled by a dynamically-sized set of [nfTS head, rTS head] buckets with
+**     the ROstrt referencing this bucket.  This encoding is denormalised into
+**     the RTstrt hash entry (*o).  This is a little nasty but saves RAM.
+**
+     **     * If (size_t) (*o) < max bucket count then this refers to a bucket.
+**       This is best an index since the bucket list can grow and be relocated.
+**     * If *o < last flushed TS then is an rTS reference
+**     * Otherwise it is an nfTS reference and we can't get a repeat match.
+**
+** 3)  Since TSs written to LFS can't be updated, the ROstrt can't be resized,
+**     so a two-pass read is done: Pass 1 computes the ROstrt size and skips
+**     all TString building; Pass 2 builds the TS using a fixed size hash.
+**
+** 4)  There is also a special LFSA mode where the LFS region uses 32-bit
+ **     target based address even on a 64-bit host and any records are repacked
+**     so pointer go from size_t to 32-bit.  In this case the LFS is effectively
+**     read-only but RAM isn't an issue so an on-host table is used to map
+ **     strings to their resolved absolute address.
+*/
+
+#define isstrtlink(o)    (*cast(size_t *, o) <= S->mapNdx)
+#define isnfTS(o)        (*o > S->rTSbarrier)
+#define strtlink(o)      S->map[*cast(size_t *, o) - 1]
+#define setstrtlink(o,n) {*cast(size_t *, o) = (n) + 1;}
+
+static TString *LFS_newlstr (LoadState *S, const char *s, size_t l, int extra) {
+  UTString sts = {0};               /* This must be Lua Test Suite compatible */
+                                    /* hence the use of UTString wrappers :-( */
+  TString *ts, *tsnext, *rts, **o;
+  if (S->pass == 1)
+    return NULL;        /* Nothing to do on Pass 1 or string already resolved */
+
+  ts         = &sts.tsv;
   ts->marked = bitmask(LFSBIT) | BIT_ISCOLLECTABLE;
   ts->extra  = extra;
-  if (l <= LUAI_MAXSHORTLEN) {                              /* short string */
-    TString  **p;
-    ts->tt = LUA_TSHRSTR;
-    ts->shrlen = cast_byte(l);
-    ts->hash = luaS_hash(s, l, fh->seed);
-    p = S->list + lmod(ts->hash, S->listLen);
-    ts->u.hnext = *p;
-    ts->next = FHaddr(S, GCObject *, fh->shortTShead);
-    S->TS[S->TSndx] = *p = StoreR(S, NULL, 0, *ts, FMT_TSTRING);
-    fh->shortTShead = FHoffset(S, *p);
-  } else {                                                   /* long string */
-    TString  *p;
-    ts->tt = LUA_TLNGSTR;
-    ts->shrlen = 0;
+
+    if (l > LUAI_MAXSHORTLEN) {  /* long TS are simple: no de-duplication done. */
+    ts->tt       = LUA_TLNGSTR;
+    ts->shrlen   = 0;
     ts->u.lnglen = l;
-    ts->hash = fh->seed;
-    luaS_hashlongstr(ts);                     /* sets hash and extra fields */
-    ts->next = FHaddr(S, GCObject *, fh->longTShead);
-    S->TS[S->TSndx] = p = StoreR(S, NULL, 0, *ts, FMT_TSTRING);
-    fh->longTShead = FHoffset(S, p);
-  }
-// printf("%04u(%u): %s\n", S->TSndx, l, S->buff + sizeof(union UTString));
-  StoreN(S,S->buff + sizeof(union UTString), l+1);
-  S->TSndx++;
-}
-/*
-** The runtime (in ltm.c and llex.c) declares ~100 fixed strings and so these
-** are moved into LFS to free up an extra ~2Kb RAM.  Extra get token access
-** functions have been added to these modules.  These tokens aren't unique as
-** ("nil" and "function" are both tokens and typenames), hardwiring this
-** duplication debounce as a wrapper around addTS() is the simplest way of
-** voiding the need for extra lookup resources.
-*/
-static void addTSnodup(LoadState *S, const char *s, int extra) {
-  int i, l = strlen(s);
-  static struct {const char *k; int found; } t[] = {{"nil", 0},{"function", 0}};
-  for (i = 0; i < sizeof(t)/sizeof(*t); i++) {
-    if (!strcmp(t[i].k, s)) {
-      if (t[i].found) return;  /* ignore the duplicate copy */
-      t[i].found = 1; /* flag that this constant is already loaded */
-      break;
+    ts->hash     = S->seed;
+    luaS_hashlongstr(ts);                       /* sets hash and extra fields */
+    ts->next      = (GCObject *)S->longTShead;
+    ts            = STORE(S, TString, sts, sts);
+    STOREBUF(S, NULL, s, l+1);
+    S->longTShead = ts;
+  } else {                                                    /* short string */
+    ts->hash    = luaS_hash(s, l, S->seed);
+    o           = S->ROstrt.hash + lmod(ts->hash, S->ROstrt.size);
+    tsnext      = *o;
+#ifdef LUA_USE_HOST
+    if (S->mode == MODE_LFSA) {
+      TString *ts1 = luaS_newlstr(S->L, s, l);
+      const TValue *o = luaH_getstr(S->ROstrtMap, ts1);   /* key uses RAMstrt */
+      if (!ttisnil(o))
+        return tsvalue(o);
+    } else {
+#endif
+   /*
+    * The hash slot points to a 0 or more TS in a chain, with 4 chain cases:
+    *  (A) NIL; (B) nfTS chain; (C) rTS chain; (D) nfTS + rTS chain.  Cases
+    *  (C + D) need might have an existing match. (A + B) are straight updates.
+    *  (C) needs a new map bucket.  (C + D) update the bucket nfTS head.
+    */
+    if (*o == NULL || isnfTS(o)) {
+      rts = NULL;                                        /* Case A and Case B */
+    } else if (!isstrtlink(o)) {
+      rts = *o;                                                     /* Case C */
+    } else {
+      rts    = strtlink(o).rTShead;                                 /* Case D */
+      tsnext = strtlink(o).nfTShead;
+    }
+    for (; rts != NULL; rts = rts->u.hnext) {               /* Scan rTS chain */
+      if (l == getshrlen(rts) &&
+           memcmp(s, getstr(rts), l * sizeof(char)) == 0)
+        return rts;                                    /* return rTS if match */
+    }
+#ifdef LUA_USE_HOST
+    }
+#endif
+    ts->tt      = LUA_TSHRSTR;
+    ts->shrlen  = (lu_byte)l;
+    ts->u.hnext = tsnext;      /* ignore NFTS / RTS distinctions for chaining */
+    ts->next    = (GCObject *)S->shortTShead;
+     ts          = (TString *) STORE(S, UTString, sts, sts);
+    STOREBUF(S, NULL, s, l+1);
+    S->shortTShead = ts;
+
+     if (*o == NULL || isnfTS(o)) {
+      *o = ts;                                           /* Case A and Case B */
+    } else {
+      if (!isstrtlink(o)) {                                         /* Case C */
+        luaM_growvector(S->L, S->map, S->mapNdx, S->mapLen,
+                        struct strtlink, 1024, "strt clashes");
+        S->map[S->mapNdx].rTShead  = *o;
+        setstrtlink(o, S->mapNdx++);
       }
+      strtlink(o).nfTShead = ts;                         /* Case C and Case D */
+    }
+    S->ROstrt.nuse++;
   }
-  memcpy(getstr(cast(TString *, S->buff)), s, l);
-  addTS(S, l, extra);
+
+#ifdef LUA_USE_HOST
+  if (S->mode == MODE_LFSA) {
+    TValue tv, *node;
+    setsvalue(S->L, &tv, luaS_newlstr(S->L, s, l));
+    node = luaH_set(S->L, S->ROstrtMap, &tv);
+    lua_assert(ttisnil(node));      /* key uses RAMstrt, value is LFS TS addr */
+    setsvalue(S->L, node, ts);
+  }
+#endif
+  return ts;
 }
+
+static void LFS_flushcache (LoadState *S) {
+  TString **o = S->ROstrt.hash;
+  FLASH_SYNC(S);         /* all non-flushed refs are now flushed and readable */
+  for (int i = 0; i < S->ROstrt.size; i++, o++) {
+    if (*o && isstrtlink(o))
+      *o = strtlink(o).nfTShead;
+    if (*o > S->rTSbarrier)  /* Reset the barrier to the highest TS processed */
+      S->rTSbarrier = *o;
+    lua_assert(*o != (TString *)0xabababababababab);
+  }
+  S->mapNdx = 0;
+}
+
+static ROTable *aux_LFSrotable (LoadState *S, ROTable_entry *ev, int size,
+                                int hasindex, const ROTable *meta) {
+  ROTable t;
+  t.next      = (GCObject *)1;
+  t.tt        = LUA_TTBLROF;
+  t.marked    = 0;
+  t.flags     = hasindex ? cast(lu_byte, 1<<TM_INDEX) : 0;
+  t.lsizenode = size;
+  t.metatable = cast(Table *, meta);
+  t.entry     = ev;
+
+  return STORE(S, ROTable, t, t);
+}
+
+
 /*
-** Load TStrings in dump format. ALl TStrings used in an LFS image excepting
-** any fixed strings are dumped as a unique collated set.  Any strings in the
-** following Proto streams use an index reference into this list rather than an
-** inline copy.  This function loads and stores them into LFS, constructing the
-** ROstrt for the shorter interned strings.
+** Create the index ROTable. In the case of a sys + app LFS config, the
+** appLFS ROTable has an index pointing to the sysLFS table, so the extra
+** metatable also needs to be generated.
 */
-static void LoadAllStrings (LoadState *S) {
-  lua_State *L = S->L;
-  global_State *g = G(L);
-  int nb       = sizelstring(LoadInt(S));
-  int ns       = LoadInt(S);
-  int nl       = LoadInt(S);
-  int nstrings = LoadInt(S);
-  int n        = ns + nl;
-  int nlist    = 1<<luaO_ceillog2(ns);
-  int i, extra;
-  const char *p;
-  /* allocate dynamic resources and save in S for error path collection */
-  S->TS      = luaM_newvector(L, n+1, TString *);
-  S->TSlen   = n+1;
-  S->buff    = luaM_newvector(L, nb, char);
-  S->buffLen = nb;
-  S->list    = luaM_newvector(L, nlist, TString *);
-  S->listLen = nlist;
-  memset (S->list, 0, nlist*sizeof(TString *));
-  /* add the strings in the image file to LFS */
-  for (i = 1; i <= nstrings; i++) {
-    int tt = LoadByte(S);
-    lua_assert((tt&LUAU_TMASK)==LUAU_TSSTRING || (tt&LUAU_TMASK)==LUAU_TLSTRING);
-    int l = LoadInteger(S, tt) - 1; /* No NULL entry in list of TSs */
-    LoadVector(S, getstr(cast(TString *, S->buff)), l);
-    addTS(S, l, 0);
+static ROTable *LFS_createIndex (LoadState *S, const ROTable *indexMeta) {
+  struct ROTable_entry e;
+  const struct ROTable_entry *ev;
+  struct ROTable_entry nl = {0};
+  int cnt = 0;
+  TValue tv[2];
+  if (inRAM(S))
+    return NULL;
+  setnilvalue(cast(TValue *, &nl.value));
+  if (indexMeta) {
+    /* create {__index = meta, NULLVAL} entry vector } */
+    e.key = getstr(LFS_newlstr(S, "__index", sizeof("__index")-1, 0));
+    sethvalue(S->L, cast(TValue *,&e.value), cast(Table *, indexMeta));
+    ev = STORE(S, ROTable_entry, e , e);
+    STORE(S, ROTable_entry, nl, nl);
+    /* and store the extra metatable */
+    indexMeta = cast(const ROTable *, aux_LFSrotable(S, ev, 1, 1, NULL));
   }
-  /* add the fixed strings to LFS */
-  for (i = 0; (p = luaX_getstr(i, &extra))!=NULL; i++) {
-    addTSnodup(S, p, extra);
+  ev = cast(struct ROTable_entry *, STORENEXT(S));
+  setnilvalue(tv);
+  while (luaH_next(S->L, S->t, tv)) {
+    TString *ts = tsvalue(tv);
+    ts = LFS_newlstr(S, getstr(ts), tsslen(ts), 0);  // <<< is this needed
+    lua_assert(ts);
+    e.key = getstr(ts);                             // need LFSA compatible version
+    setobj(S->L, cast(TValue *, &e.value), tv+1);
+    STORE(S, ROTable_entry, e, e);
+    cnt++;
   }
-  addTSnodup(S, getstr(g->memerrmsg), 0);
-  addTSnodup(S, LUA_ENV, 0);
-  for (i = 0; (p = luaT_getstr(i))!=NULL; i++) {
-    addTSnodup(S, p, 0);
-  }
-  /* check that the actual size is the same as the predicted */
-  lua_assert(n == S->TSndx-1);
-  S->fh->oROhash = FHoffset(S, StoreAV(S, S->list, nlist));
-  S->fh->nROuse  = ns;
-  S->fh->nROsize = nlist;
-  StoreFlush(S);
-  S->buff    = luaM_freearray(L, S->buff, nb);
-  S->buffLen = 0;
-  S->list    = luaM_freearray(L, S->list, nlist);
-  S->listLen = 0;
+  e.key = NULL;
+  setnilvalue((TValue *)&e.value);
+  STORE(S, ROTable_entry, e, e);
+  return aux_LFSrotable(S, ev, cnt, 0, indexMeta);
 }
-static void LoadAllProtos (LoadState *S) {
-  lua_State *L = S->L;
-  ROTable_entry eol = {NULL, LRO_NILVAL};
-  int i, n = LoadInt(S);
-  S->pv    = luaM_newvector(L, n, Proto *);
-  S->pvLen = n;
-  /* Load Protos and store addresses in the Proto vector */
-  for (i = 0; i < n; i++) {
-    S->pv[i] = LoadFunction(S, luaF_newproto(L), NULL);
-  }
-  /* generate the ROTable entries from first N constants; the last is a timestamp */
-  lua_assert(n+1 == LoadInt(S));
-  ROTable_entry *entry_list = cast(ROTable_entry *, StoreGetPos(S));
-  for (i = 0; i < n; i++) {
-    lu_byte tt_data = LoadByte(S);
-    TString *Tname = LoadString2(S, tt_data);
-    const char *name = getstr(Tname) + OFFSET_TSTRING;
-    lua_assert((tt_data & LUAU_TMASK) == LUAU_TSSTRING);
-    ROTable_entry me = {name, LRO_LUDATA(S->pv[i])};
-    StoreR(S, NULL, 0, me, FMT_ROTENTRY);
-  }
-  StoreR(S, NULL, 0, eol, FMT_ROTENTRY);
-  /* terminate the ROTable entry list and store the ROTable header */
-  ROTable ev = { (GCObject *)1, LUA_TTBLROF, LROT_MARKED,
-                 (lu_byte) ~0, n, NULL, entry_list};
-  S->fh->protoROTable = FHoffset(S, StoreR(S, NULL, 0, ev, FMT_ROTABLE));
-  /* last const is timestamp */
-  S->fh->timestamp = LoadInteger(S, LoadByte(S));
-}
-static void undumpLFS(lua_State *L, void *ud) {
-  LoadState *S = cast(LoadState *, ud);
-  void *F = S->Z->data;
-  S->startLFS = StoreGetPos(S);
-  luaN_setFlash(F, sizeof(LFSHeader));
-  S->fh->flash_sig = FLASH_SIG;
-  if (LoadByte(S) != LUA_SIGNATURE[0])
-    error(S, "invalid header in");
-  checkHeader(S, LUAC_LFS_IMAGE_FORMAT);
-  S->fh->seed = LoadInteger(S, LoadByte(S));
-  checkliteral(S, LUA_STRING_SIG,"no string vector");
-  LoadAllStrings (S);
-  checkliteral(S, LUA_PROTO_SIG,"no Proto vector");
-  LoadAllProtos(S);
-  S->fh->flash_size = byteptr(StoreGetPos(S)) - byteptr(S->startLFS);
-  luaN_setFlash(F, 0);
-  StoreN(S, S->fh, 1);
-  luaN_setFlash(F, 0);
-  S->TS = luaM_freearray(L, S->TS, S->TSlen);
-}
-/*
-** Load precompiled LFS image.  This is called from a hook in the firmware
-** startup if LFS reload is required.
-*/
-LUAI_FUNC int luaU_undumpLFS(lua_State *L, ZIO *Z, int isabs) {
-  LFSHeader fh = {0};
-  LoadState S  = {0};
-  int status;
-  S.L = L;
-  S.Z = Z;
-  S.mode = isabs && sizeof(size_t) != sizeof(lu_int32) ? MODE_LFSA : MODE_LFS;
-  S.useStrRefs = 1;
-  S.fh = &fh;
-  L->nny++;                                 /* do not yield during undump LFS */
-  status = luaD_pcall(L, undumpLFS, &S, savestack(L, L->top), L->errfunc);
-  luaM_freearray(L, S.TS, S.TSlen);
-  luaM_freearray(L, S.buff, S.buffLen);
-  luaM_freearray(L, S.list, S.listLen);
-  luaM_freearray(L, S.pv, S.pvLen);
-  L->nny--;
-  return status;
-}
+
+

--- a/app/lua53/lundump.h
+++ b/app/lua53/lundump.h
@@ -12,83 +12,61 @@
 #include "lzio.h"
 
 /* These allow a multi=byte flag:1,type:3,data:4 packing in the tt byte */
-#define LUAU_TNIL		    (0<<4)
-#define LUAU_TBOOLEAN		(1<<4)
-#define LUAU_TNUMFLT		(2<<4)
-#define LUAU_TNUMPINT		(3<<4)
-#define LUAU_TNUMNINT		(4<<4)
-#define LUAU_TSSTRING		(5<<4)
-#define LUAU_TLSTRING		(6<<4)
-#define LUAU_TMASK      (7<<4)
-#define LUAU_DMASK      0x0f
-
+#define LUAU_TNIL      (0<<4)
+#define LUAU_TBOOLEAN  (1<<4)
+#define LUAU_TNUMFLT   (2<<4)
+#define LUAU_TNUMPINT  (3<<4)
+#define LUAU_TNUMNINT  (4<<4)
+#define LUAU_TSTRING   (5<<4)
+#define LUAU_TMASK     (7<<4)
+#define LUAU_DMASK     0x0f
 
 /* data to catch conversion errors */
-#define LUAC_DATA	"\x19\x93\r\n\x1a\n"
+#define LUAC_DATA "\x19\x93\r\n\x1a\n"
 
-#define LUAC_INT	0x5678
-#define LUAC_NUM	cast_num(370.5)
+#define LUAC_INT         0x5678
+#define LUAC_NUM         cast_num(370.5)
 #define LUAC_FUNC_MARKER 0xFE
-#define LUA_TNUMNINT  	(LUA_TNUMBER | (2 << 4))  /* negative integer numbers */
+#define LUA_TNUMNINT     (LUA_TNUMBER | (2 << 4)) /* negative integer numbers */
 
-#define MYINT(s)	(s[0]-'0')
-#define LUAC_VERSION	(MYINT(LUA_VERSION_MAJOR)*16+MYINT(LUA_VERSION_MINOR))
-#define LUAC_FORMAT         	10	     /* this is the NodeMCU format */
+#define MYINT(s)  (s[0]-'0')
+#define LUAC_VERSION  (MYINT(LUA_VERSION_MAJOR)*16+MYINT(LUA_VERSION_MINOR))
+#define LUAC_FORMAT           10       /* this is the NodeMCU format */
 #define LUAC_LFS_IMAGE_FORMAT 11
 #define LUA_STRING_SIG       "\x19ss"
 #define LUA_PROTO_SIG        "\x19pr"
 #define LUA_HDR_BYTE         '\x19'
+
+typedef void * (*luaU_Writer) (void *ud, const void *p, size_t sz);
+
+typedef struct LoadState LoadState;
+
+typedef struct luaU_data {
+  stringtable  ROstrt;
+  ROTable     *protoROTable;
+  Proto       *protoHead;
+  TString     *shortTShead;
+  TString     *longTShead;
+  int          tsTot;
+} luaU_data;
+
+
 /* load one chunk; from lundump.c */
-LUAI_FUNC LClosure* luaU_undump (lua_State* L, ZIO* Z, const char* name);
+LUAI_FUNC void luaU_undumpx (lua_State* L, ZIO* Z, const char* name, LoadState *S);
+#define luaU_undump(l,z,n)  luaU_undumpx(l,z,n,NULL)
+LUAI_FUNC LoadState *luaU_LoadState (lua_State *L, Table *t, int ROstrtSize,
+                                     luaU_Writer fw, void *fwd,
+                                     int mode, unsigned int seed);
 
-/* dump one chunk; from ldump.c */
-LUAI_FUNC int luaU_dump (lua_State* L, const Proto* f, lua_Writer w,
-                         void* data, int strip);
-LUAI_FUNC int luaU_DumpAllProtos(lua_State *L, const Proto *m, lua_Writer w,
+LUAI_FUNC void luaU_closeLoadState (LoadState *S, luaU_data *res,
+                                    const ROTable *indexMeta);
+LUAI_FUNC void luaU_addstrings(LoadState *S, const char **s, lu_byte *e);
+LUAI_FUNC int luaU_dump (lua_State *L, Table *pt, lua_Writer w,
                          void *data, int strip);
-
-LUAI_FUNC int luaU_undumpLFS(lua_State *L, ZIO *Z, int isabs);
+LUAI_FUNC unsigned int luaU_zlibcrc32 (const void *data, size_t length,
+                                       unsigned int crc);
+LUAI_FUNC const char *luaU_getbasename (lua_State *L, const TString *filename,
+                                        size_t *len);
 LUAI_FUNC int luaU_stripdebug (lua_State *L, Proto *f, int level, int recv);
-
-typedef struct FlashHeader LFSHeader;
-/*
-** The LFSHeader uses offsets rather than pointers to avoid 32 vs 64 bit issues
-** during host compilation.  The offsets are in units of lu_int32's and NOT
-** size_t, though clearly any internal pointers are of the size_t for the
-** executing architectures: 4 or 8 byte.  Likewise recources are size_t aligned
-** so LFS regions built for 64-bit execution will have 4-byte alignment packing
-** between resources.
-*/
-struct FlashHeader{
-  lu_int32 flash_sig;     /* a standard fingerprint identifying an LFS image */
-  lu_int32 flash_size;    /* Size of LFS image in bytes */
-  lu_int32 seed;          /* random number seed used in LFS */
-  lu_int32 timestamp;     /* timestamp of LFS build */
-  lu_int32 nROuse;        /* number of elements in ROstrt */
-  lu_int32 nROsize;       /* size of ROstrt */
-  lu_int32 oROhash;       /* offset of TString ** ROstrt hash */
-  lu_int32 protoROTable;  /* offset of master ROTable for proto lookup */
-  lu_int32 protoHead;     /* offset of linked list of Protos in LFS */
-  lu_int32 shortTShead;   /* offset of linked list of short TStrings in LFS */
-  lu_int32 longTShead;    /* offset of linked list of long TStrings in LFS */
-  lu_int32 reserved;
-};
-
-#ifdef LUA_USE_HOST
-extern void *LFSregion;
-LUAI_FUNC void luaN_setabsolute(lu_int32 addr);
-#endif
-
-#define FLASH_FORMAT_VERSION ( 2 << 8)
-#define FLASH_SIG_B1          0x06
-#define FLASH_SIG_B2          0x02
-#define FLASH_SIG_PASS2       0x0F
-#define FLASH_FORMAT_MASK    0xF00
-#define FLASH_SIG_B2_MASK     0x04
-#define FLASH_SIG_ABSOLUTE    0x01
-#define FLASH_SIG_IN_PROGRESS 0x08
-#define FLASH_SIG  (0xfafaa050 | FLASH_FORMAT_VERSION)
-
-#define FLASH_FORMAT_MASK    0xF00
 
 #endif


### PR DESCRIPTION
Fixes #3206 (part)

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

### Notes

-  This is a major upgrade to LFS for implement on-ESP building of LFS regions.  I have had to do some major rework of the dump / undump architecture to achieve this, and we can discuss this later. 
-  This in a initial tranche for review and comment.  I have done basic testing, but still have a lot more use cases to enumerate, so this should be considered alpha code at this stage.  I also have documentation changes and some peripheral API stuff (such as #3145) to implement.
-  I have tagged Johny and Nathaniel as reviews, as they are most familiar with the NodeMCU Lua internals.  However, any constructive input is welcome.
-  The basic functionality also works in the `luac.cross -e` environment.  Create a script containing `debug.debug()` and execute this to make a basic interpreter available.  `os` and `io` are available and there are (HOST only) base functions `lfsreload` and `lfsindex`.