### PR TITLE
Don't free a ref of zero -- bad things happen...

### DIFF
--- a/app/modules/gpio_pulse.c
+++ b/app/modules/gpio_pulse.c
@@ -416,7 +416,9 @@ static int gpio_pulse_start(lua_State *L) {
     return luaL_error( L, "missing callback" );
   }
 
-  luaL_unref(L, LUA_REGISTRYINDEX, pulser->cb_ref);
+  if (pulser->cb_ref) {
+    luaL_unref(L, LUA_REGISTRYINDEX, pulser->cb_ref);
+  }
   pulser->cb_ref = luaL_ref(L, LUA_REGISTRYINDEX);
 
   active_pulser = pulser;


### PR DESCRIPTION
Fixes #2940.

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.

It turns out that a `luaL_unref(L, LUA_REGISTRYINDEX, 0)` has the rather surprising effect of throwing away the freelist of cells in the registry. This means that the registry then tends to grow. I wonder how many other places this happens!
