### PR TITLE
Add node.osoutput() method for esp32

### DIFF
--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -245,7 +245,7 @@ static int node_output(lua_State *L) {
     return 0;
 }
 
-// The implementation of node.osoutput redirect all OS logging to LUA space
+// The implementation of node.osoutput redirect all OS logging to Lua space
 lua_ref_t os_output_redir = LUA_NOREF;  // this will hold the Lua callback
 static vprintf_like_t oldvprintf;       // keep the old vprintf
 

--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -245,6 +245,46 @@ static int node_output(lua_State *L) {
     return 0;
 }
 
+// The implementation of node.osoutput redirect all OS logging to LUA space
+lua_ref_t os_output_redir = LUA_NOREF;  // this will hold the Lua callback
+static vprintf_like_t oldvprintf;       // keep the old vprintf
+
+// redir_vprintf will be called everytime the OS attempts to print a trace statement
+int redir_vprintf(const char *fmt, va_list ap)
+{
+    static char data[128];
+    int size = vsnprintf(data, 128, fmt, ap);
+
+    if (os_output_redir != LUA_NOREF) {  // prepare lua call
+        lua_State *L = lua_getstate();
+        lua_rawgeti(L, LUA_REGISTRYINDEX, os_output_redir);  // push function reference
+        lua_pushlstring(L, (char *)data, size);           // push data
+        lua_pcall(L, 1, 0, 0);                            // invoke callback
+    }
+    return size;
+}
+
+
+// Lua: node.output(func, serial_debug)
+static int node_osoutput(lua_State *L) {
+    if (lua_type(L, 1) == LUA_TFUNCTION || lua_type(L, 1) == LUA_TLIGHTFUNCTION) {
+        if (os_output_redir == LUA_NOREF) {
+            // register our log redirect first time this is invoked
+            oldvprintf = esp_log_set_vprintf(redir_vprintf);
+        } else {
+            luaX_unset_ref(L, &os_output_redir);  // dereference previous callback
+        }
+        luaX_set_ref(L, 1, &os_output_redir);  // set the callback
+    } else {
+        if (os_output_redir != LUA_NOREF) {
+            esp_log_set_vprintf(oldvprintf);
+            luaX_unset_ref(L, &os_output_redir);                // forget callback
+        }
+    }
+
+    return 0;
+}
+
 /* node.stripdebug([level[, function]]). 
  * level:    1 don't discard debug
  *           2 discard Local and Upvalue debug info
@@ -494,6 +534,7 @@ LROT_BEGIN(node)
   LROT_FUNCENTRY( heap,       node_heap )
   LROT_FUNCENTRY( input,      node_input )
   LROT_FUNCENTRY( output,     node_output )
+  LROT_FUNCENTRY( osoutput,   node_osoutput )
   LROT_FUNCENTRY( osprint,    node_osprint )
   LROT_FUNCENTRY( restart,    node_restart )
   LROT_FUNCENTRY( stripdebug, node_stripdebug )

--- a/docs/modules/node.md
+++ b/docs/modules/node.md
@@ -304,6 +304,35 @@ node.output(nil, 0)
 #### See also
 [`node.input()`](#nodeinput)
 
+## node.osoutput()
+
+Redirects the debugging output from the Espressif SDK to a callback function allowing it to be captured or processed in lua.
+
+####Syntax
+`node.osoutput(function(str))`
+
+#### Parameters
+
+- `function(str)` a function accepts debugging output as str, and can send the output to a socket (or maybe a file). `nil` to unregister the previous function.
+
+#### Returns
+
+Nothing
+
+#### Example
+
+```lua
+function luaprint(str)
+  print("lua space: "str)
+end
+node.osoutput(luaprint)
+```
+
+```lua
+-- disable all output completely
+node.osoutput(nil)
+```
+
 ## node.readvdd33() --deprecated
 Moved to [`adc.readvdd33()`](adc/#adcreadvdd33).
 

--- a/docs/modules/node.md
+++ b/docs/modules/node.md
@@ -306,7 +306,7 @@ node.output(nil, 0)
 
 ## node.osoutput()
 
-Redirects the debugging output from the Espressif SDK to a callback function allowing it to be captured or processed in lua.
+Redirects the debugging output from the Espressif SDK to a callback function allowing it to be captured or processed in Lua.
 
 ####Syntax
 `node.osoutput(function(str))`
@@ -527,4 +527,3 @@ priority is 2
 priority is 1
 priority is 0
 ```
-


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This PR adds a new function to the node module which allows redirection of SDK debug output to lua space.  We found this useful at konnected when we were integrating our system into a centralized error aggregator.
