### PR TITLE
Fix platform_post by adding ICACHE_RAM_ATTR

### DIFF
--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -1151,7 +1151,3 @@ platform_task_handle_t platform_task_get_id (platform_task_callback_t t) {
   TQB.task_func[TQB.task_count++] = t;
   return TH_MONIKER + ((TQB.task_count-1) << TH_SHIFT);
 }
-
-bool ICACHE_RAM_ATTR platform_post (uint8 prio, platform_task_handle_t handle, platform_task_param_t par) {
-  return system_os_post(prio, handle | prio, par);
-}

--- a/app/platform/platform.c
+++ b/app/platform/platform.c
@@ -1152,6 +1152,6 @@ platform_task_handle_t platform_task_get_id (platform_task_callback_t t) {
   return TH_MONIKER + ((TQB.task_count-1) << TH_SHIFT);
 }
 
-bool platform_post (uint8 prio, platform_task_handle_t handle, platform_task_param_t par) {
+bool ICACHE_RAM_ATTR platform_post (uint8 prio, platform_task_handle_t handle, platform_task_param_t par) {
   return system_os_post(prio, handle | prio, par);
 }

--- a/app/platform/platform.h
+++ b/app/platform/platform.h
@@ -376,7 +376,9 @@ uint32_t platform_rcr_write (uint8_t rec_id, const void *rec, uint8_t size);
 typedef void (*platform_task_callback_t)(platform_task_param_t param, uint8 prio);
 platform_task_handle_t platform_task_get_id(platform_task_callback_t t);
 
-bool platform_post(uint8 prio, platform_task_handle_t h, platform_task_param_t par);
+static inline bool platform_post(uint8 prio, platform_task_handle_t handle, platform_task_param_t par) {
+  return system_os_post(prio, handle | prio, par);
+}
 #define platform_freeheap() system_get_free_heap_size()
 
 // Get current value of CCOUNt register


### PR DESCRIPTION
Fixes #3285 (maybe).



- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.

The ICACHE_RAM_ATTR is missing from the platform_post function and this could cause all sorts of failures under high event loads.
