### PR TITLE
Add deprecation note to node.flashreload

### DIFF
--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -41,11 +41,6 @@ static int default_onerror(lua_State *L) {
   return 0;
 }
 
-LUAI_FUNC int lua_lfsreload_deprecated (lua_State *L) {
-  platform_print_deprecation_note("node.flashreload", "soon. Use node.LFS interface instead");
-  return node_lfsreload (L);
-}
-
 // Lua: setonerror([function])
 static int node_setonerror( lua_State* L ) {
   lua_settop(L, 1);
@@ -655,6 +650,12 @@ static int node_lfsreload (lua_State *L) {
   lua_settop(L, 1);
   luaL_lfsreload(L);
   return 1;
+}
+
+// Lua: n = node.flashreload(lfsimage)
+static int lua_lfsreload_deprecated (lua_State *L) {
+  platform_print_deprecation_note("node.flashreload", "soon. Use node.LFS interface instead");
+  return node_lfsreload (L);
 }
 
 // Lua: n = node.flashindex(module)

--- a/app/modules/node.c
+++ b/app/modules/node.c
@@ -41,6 +41,11 @@ static int default_onerror(lua_State *L) {
   return 0;
 }
 
+LUAI_FUNC int lua_lfsreload_deprecated (lua_State *L) {
+  platform_print_deprecation_note("node.flashreload", "soon. Use node.LFS interface instead");
+  return node_lfsreload (L);
+}
+
 // Lua: setonerror([function])
 static int node_setonerror( lua_State* L ) {
   lua_settop(L, 1);
@@ -872,8 +877,8 @@ LROT_BEGIN(node, NULL, 0)
   LROT_FUNCENTRY( heap, node_heap )
   LROT_FUNCENTRY( info, node_info )
   LROT_TABENTRY( task, node_task )
+  LROT_FUNCENTRY( flashreload, lua_lfsreload_deprecated )
   LROT_FUNCENTRY( flashindex, node_lfsindex )
-  LROT_FUNCENTRY( flashreload, node_lfsreload )
   LROT_TABENTRY( LFS, node_lfs )
   LROT_FUNCENTRY( setonerror, node_setonerror )
   LROT_FUNCENTRY( startupcommand, node_startupcommand )


### PR DESCRIPTION
#3251.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

\<Description of and rationale behind this PR\>
