### PR TITLE
fix regression in luaL_typerror and Change NTest so it can run tests on the host emulating node.task.post

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
     - name: NTest hosttests
       run: |
         cd tests
-        cp NTest/Ntest.lua .
+        cp NTest/NTest.lua .
         ../luac.cross -e NTest_lua.lua | tee log
         grep "failed. 0" log
       shell: bash
@@ -217,7 +217,7 @@ jobs:
     - name: NTest hosttests
       run: |
         cd tests
-        cp NTest/Ntest.lua .
+        cp NTest/NTest.lua .
         ../luac.cross.exe -e NTest_lua.lua | tee log
         grep "failed. 0" log
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,13 @@ jobs:
         ../../luac.cross -e ../NTest/NTest_NTest.lua | tee log
         grep "failed. 0" log
       shell: bash
+    - name: NTest hosttests
+      run: |
+        cd tests
+        cp NTest/Ntest.lua .
+        ../luac.cross -e NTest_lua.lua | tee log
+        grep "failed. 0" log
+      shell: bash
 
 
   NTest_win:
@@ -205,6 +212,13 @@ jobs:
       run: |
         cd tests/NTest
         ../../luac.cross.exe -e ../NTest/NTest_NTest.lua | tee log
+        grep "failed. 0" log
+      shell: bash
+    - name: NTest hosttests
+      run: |
+        cd tests
+        cp NTest/Ntest.lua .
+        ../luac.cross.exe -e NTest_lua.lua | tee log
         grep "failed. 0" log
       shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
         cd tests
         cp NTest/NTest.lua .
         ../luac.cross -e NTest_lua.lua | tee log
-        grep  -v " ==>  " log
+        (if grep  " ==>  " log ; then exit 1 ; fi)
       shell: bash
 
 
@@ -219,7 +219,7 @@ jobs:
         cd tests
         cp NTest/NTest.lua .
         ../luac.cross.exe -e NTest_lua.lua | tee log
-        grep -v " ==>  " log
+        (if grep  " ==>  " log ; then exit 1 ; fi)
       shell: bash
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,7 +184,7 @@ jobs:
         cd tests
         cp NTest/NTest.lua .
         ../luac.cross -e NTest_lua.lua | tee log
-        grep "failed. 0" log
+        grep  -v " ==>  " log
       shell: bash
 
 
@@ -219,7 +219,7 @@ jobs:
         cd tests
         cp NTest/NTest.lua .
         ../luac.cross.exe -e NTest_lua.lua | tee log
-        grep "failed. 0" log
+        grep -v " ==>  " log
       shell: bash
 
 

--- a/app/lua/lauxlib.c
+++ b/app/lua/lauxlib.c
@@ -214,7 +214,7 @@ LUALIB_API int luaL_argerror (lua_State *L, int narg, const char *extramsg) {
 
 LUALIB_API int luaL_typerror (lua_State *L, int narg, const char *tname) {
   const char *msg = lua_pushfstring(L, "%s expected, got %s",
-                                    tname, lua_typename(L, narg));
+                                    tname, luaL_typename(L, narg));
   return luaL_argerror(L, narg, msg);
 }
 

--- a/tests/NTest/NTest.lua
+++ b/tests/NTest/NTest.lua
@@ -22,7 +22,7 @@ end
 -- implement pseudo task handling for on host testing
 local drain_post_queue = function() end
 
-if not node then
+if not node then  -- assume we run on host, not on MCU
   local post_queue = {{},{},{}}
 
   drain_post_queue = function()
@@ -46,24 +46,8 @@ if not node then
     table.insert(post_queue[p], f)
   end
 
-  local errorfunc
-  node.setonerror = function(fn) errorfunc = fn end
+  node.setonerror = function(fn) node.Host_Error_Func = fn end  -- luacheck: ignore 142
   -- luacheck: pop
