### PR TITLE
Fix problem reading files a multiple of 128 bytes long

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -442,6 +442,9 @@ static int file_g_read( lua_State* L, int n, int16_t end_char, int fd )
     int nread   = vfs_read(fd, p, nwanted);
 
     if (nread == VFS_RES_ERR || nread == 0) {
+      if (j > 0) {
+        break;
+      }
       lua_pushnil(L);
       return 1;
     }


### PR DESCRIPTION
Fixes #3277.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [N/A ] The code changes are reflected in the documentation at `docs/*`.

If we have successfully read some data from the file, then make sure we return that chunk when we get to end of file.
