### PR TITLE
MCP23017 module refactorings to save some heap

### DIFF
--- a/lua_modules/mcp23017/mcp23017.lua
+++ b/lua_modules/mcp23017/mcp23017.lua
@@ -26,34 +26,6 @@
 local i2c, string, issetBit, setBit, clearBit =
       i2c, string, bit.isset, bit.set, bit.clear
 
--- registers (not used registers are commented out)
-local MCP23017_IODIRA = 0x00
-local MCP23017_IODIRB = 0x01
-local MCP23017_DEFVALA = 0x06
-local MCP23017_DEFVALB = 0x07
-local MCP23017_GPIOA = 0x12
-local MCP23017_GPIOB = 0x13
---[[
-local MCP23017_IPOLA = 0x02
-local MCP23017_IPOLB = 0x03
-local MCP23017_GPINTENA = 0x04
-local MCP23017_GPINTENB = 0x05
-local MCP23017_DEFVALA = 0x06
-local MCP23017_DEFVALB = 0x07
-local MCP23017_INTCONA = 0x08
-local MCP23017_INTCONB = 0x09
-local MCP23017_IOCON = 0x0A
-local MCP23017_IOCON2 = 0x0B
-local MCP23017_GPPUA = 0x0C
-local MCP23017_GPPUB = 0x0D
-local MCP23017_INTFA = 0x0E
-local MCP23017_INTFB = 0x0F
-local MCP23017_INTCAPA = 0x10
-local MCP23017_INTCAPB = 0x11
-local MCP23017_OLATA = 0x14
-local MCP23017_OLATB = 0x15
-]]
-
 -- metatable
 local mcp23017 = {
     -- convenience parameter enumeration names
@@ -106,30 +78,30 @@ end
 
 function mcp23017:writeIODIR(bReg, newByte)
     writeByte(self.address, self.i2cId,
-        bReg and MCP23017_IODIRB or MCP23017_IODIRA, newByte)
+        bReg and 0x1 --[[IODIRB register]] or 0x0 --[[IODIRA register]], newByte)
 end
 
 function mcp23017:writeGPIO(bReg, newByte)
     writeByte(self.address, self.i2cId,
-        bReg and MCP23017_GPIOB or MCP23017_GPIOA, newByte)
+        bReg and 0x13 --[[GPIOB register]] or 0x12 --[[GPIOA register]], newByte)
 end
 
 function mcp23017:readGPIO(bReg)
     return readByte(self.address, self.i2cId,
-        bReg and MCP23017_GPIOB or MCP23017_GPIOA)
+        bReg and 0x13 --[[GPIOB register]] or 0x12 --[[GPIOA register]])
 end
 
 -- read pin input
 function mcp23017:getPinState(bReg, pin)
     return issetBit(readByte(self.address, self.i2cId,
-        bReg and MCP23017_GPIOB or MCP23017_GPIOA),
+        bReg and 0x13 --[[GPIOB register]] or 0x12 --[[GPIOA register]]),
         checkPinIsInRange(pin))
 end
 
 -- set pin to low or high
 function mcp23017:setPin(bReg, pin, state)
     local a, i = self.address, self.i2cId
