### PR TITLE
Fixing bug in `file.readline` when line length exceeds 128 chars

### DIFF
--- a/app/modules/file.c
+++ b/app/modules/file.c
@@ -452,7 +452,7 @@ static int file_g_read( lua_State* L, int n, int16_t end_char, int fd )
     for (i = 0; i < nread; ++i) {
       luaL_addchar(&b, p[i]);
       if (p[i] == end_char) {
-        vfs_lseek(fd, -nread + j + i + 1, VFS_SEEK_CUR); //reposition after end char found
+        vfs_lseek(fd, -nread + i + 1, VFS_SEEK_CUR); //reposition after end char found
         nread = 0;   // force break on outer loop
         break;
       }


### PR DESCRIPTION
Fixes #3301.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Fixes bug in  `file.readline` (in fact in `file.read`) when line length exceeds 128 chars.