### PR TITLE
BME280 Lua module - `(config[3] & 0xFC) | BME280_FORCED_MODE` workaround bug fix

### DIFF
--- a/lua_modules/bme280/bme280.lua
+++ b/lua_modules/bme280/bme280.lua
@@ -130,8 +130,8 @@ function bme280_startreadout(self, callback, delay, alt)
   delay = delay or BME280_SAMPLING_DELAY
 
   if self._isbme then write_reg(self.id, self.addr, BME280_REGISTER_CONTROL_HUM, self._config[2]) end
-  write_reg(self.id, self.addr, BME280_REGISTER_CONTROL, math_floor(self._config[3]:byte(1)/4)+ 1)
-    -- math_floor(self._config[3]:byte(1)/4)+ 1
+  write_reg(self.id, self.addr, BME280_REGISTER_CONTROL, 4*math_floor(self._config[3]:byte(1)/4)+ 1)
+    -- 4*math_floor(self._config[3]:byte(1)/4)+ 1
     --   an awful way to avoid bit operations but calculate (config[3] & 0xFC) | BME280_FORCED_MODE
     -- Lua 5.3 integer division // would be more suitable
 


### PR DESCRIPTION
Fixes #3323.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Fixes the workaround calculation of `(config[3] & 0xFC) | BME280_FORCED_MODE` by formula `4*math_floor(self._config[3]:byte(1)/4)+ 1` where a multiplication back by 4 (`shl 2`) was missing.