-    local inReq = bReg and MCP23017_GPIOB or MCP23017_GPIOA
+    local inReq = bReg and 0x13 --[[GPIOB register]] or 0x12 --[[GPIOA register]]
     local inPin = checkPinIsInRange(pin)
     local response = readByte(a, i, inReq)
     writeByte(a, i, inReq,
@@ -140,7 +112,7 @@ end
 -- set mode for a pin
 function mcp23017:setMode(bReg, pin, mode)
     local a, i = self.address, self.i2cId
-    local inReq = bReg and MCP23017_IODIRB or MCP23017_IODIRA
+    local inReq = bReg and 0x1 --[[IODIRB register]] or 0x0 --[[IODIRA register]]
     local inPin = checkPinIsInRange(pin)
     local response = readByte(a, i, inReq)
     writeByte(a, i, inReq,
@@ -151,14 +123,14 @@ end
 -- reset gpio mode
 function mcp23017:reset()
     local a, i = self.address, self.i2cId
-    writeByte(a, i, MCP23017_IODIRA, 0xFF)
-    writeByte(a, i, MCP23017_IODIRB, 0xFF)
+    writeByte(a, i, 0x0 --[[IODIRA register]], 0xFF)
+    writeByte(a, i, 0x1 --[[IODIRB register]], 0xFF)
 end
 
 -- setup internal pullup
 function mcp23017:setInternalPullUp(bReg, iByte)
     writeByte(self.address, self.i2cId,
-        bReg and MCP23017_DEFVALB or MCP23017_DEFVALA, iByte)
+        bReg and 0x7 --[[DEFVALB register]] or 0x6 --[[DEFVALA register]], iByte)
 end
 
 return function(address, i2cId)


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Experimentally, I made some changes I had suggested for #3197 and would like to report my findings for consideration and possible merge.  I recognize the danger of violence applied to deceased equines, however I continue to feel that there is significant low-hanging technological debt within our tree and I would like new modules to be exemplars of not creating more.

Heap measurements were taken by quiescing the ESP as much as possible (no Lua tasks or timers, `wifi.sta.disconnect()`) and taking the maximum of five outputs of `=node.heap()` across several seconds after each line of input; at startup, there are 44488 bytes of heap available.  The ESP is running Lua 5.3 with the garbage collector policy modified by `collectgarbage("setpause", 0); collectgarbage("step", 100)`, which should have the effect of reclaiming garbage as aggressively as possible.  The Lua module is given to the ESP as a file in SPIFFS; LFS is likely to have no significant impact on the conclusions of these experiments, as we are primarily measuring the impact of necessarily dynamic structures on the heap (local values and closures).

# As merged

The module was modified to not need hardware available to it, using this hack.  This slightly reduces the code size, but not in any way likely significant to the conclusions drawn from the experiment.

```diff
diff --git a/lua_modules/mcp23017/mcp23017.lua b/lua_modules/mcp23017/mcp23017.lua
index 47aedccf..ceff4b8e 100644
--- a/lua_modules/mcp23017/mcp23017.lua
+++ b/lua_modules/mcp23017/mcp23017.lua
@@ -62,10 +62,7 @@ mcp23017.__index = mcp23017
 
 -- check device is available on address
 local function checkDevice(address, i2cId)
-    i2c.start(i2cId)
-    local response = i2c.address(i2cId, address, i2c.TRANSMITTER)
-    i2c.stop(i2cId)
-    return response
+  return true
 end
 
 -- write byte
@@ -111,12 +108,14 @@ local function setup(address, i2cId)
         error("MCP23017 address is out of range")
     end
 
-    if (checkDevice(address, i2cId) ~= true) then
-        error("MCP23017 device on " .. string.format('0x%02X', address) .. " not found")
-    else
-        reset(address, i2cId)
-        return 1
-    end
+    return true
+
+    -- if (checkDevice(address, i2cId) ~= true) then
+    --     error("MCP23017 device on " .. string.format('0x%02X', address) .. " not found")
+    -- else
+    --     reset(address, i2cId)
+    --     return 1
+    -- end
 end
 
 return function(address, i2cId)
```

| command         | heap (delta) |
|-----------------|--------------|
| `x = loadfile`  | 37944 (6544) |
| `y = x()`       | 36408 (1536) |
| `z1 = y(32, 0)` | 35504 (904)  |
| `z2 = y(33, 1)` | 34472 (1032) |

Summary: there are roughly 6.5KB of code loaded and 1.5K of dynamic structure created for the module itself (e.g., the metatable, top-level locals, and any initial closures constructed).  Each instance of the MCP23017 driver occupies around 1K of heap.

# Commit 1 ("functions to metatable")

This commit mostly moves functions from instances to the module's metatable and avoids creating closures.  Some `local`s holding constants are eliminated, which additionally reduces the size of the closures that do get created (now mostly at module instantiation time, not instance construction time).

Again the module was modified to not need hardware:

```diff
diff --git a/lua_modules/mcp23017/mcp23017.lua b/lua_modules/mcp23017/mcp23017.lua
index bde1a080..e5bfe959 100644
--- a/lua_modules/mcp23017/mcp23017.lua
+++ b/lua_modules/mcp23017/mcp23017.lua
@@ -169,11 +169,11 @@ return function(address, i2cId)
         error("MCP23017 address is out of range")
     end
 
-    if (checkDevice(address, i2cId) ~= true) then
-        error("MCP23017 device on " .. string.format('0x%02X', address) .. " not found")
-    end
+    -- if (checkDevice(address, i2cId) ~= true) then
+    --     error("MCP23017 device on " .. string.format('0x%02X', address) .. " not found")
+    -- end
 
-    reset(address, i2cId)
+    -- reset(address, i2cId)
     return self
 end
 
```

| command         | heap (delta) |
|-----------------|--------------|
| `x = loadfile`  | 38024 (6464) |
| `y = x()`       | 36408 (1616) |
| `z1 = y(32, 0)`  | 36224 (184)  |
| `z2 = y(33, 1)`  | 35968 (256)  |

Summary: No significant changes to code size or initial module construction, but substantial reduction in per-instance costs by avoiding the creation of closures for each function.  The difference between first and second is likely just sampling noise; nevertheless, this delta achieves a heap savings of approximately 748 bytes per instance on average (~ 75% reduction).

# Commit 2 ("inline constants")

This is a more, and possibly unacceptably, aggressive inlining of constants instead of using `local`s.  The savings are not overwhelming, but, IMHO, still worth accepting into the tree.  The savings would be more substantial if the features corresponding to the other registers were also implemented, and so I view the use of inline constants as _more scalable_ than `local`s.

The same no-hardware diff as above was applied.

| command         | heap (delta) |
|-----------------|--------------|
| `x = loadfile`  | 38280 (6208) |
| `y = x()`       | 36952 (1328) |
| `z1 = y(32, 0)`  | 36776 (176)  |
| `z2 = y(33, 1)`  | 36496 (280)  |

Summary: We see that this gives a further saving of approximately 256 bytes of code (insignificant with LFS deployed) but also 288 bytes of heap at module construction time, or about 0.5% of the total heap space available at module startup.  Per-instance overheads are not significantly changed (and are again  probably just sampling noise).

# Summary

The `mcp23017` module as merged is likely fine, and at worst a tad overzealous in its heap usage, for the most common scenario of one MCP23017 in use.  However, it has poor scaling linear factors in two dimensions: 1) if instantiated multiple times, the per-instance overhead is excessive, and 2) as more of the chip's features are elaborated into Lua, the use of on-heap `local`s to hold integer constants will bloat the dynamic heap rather than the code size (which can be borne by LFS).

Why do I care so much, anyway?  As the proposed #2983 test environment and harness uses a MCP23017 for GPIO testing, it would be nice to replace the bespoke driver in that series with this now-mainlined module.  But testing NodeMCU frequently runs up against memory limitations and not exacerbating those would be quite nice.