### PR TITLE
Add GitHub Actions to do our CI Builds. Will build in parallel and many more jobs than now.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ release ]
   pull_request:
-    branches: [ dev ]
+    branches: [ dev, release ]
 
 jobs:
 
@@ -20,7 +20,7 @@ jobs:
             numbers: 'integral'  
           - lua_ver: 53
             numbers: '64bit'  
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     env:
       LUA: ${{ matrix.lua_ver }}
@@ -96,7 +96,7 @@ jobs:
             numbers: '64bit'  
             filter: 'cat'
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     steps:
     - name: Checkout repo
@@ -159,7 +159,7 @@ jobs:
           - lua_ver: 53
             numbers: '64bit'  
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     steps:
     - name: Checkout repo
@@ -216,7 +216,7 @@ jobs:
       matrix:
         include:
           - os: 'linux'
-            vm: 'ubuntu-latest'
+            vm: 'ubuntu-16.04'
           - os: 'windows'
             vm: 'windows-latest'
     runs-on: ${{ matrix.vm }} 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,235 @@ on:
     branches: [ dev ]
 
 jobs:
-  build:
 
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        lua_ver: [51, 53]
+        numbers: ['float']
+        include:
+          - lua_ver: 51
+            numbers: 'integral'  
+          - lua_ver: 53
+            numbers: '64bit'  
     runs-on: ubuntu-latest
+
+    env:
+      LUA: ${{ matrix.lua_ver }}
 
     steps:
     - uses: actions/checkout@v2
-    - name: make
+      with:
+        submodules: true
+    - run: pip install pyserial
+      shell: bash
+    - run: sudo apt install srecord
+      shell: bash
+    - name: Build firmware
+      if: matrix.numbers == 'float'
       run: make
