### PR TITLE
Ensure tmr ref is valid before calling tmr callback

### DIFF
--- a/components/modules/tmr.c
+++ b/components/modules/tmr.c
@@ -43,7 +43,7 @@ static void alarm_timer_task(task_param_t param, task_prio_t prio)
 {
   tmr_t tmr = (tmr_t)param;
   lua_State* L = lua_getstate();
-  if (tmr->cb_ref == LUA_NOREF)
+  if (tmr->cb_ref == LUA_NOREF || tmr->self_ref == LUA_NOREF)
     return;
   lua_rawgeti(L, LUA_REGISTRYINDEX, tmr->cb_ref);
   lua_rawgeti(L, LUA_REGISTRYINDEX, tmr->self_ref);


### PR DESCRIPTION
Fixes #3311 

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Rapid auto timers can result in alarm timer tasks being queued up. If the timer is stopped while the tasks are queued it will result in the queued up alarms invoking callbacks with a `nil` tmr argument.  Details can be found in #3311.

This PR adds a check to ensure we no longer invoke the Lua callback if the tmr is stopped. 