-
-  cbWrap = function(cb)
-      return function(...)
-          local ok, p1,p2,p3,p4 = pcall(cb, ...)
-          if not ok then
-            if errorfunc then
-              errorfunc(p1)
-            else
-              print(p1, "::::::::::::: reboot :::::::::::::")
-            end
-          else
-            return p1,p2,p3,p4
-          end
-        end
-    end
 end
 
 

--- a/tests/NTest/NTest.lua
+++ b/tests/NTest/NTest.lua
@@ -19,6 +19,55 @@ local function TERMINAL_HANDLER(e, test, msg, errormsg)
   end
 end
 
+-- implement pseudo task handling for on host testing
+local drain_post_queue = function() end
+
+if not node then
+  local post_queue = {{},{},{}}
+
+  drain_post_queue = function()
+    while #post_queue[1] + #post_queue[2] + #post_queue[3] > 0 do
+      for i = 3, 1, -1 do
+        if #post_queue[i] > 0 then
+          local f = table.remove(post_queue[i], 1)
+          if f then
+            f()
+          end
+          break
+        end
+      end
+    end
+  end
+
+  -- luacheck: push ignore 121 122 (setting read-only global variable)
+  node = {}
+  node.task = {LOW_PRIORITY = 1, MEDIUM_PRIORITY = 2, HIGH_PRIORITY = 3}
+  node.task.post = function (p, f)
+    table.insert(post_queue[p], f)
+  end
+
+  local errorfunc
+  node.setonerror = function(fn) errorfunc = fn end
+  -- luacheck: pop
+
+  cbWrap = function(cb)
+      return function(...)
+          local ok, p1,p2,p3,p4 = pcall(cb, ...)
+          if not ok then
+            if errorfunc then
+              errorfunc(p1)
+            else
+              print(p1, "::::::::::::: reboot :::::::::::::")
+            end
+          else
+            return p1,p2,p3,p4
+          end
+        end
+    end
+end
+
+
+
 --[[
 if equal returns true
 if different returns {msg = "<reason>"}
@@ -233,6 +282,7 @@ local function NTest(testrunname, failoldinterface)
     table.insert(pendingtests, testfn)
     if #pendingtests == 1 then
       runpending()
+      drain_post_queue()
     end
   end
 

--- a/tests/NTest/NTest_NTest.lua
+++ b/tests/NTest/NTest_NTest.lua
@@ -406,6 +406,23 @@ end -- load_tests()
 
 local cbWrap = function(cb) return cb end
 
+if not node.LFS then  -- assume we run on host, not on MCU. node is already defined by NTest if running on host
+  cbWrap = function(cb)
+      return function(...)
+          local ok, p1,p2,p3,p4 = pcall(cb, ...)
+          if not ok then
+            if node.Host_Error_Func then  -- luacheck: ignore 143
+              node.Host_Error_Func(p1)  -- luacheck: ignore 143
+            else
+              print(p1, "::::::::::::: reboot :::::::::::::")
+            end
+          else
+            return p1,p2,p3,p4
+          end
+        end
+    end
+end
+
 -- Helper function to print arrays
 local function stringify(t)
   local s = ''

--- a/tests/NTest_lua.lua
+++ b/tests/NTest_lua.lua
@@ -1,4 +1,4 @@
-N = require "NTest" ("Lua detail tests")
+local N = require "NTest" ("Lua detail tests")
 
 N.test('typeerror', function()
   fail(function() math.abs("") end, "number expected, got string", "string")

--- a/tests/NTest_lua.lua
+++ b/tests/NTest_lua.lua
@@ -1,0 +1,6 @@
+N = require "NTest" ("Lua detail tests")
+
+N.test('typeerror', function()
+  fail(function() math.abs("") end, "number expected, got string", "string")
+  fail(function() math.abs() end, "number expected, got no value", "no value")
+end)


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for `master`.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

### Description of and rationale behind this PR

There is a regression in the luaL_typerror function which results in wrong types being print.
This PR fixes that regression

To back this fix by automatic testing it also enables the NTest system to run on the host using luac.cross.