+      shell: bash
+    - name: Build integral firmware
+      if: ${{ matrix.numbers == 'integral' }}
+      run: |
+        make EXTRA_CCFLAGS="-DLUA_NUMBER_INTEGRAL"
+        mv luac.cross.int luac.cross
+      shell: bash
+    - name: Build 64bit firmware
+      if: ${{ matrix.numbers == '64bit' }}
+      run: |
+        make EXTRA_CCFLAGS="-DLUA_NUMBER_64BITS"
+      shell: bash
+    - name: Upload luac.cross
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: luac.cross_${{ matrix.lua_ver }}_${{ matrix.numbers }}
+        path: luac.cross
+
+
+  build_luac_cross_win:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Build luac.cross.exe
+      run: |
+        set
+        "%programfiles%\git\usr\bin\xargs"
+        cd msvc
+        "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" /p:Configuration=Release /p:Platform=x64
+        mv luac-cross/x64/Release/luac.cross.exe ..
+      shell: cmd
+    - name: Upload luac.cross
+      if: ${{ success() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: luac.cross_51_float_win
+        path: luac.cross.exe
+
+
+  compile_lua:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        lua_ver: [51, 53]
+        numbers: ['float']
+        filter: [ 'cat' ]
+        include:
+          - lua_ver: 51
+            numbers: 'integral'
+            filter: 'grep -v "lua_modules/lm92/lm92.lua\|lua_modules/hdc1000/HDC1000.lua\|lua_examples/u8g2/graphics_test.lua"'  
+          - lua_ver: 53
+            numbers: '64bit'  
+            filter: 'cat'
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Download luac.cross
+      uses: actions/download-artifact@v1
+      with:
+        name: luac.cross_${{ matrix.lua_ver }}_${{ matrix.numbers }}
+        path: ./
+    - name: Fix file permission
+      run: chmod +x luac.cross
+    - name: compile Lua
+      run: |
+        find lua_modules lua_examples tests/NTest* -iname "*.lua" | ${{ matrix.filter }} | xargs --delimiter="\n" echo
+        find lua_modules lua_examples tests/NTest* -iname "*.lua" | ${{ matrix.filter }} | xargs --delimiter="\n" ./luac.cross -p
+      shell: bash
+
+
+  compile_lua_win:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        lua_ver: [51]
+        numbers: ['float']
+        filter: [ 'cat' ]
+    needs: build_luac_cross_win
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Download luac.cross
+      uses: actions/download-artifact@v1
+      with:
+        name: luac.cross_${{ matrix.lua_ver }}_${{ matrix.numbers }}_win
+        path: ./
+    - name: compile Lua
+      run: |
+        PATH="/C/Program\ Files/Git/usr/bin:${PATH}"
+        find lua_modules lua_examples tests/NTest* -iname "*.lua" | ${{ matrix.filter }} | xargs --delimiter="\n" echo
+        find lua_modules lua_examples tests/NTest* -iname "*.lua" | ${{ matrix.filter }} | xargs --delimiter="\n" ./luac.cross -p
+      shell: bash
+
+
+  NTest:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        lua_ver: [51, 53]
+        numbers: ['float']
+        include:
+          - lua_ver: 51
+            numbers: 'integral'  
+          - lua_ver: 53
+            numbers: '64bit'  
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Download luac.cross
+      uses: actions/download-artifact@v1
+      with:
+        name: luac.cross_${{ matrix.lua_ver }}_${{ matrix.numbers }}
+        path: ./
+    - name: Fix file permission
+      run: chmod +x luac.cross
+    - name: NTest selfcheck
+      run: |
+        cd tests/NTest
+        ../../luac.cross -e ../NTest/NTest_NTest.lua | tee log
+        grep "failed. 0" log
+      shell: bash
+
+
+  NTest_win:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        lua_ver: [51]
+        numbers: ['float']
+    needs: build_luac_cross_win
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+      with:
+        submodules: false
+    - name: Download luac.cross
+      uses: actions/download-artifact@v1
+      with:
+        name: luac.cross_${{ matrix.lua_ver }}_${{ matrix.numbers }}_win
+        path: ./
+    - name: NTest selfcheck
+      run: |
+        cd tests/NTest
+        ../../luac.cross.exe -e ../NTest/NTest_NTest.lua | tee log
+        grep "failed. 0" log
+      shell: bash
+
+
+  luacheck:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: 'linux'
+            vm: 'ubuntu-latest'
+          - os: 'windows'
+            vm: 'windows-latest'
+    runs-on: ${{ matrix.vm }} 
+      
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: false
+    - run: sudo apt install luarocks
+      if : matrix.os == 'linux'
+      shell: bash
+    - name: get luacheck.exe  # is also done in the travis script but in this action it does not run in bash
+      if : matrix.os == 'windows'
+      run: |
+        mkdir cache
+        C:msys64\usr\bin\wget.exe --tries=5 --timeout=10 --waitretry=10 --read-timeout=10 --retry-connrefused -O cache/luacheck.exe https://github.com/mpeterv/luacheck/releases/download/0.23.0/luacheck.exe
+      shell: cmd
+    - name: luacheck
+      run: |
+        PATH="/C/Program\ Files/Git/usr/bin:${PATH}"
+        ./tools/travis/run-luacheck-${{ matrix.os }}.sh
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: make
+      run: make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,3 +239,4 @@ jobs:
         PATH="/C/Program\ Files/Git/usr/bin:${PATH}"
         ./tools/travis/run-luacheck-${{ matrix.os }}.sh
       shell: bash
+


### PR DESCRIPTION
Fixes #No Issue.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

\<Description of and rationale behind this PR\>
This adds An Action to do many checks on commits on PRs.
Many tests are added new compared to the travis build.

Currently this PR does not execute the Actions for some reason. See https://github.com/HHHartmann/nodemcu-firmware/pull/1 for a working example.

At the moment there are following steps:

CI / build (51, float) (pull_request) Successful in 1m
CI / build (51, integral) (pull_request) Successful in 1m
CI / build (53, float) (pull_request) Successful in 1m
CI / build_luac_cross_win (pull_request) Successful in 1m — build_luac_cross_win
CI / luacheck (linux, ubuntu-latest) (pull_request) Successful in 26s
CI / luacheck (windows, windows-latest) (pull_request) Successful in 20s
CI / compile_lua (51, float, cat) (pull_request) Successful in 7s
CI / compile_lua (51, integral, grep -v "lua_modules/lm92/lm92.lua\|lua_modules/hdc1000/HDC1000.lua\|l... (pull_request) Successful in 6s
CI / compile_lua (53, float, cat) (pull_request) Successful in 7s
CI / NTest (51, float) (pull_request) Successful in 6s
CI / NTest (51, integral) (pull_request) Successful in 6s
CI / NTest (53, float) (pull_request) Successful in 6s

More tests for win luac.cross to come as soon as https://github.com/nodemcu/nodemcu-firmware/pull/3336 is merged