### PR TITLE
Fix the initialization of the wifi default hostname. 

### DIFF
--- a/app/include/user_config.h
+++ b/app/include/user_config.h
@@ -165,7 +165,9 @@
 // alphanumeric characters. If you are imaging multiple modules with this
 // firmware then you must also define WIFI_STA_HOSTNAME_APPEND_MAC to
 // append the last 3 octets of the MAC address.  Note that the total
-// Hostname MUST be 32 chars or less.
+// Hostname MUST be 32 chars or less. If the resulting hostname is 
+// invalid, then it will not be used, and a message will be printed
+// during boot.
 
 //#define WIFI_STA_HOSTNAME "NodeMCU"
 //#define WIFI_STA_HOSTNAME_APPEND_MAC

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1969,28 +1969,24 @@ void wifi_change_default_host_name(void)
   uint8 opmode_temp=wifi_get_opmode();
   wifi_set_opmode_current(STATION_MODE);
   char temp[33] = {0};//32 chars + NULL
-  uint8_t mac[6];
-  wifi_get_macaddr(STATION_IF, mac);
 
-#ifndef WIFI_STA_HOSTNAME
-  sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
-#elif defined(WIFI_STA_HOSTNAME) && !defined(WIFI_STA_HOSTNAME_APPEND_MAC)
-  if(wifi_sta_checkhostname(WIFI_STA_HOSTNAME, strlen(WIFI_STA_HOSTNAME))){
-    sprintf(temp, "%s", WIFI_STA_HOSTNAME);
-  }
-  else{
-    sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
-  }
-#elif defined(WIFI_STA_HOSTNAME) && defined(WIFI_STA_HOSTNAME_APPEND_MAC)
-  if(strlen(WIFI_STA_HOSTNAME) <= 26 && wifi_sta_checkhostname(WIFI_STA_HOSTNAME, strlen(WIFI_STA_HOSTNAME))){
-    sprintf(temp, "%s%X%X%X", WIFI_STA_HOSTNAME, (mac)[3], (mac)[4], (mac)[5]);
-  }
-  else{
-    sprintf(temp, "NODE-%X%X%X", (mac)[3], (mac)[4], (mac)[5]);
+  const char *hostname = "NODE";
+#ifdef WIFI_STA_HOSTNAME
+  if (wifi_sta_checkhostname(WIFI_STA_HOSTNAME, strlen(WIFI_STA_HOSTNAME))) {
+    hostname = WIFI_STA_HOSTNAME;
   }
 #endif
 
-  wifi_station_set_hostname((char*)temp);
+#if defined(WIFI_STA_HOSTNAME_APPEND_MAC) || !defined(WIFI_STA_HOSTNAME)
+  uint8_t mac[6];
+  wifi_get_macaddr(STATION_IF, mac);
+
+  snprintf(temp, sizeof(temp), "%s-%02X%02X%02X", hostname, (mac)[3], (mac)[4], (mac)[5]);
+#else
+  snprintf(temp, sizeof(temp), "%s", hostname);
+#endif
+
+  wifi_station_set_hostname(temp);
 
   if(opmode_temp != wifi_get_opmode()){
     wifi_set_opmode_current(opmode_temp);

--- a/app/modules/wifi.c
+++ b/app/modules/wifi.c
@@ -1970,23 +1970,32 @@ void wifi_change_default_host_name(void)
   wifi_set_opmode_current(STATION_MODE);
   char temp[33] = {0};//32 chars + NULL
 
+#if defined(WIFI_STA_HOSTNAME)
+  const char *hostname = WIFI_STA_HOSTNAME;
+#else
   const char *hostname = "NODE";
-#ifdef WIFI_STA_HOSTNAME
-  if (wifi_sta_checkhostname(WIFI_STA_HOSTNAME, strlen(WIFI_STA_HOSTNAME))) {
-    hostname = WIFI_STA_HOSTNAME;
-  }
 #endif
 
 #if defined(WIFI_STA_HOSTNAME_APPEND_MAC) || !defined(WIFI_STA_HOSTNAME)
   uint8_t mac[6];
   wifi_get_macaddr(STATION_IF, mac);
 
-  snprintf(temp, sizeof(temp), "%s-%02X%02X%02X", hostname, (mac)[3], (mac)[4], (mac)[5]);
+  int len = snprintf(temp, sizeof(temp), "%s-%02X%02X%02X", hostname, (mac)[3], (mac)[4], (mac)[5]);
 #else
-  snprintf(temp, sizeof(temp), "%s", hostname);
+  int len = snprintf(temp, sizeof(temp), "%s", hostname);
+#endif
+
+#if defined(WIFI_STA_HOSTNAME)
+  if (wifi_sta_checkhostname(temp, len)) {
 #endif
 
   wifi_station_set_hostname(temp);
+
+#if defined(WIFI_STA_HOSTNAME)
+  } else {
+    dbg_printf("\nInvalid hostname: %s\n", temp);
+  }
+#endif
 
   if(opmode_temp != wifi_get_opmode()){
     wifi_set_opmode_current(opmode_temp);

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -311,9 +311,6 @@ void user_init(void) {
 #ifdef LUA_USE_MODULES_RTCTIME
     rtctime_late_startup ();
 #endif
-#ifdef LUA_USE_MODULES_WIFI
-    wifi_change_default_host_name();
-#endif
     if( platform_init() != PLATFORM_OK ) {
         // This should never happen
         NODE_DBG("Can not init platform for modules.\n");
@@ -321,6 +318,9 @@ void user_init(void) {
     }
     UartBautRate br = BIT_RATE_DEFAULT;
     uart_init (br, br);
+#ifdef LUA_USE_MODULES_WIFI
+    wifi_change_default_host_name();
+#endif
 #ifndef NODE_DEBUG
     system_set_os_print(0);
 #endif

--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -25,6 +25,7 @@
 #include "mem.h"
 #include "espconn.h"
 #include "sections.h"
+#include "../modules/wifi_common.h"
 
 #ifdef LUA_USE_MODULES_RTCTIME
 #include "rtc/rtctime.h"
@@ -300,17 +301,6 @@ void nodemcu_init(void) {
      lua_main();  // If it returns true then LFS restart is needed
 }
 
-#ifdef LUA_USE_MODULES_WIFI
-#include "../modules/wifi_common.h"
-
-void user_rf_pre_init(void)
-{
-//set WiFi hostname before RF initialization (adds ~479 us to boot time)
-  wifi_change_default_host_name();
-}
-#endif
-
-
 /******************************************************************************
  * FunctionName : user_init
  * Description  : entry of user application, init user function here
@@ -320,6 +310,9 @@ void user_rf_pre_init(void)
 void user_init(void) {
 #ifdef LUA_USE_MODULES_RTCTIME
     rtctime_late_startup ();
+#endif
+#ifdef LUA_USE_MODULES_WIFI
+    wifi_change_default_host_name();
 #endif
     if( platform_init() != PLATFORM_OK ) {
         // This should never happen


### PR DESCRIPTION
Fixes #3297.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- N/A The code changes are reflected in the documentation at `docs/*`.

It turns out that the user_rf_pre_init is not called any more. This change really just moves the call into the user_init. However, I also cleaned up the wifi_set_default_host_name() function so it uses fewer #ifdefs 
