### PR TITLE
add support for sw_version in node.info()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ extmods.ini
 .project
 .settings/
 .vscode/**
+
+#ignore temp file for build infos
+buildinfo.h

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ ESP32_TOOLCHAIN_DL:=$(THIS_DIR)/cache/toolchain-esp32-$(PLATFORM)-$(TOOLCHAIN_VE
 
 all: | $(ESP32_GCC)
 %: | $(ESP32_GCC)
+	@tools/update_buildinfo.sh
 	@echo Setting IDF_PATH and re-invoking...
 	@env IDF_PATH=$(IDF_PATH) PATH="$(PATH):$(ESP32_BIN)" $(MAKE) -f $(THIS_MK_FILE) $@
 	@if test "$@" = "clean"; then rm -rf $(THIS_DIR)/tools/toolchains/esp32-*; fi

--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -15,6 +15,7 @@
 #include "esp_vfs.h"
 #include "lnodeaux.h"
 #include "lflash.h"
+#include "user_version.h"
 
 // Lua: node.chipid()
 static int node_chipid( lua_State *L )
@@ -149,6 +150,36 @@ static int node_dsleep (lua_State *L)
   return 0;
 }
 
+static void add_int_field( lua_State* L, lua_Integer i, const char *name){
+  lua_pushinteger(L, i);
+  lua_setfield(L, -2, name);
+}
+
+static void add_string_field( lua_State* L, const char *s, const char *name) {
+  lua_pushstring(L, s);
+  lua_setfield(L, -2, name);
+}
+
+static int node_info( lua_State* L ){
+  const char* options[] = {"sw_version", "default", NULL};
+  int option = luaL_checkoption (L, 1, options[1], options);
+
+  switch (option) {
+    case 0: // sw_version
+    default: { // default
+      lua_createtable(L, 0, 7);
+      add_string_field(L, NODE_VERSION,          "node_version");
+      add_int_field(L, NODE_VERSION_MAJOR,       "node_version_major");
+      add_int_field(L, NODE_VERSION_MINOR,       "node_version_minor");
+      add_int_field(L, NODE_VERSION_REVISION,    "node_version_revision");
+      add_string_field(L, BUILDINFO_BRANCH,      "git_branch");
+      add_string_field(L, BUILDINFO_COMMIT_ID,   "git_commit_id");
+      add_string_field(L, BUILDINFO_RELEASE,     "git_release");
+      add_string_field(L, BUILDINFO_RELEASE_DTS, "git_commit_dts");
+      return 1;
+    }
+  }
+}
 
 extern lua_Load gLoad;
 extern bool user_process_input(bool force);
@@ -492,6 +523,7 @@ LROT_BEGIN(node)
   LROT_FUNCENTRY( flashreload,luaN_reload_reboot )
   LROT_FUNCENTRY( flashindex, luaN_index )
   LROT_FUNCENTRY( heap,       node_heap )
+  LROT_FUNCENTRY( info,       node_info )
   LROT_FUNCENTRY( input,      node_input )
   LROT_FUNCENTRY( output,     node_output )
   LROT_FUNCENTRY( osprint,    node_osprint )

--- a/components/platform/include/user_version.h
+++ b/components/platform/include/user_version.h
@@ -1,6 +1,8 @@
 #ifndef __USER_VERSION_H__
 #define __USER_VERSION_H__
 
+#include <buildinfo.h>
+
 #define NODE_VERSION_MAJOR		0U
 #define NODE_VERSION_MINOR		0U
 #define NODE_VERSION_REVISION	0U
@@ -8,7 +10,7 @@
 
 #define NODE_VERSION	"NodeMCU ESP32"
 #ifndef BUILD_DATE
-#define BUILD_DATE	  "unspecified"
+#define BUILD_DATE	  BUILDINFO_BUILD_DATE
 #endif
 
 #define SDK_VERSION "IDF"

--- a/docs/modules/node.md
+++ b/docs/modules/node.md
@@ -153,28 +153,40 @@ system heap size left in bytes (number)
 
 ## node.info()
 
-Returns NodeMCU version, chipid, flashid, flash size, flash mode, flash speed.
+Returns information about the software version.
 
 #### Syntax
-`node.info()`
+`node.info([group])`
 
 #### Parameters
-none
+`group` A designator for a group of properties. Only `"sw_version"` is supported at this time.
 
 #### Returns
- - `majorVer` (number)
- - `minorVer` (number)
- - `devVer` (number)
- - `chipid` (number)
- - `flashid` (number)
- - `flashsize` (number)
- - `flashmode` (number)
- - `flashspeed` (number)
+If a `group` is given the return value will be a table containing the following elements:
+
+- for `group` = `"sw_version"`
+	- `git_branch` (string)
+	- `git_commit_id` (string)
+	- `git_release` (string) release name +additional commits e.g. "2.0.0-master_20170202 +403"
+	- `git_commit_dts` (string) commit timestamp in an ordering format. e.g. "201908111200"
+	- `node_version_major` (number)
+	- `node_version_minor` (number)
+	- `node_version_revision` (number)
+  - `node_version` (string)
+
+!!! attention
+
+	Not providing a `group` will result in the "sw_version" group being returned.
 
 #### Example
 ```lua
-majorVer, minorVer, devVer, chipid, flashid, flashsize, flashmode, flashspeed = node.info()
-print("NodeMCU "..majorVer.."."..minorVer.."."..devVer)
+for k,v in pairs(node.info("sw_version")) do
+  print (k,v)
+end
+```
+
+```lua
+print(node.info("sw_version").git_release)
 ```
 
 ## node.input()
@@ -446,11 +458,11 @@ provides more detailed information on the EGC.
 #### Parameters
 - `mode`
 	- `node.egc.NOT_ACTIVE` EGC inactive, no collection cycle will be forced in low memory situations
-	- `node.egc.ON_ALLOC_FAILURE` Try to allocate a new block of memory, and run the garbage collector if the allocation fails. If the allocation fails even after running the garbage collector, the allocator will return with error. 
+	- `node.egc.ON_ALLOC_FAILURE` Try to allocate a new block of memory, and run the garbage collector if the allocation fails. If the allocation fails even after running the garbage collector, the allocator will return with error.
 	- `node.egc.ON_MEM_LIMIT` Run the garbage collector when the memory used by the Lua script goes beyond an upper `limit`. If the upper limit can't be satisfied even after running the garbage collector, the allocator will return with error.
 	- `node.egc.ALWAYS` Run the garbage collector before each memory allocation. If the allocation fails even after running the garbage collector, the allocator will return with error. This mode is very efficient with regards to memory savings, but it's also the slowest.
 - `level` in the case of `node.egc.ON_MEM_LIMIT`, this specifies the memory limit.
-  
+
 #### Returns
 `nil`
 
@@ -463,11 +475,11 @@ provides more detailed information on the EGC.
 
 ## node.task.post()
 
-Enable a Lua callback or task to post another task request. Note that as per the 
-example multiple tasks can be posted in any task, but the highest priority is 
+Enable a Lua callback or task to post another task request. Note that as per the
+example multiple tasks can be posted in any task, but the highest priority is
 always delivered first.
 
-If the task queue is full then a queue full error is raised.  
+If the task queue is full then a queue full error is raised.
 
 ####Syntax
 `node.task.post([task_priority], function)`
@@ -477,7 +489,7 @@ If the task queue is full then a queue full error is raised.
 	- `node.task.LOW_PRIORITY` = 0
 	- `node.task.MEDIUM_PRIORITY` = 1
 	- `node.task.HIGH_PRIORITY` = 2
-- `function` a callback function to be executed when the task is run. 
+- `function` a callback function to be executed when the task is run.
 
 If the priority is omitted then  this defaults  to `node.task.MEDIUM_PRIORITY`
 
@@ -486,12 +498,12 @@ If the priority is omitted then  this defaults  to `node.task.MEDIUM_PRIORITY`
 
 #### Example
 ```lua
-for i = node.task.LOW_PRIORITY, node.task.HIGH_PRIORITY do 
+for i = node.task.LOW_PRIORITY, node.task.HIGH_PRIORITY do
   node.task.post(i,function(p2)
     print("priority is "..p2)
-  end) 
-end      
-``` 
+  end)
+end
+```
 prints
 ```
 priority is 2

--- a/tools/update_buildinfo.sh
+++ b/tools/update_buildinfo.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+COMMIT_ID="$(git rev-parse HEAD)"
+BRANCH="$(git rev-parse --abbrev-ref HEAD | sed -E 's/[\/\\]+/_/g')"
+RELEASE="$(git describe --tags --long | sed -E 's/(.*)-(.*)-.*/\1 +\2/g' | sed 's/ +0$//')"
+RELEASE_DTS=$(TZ=UTC git show --quiet --date=format-local:"%Y%m%d%H%M" --format="%cd" HEAD)
+BUILD_DATE="$(date "+%Y-%m-%d %H:%M")"
+
+# create temp buildinfo
+TEMPFILE=/tmp/buildinfo.h
+cat > $TEMPFILE << EndOfMessage
+#ifndef __BUILDINFO_H__
+#define __BUILDINFO_H__
+
+#define USER_PROLOG "$USER_PROLOG"
+#define BUILDINFO_BRANCH "$BRANCH"
+#define BUILDINFO_COMMIT_ID "$COMMIT_ID"
+#define BUILDINFO_RELEASE "$RELEASE"
+#define BUILDINFO_RELEASE_DTS "$RELEASE_DTS"
+#define BUILDINFO_BUILD_DATE "$BUILD_DATE"
+
+EndOfMessage
+
+echo "#endif	/* __BUILDINFO_H__ */" >> $TEMPFILE
+
+diff -q $TEMPFILE components/platform/include/buildinfo.h || cp $TEMPFILE components/platform/include/buildinfo.h
+rm $TEMPFILE


### PR DESCRIPTION
Fixes #2759 

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This PR adds basic support for the previously missing node.info() method on esp32.  It is modeled after the newer `group` properties design found in the 8266 codebase. At this time only the `sw_version` group is implemented.

I also partially ported the `update_buildinfo.sh` script to expose build info associated with the `sw_version` group.  

Autoformatter cleaned up a few rogue spaces in the .md file before I turned it off.  This is why some non-related edits exist in the docs.