### PR TITLE
Adding ' ' flag to string.format & double rounding method

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -220,6 +220,20 @@
 //#define DEVELOPMENT_BREAK_ON_STARTUP_PIN 1
 //#define DEVELOP_VERSION
 
+// By default NodeMCU Lua number is built with single-precision (32-bit) floats.
+// Some numbers do not have enough precise representation which could lead
+// to suprising results when rounding is used. E.g. 3.1415 rounded to 3 decimal
+// point digits rounds to 3.141 (="%.3f"%3.1415). This is due to the fact that
+// 3.1415 is stored as 3.141499996185303 and so rounded 3.141.
+// Enabling the setting implements a Double rounding method that makes the
+// number to be rounded to more intuitive result ("%.3f"%3.1415 prints 3.142).
+// The algorithm is as follows: if the number rounded to 7 dps does not correspond
+// to its representation (here 3.1414999 vs 3.1415000) then the number is
+// increased by the smallest increment (here to 3.141500235) which results in 
+// "correct" rounding to lower than 7 decimal places.
+
+//#define SPRINTF_ROUNDING_MODE_DOUBLEROUNDING
+
 
 // *** Heareafter, there be demons ***
 


### PR DESCRIPTION
Fixes #3265.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This PR has two commits for the time being. These are to be squashed before merger.

### The first commit implements ' ' flag to string format (%f, %g, %e)

It passes well the test performed by @mk-pmb in #3265 - this [script](https://gist.github.com/mk-pmb/be928b5508c8cb0558ae50e07fa82210).

Also it removes a part of code non compatible with Ubuntu's Lua 5.1 as well as Lua 5.3.
The code is removing the - sign for negative zero. `"%.3f"%-0.0004` should indeed give `-0.000`.

This test gives same results in NodeMCU Lua as well as in Ubuntu:
```Lua
for i=-1,1 do print(("%.3f\t%+.3f\t% .3f"):format(0.0004*i, 0.0004*i, 0.0004*i)) end
-0.000	-0.000	-0.000
0.000	+0.000	 0.000
0.000	+0.000	 0.000
```

### The second commit deals with intuitively wrong rounding

As discussed in #3265 `"%.3f"%3.1415` gives `3.141` (because of its float representation). Mathematically this is correct behavior and is not a bug per se while user would expect different behavior.
I am proposing this workaround which I think is in line with the existing logic. Note that `=3.1415` prints `3.1415` and not `3.1414999`. So when it is detected that such number would print this way the least significant bit of float mantise is added leading to "correct" rounding.

This is the test it passes well
```Lua
for i=1,20 do d=(3.1405+i*0.001); print(("%.3f\t%7f\t%.20f"):format(d, d, d)) end
3.142	3.141500	3.14149999618530273438
3.143	3.142500	3.14250016212463378906
3.144	3.143500	3.14350008964538574219
3.145	3.144500	3.14450001716613769531
3.146	3.145500	3.14550018310546875000
3.147	3.146500	3.14650011062622070313
3.148	3.147500	3.14750003814697265625
3.149	3.148500	3.14849996566772460938
3.150	3.149500	3.14950013160705566406
3.151	3.150500	3.15050005912780761719
3.152	3.151500	3.15149998664855957031
3.153	3.152500	3.15250015258789062500
3.154	3.153500	3.15350008010864257813
3.155	3.154500	3.15450000762939453125
3.156	3.155500	3.15550017356872558594
3.157	3.156500	3.15650010108947753906
3.158	3.157500	3.15750002861022949219
3.159	3.158500	3.15849995613098144531
3.160	3.159500	3.15950012207031250000
3.161	3.160500	3.16050004959106445313
```
The result is the same as on Ubuntu Lua except for `%.20f` of course as 64bit doubles are used.
It works well also for `%e` format
```Lua
for i=1,10 do d=-(3.1405+i*0.001)*1e-5; print(("%.3e\t%7e\t%.20e"):format(d, d, d)) end
-3.142e-05	-3.141500e-05	-3.14149983751121908426e-05
-3.143e-05	-3.142500e-05	-3.14249991788528859615e-05
-3.144e-05	-3.143500e-05	-3.14349999825935810804e-05
-3.145e-05	-3.144500e-05	-3.14450007863342761993e-05
-3.146e-05	-3.145500e-05	-3.14550015900749713182e-05
-3.147e-05	-3.146500e-05	-3.14649987558368593454e-05
-3.148e-05	-3.147500e-05	-3.14749995595775544643e-05
-3.149e-05	-3.148500e-05	-3.14850003633182495832e-05
-3.150e-05	-3.149500e-05	-3.14950011670589447021e-05
-3.151e-05	-3.150500e-05	-3.15049983328208327293e-05
```