### PR TITLE
Fix lowprio

### DIFF
--- a/app/lua53/lnodemcu.c
+++ b/app/lua53/lnodemcu.c
@@ -628,7 +628,6 @@ extern void lua_main(void);
 ** Task callback handler. Uses luaN_call to do a protected call with full traceback
 */
 static void do_task (platform_task_param_t task_fn_ref, uint8_t prio) {
-  //dbg_printf("do_task(%d, %d)\n", task_fn_ref, prio);
   lua_State* L = lua_getstate();
   if(task_fn_ref == (platform_task_param_t)~0 && prio == LUA_TASK_HIGH) {
     lua_main();                   /* Undocumented hook for lua_main() restart */

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -376,6 +376,8 @@ uint32_t platform_rcr_write (uint8_t rec_id, const void *rec, uint8_t size);
 typedef void (*platform_task_callback_t)(platform_task_param_t param, uint8 prio);
 platform_task_handle_t platform_task_get_id(platform_task_callback_t t);
 
+typedef void (*lowest_task_t)(platform_task_param_t task_fn_ref, uint8_t prio);
+void platform_set_lowest_task(platform_task_handle_t handle, lowest_task_t fn);
 bool platform_post(uint8 prio, platform_task_handle_t h, platform_task_param_t par);
 #define platform_freeheap() system_get_free_heap_size()
 


### PR DESCRIPTION
Fixes #3285 (partly).

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

This fixes (for the LUA5.3 version) the lowest priority task from `node.task.post` so that it runs *below* the priority of all the Espressif stuff. This means that you can hard reschedule at LOW_PRIO and still have the system function fine. What is less clear to me is whether we want MEDIUM to behave like this as well.....

I should probably fix the lua5.1 build as well..... I need to update the documentation.

By the way, the implementation/idea is taken from a comment on the espressif bbs and the implementation in the arduino port (which has a model of constantly running code).