### PR TITLE
Add node.sleep() to ESP32 API

### DIFF
--- a/components/base_nodemcu/uart.c
+++ b/components/base_nodemcu/uart.c
@@ -259,6 +259,18 @@ static int uart_getconfig(lua_State* L) {
     return 4;
 }
 
+static int uart_wakeup (lua_State *L)
+{
+  uint32_t id = luaL_checkinteger(L, 1);
+  MOD_CHECK_ID(uart, id);
+  int threshold = luaL_checkinteger(L, 2);
+  esp_err_t err = uart_set_wakeup_threshold(id, threshold);
+  if (err) {
+    return luaL_error(L, "Error %d from uart_set_wakeup_threshold()", err);
+  }
+  return 0;
+}
+
 // Module function map
 LROT_BEGIN(uart)
   LROT_FUNCENTRY( setup,                      uart_setup )
@@ -268,6 +280,7 @@ LROT_BEGIN(uart)
   LROT_FUNCENTRY( on,                         uart_on )
   LROT_FUNCENTRY( setmode,                    uart_setmode )
   LROT_FUNCENTRY( getconfig,                  uart_getconfig )
+  LROT_FUNCENTRY( wakeup,                     uart_wakeup )
   LROT_NUMENTRY( STOPBITS_1,                  PLATFORM_UART_STOPBITS_1 )
   LROT_NUMENTRY( STOPBITS_1_5,                PLATFORM_UART_STOPBITS_1_5 )
   LROT_NUMENTRY( STOPBITS_2,                  PLATFORM_UART_STOPBITS_2 )

--- a/docs/modules/gpio.md
+++ b/docs/modules/gpio.md
@@ -109,8 +109,13 @@ Establish or clear a callback function to run on interrupt for a GPIO.
 #### Returns
 `nil`
 
+
 ## gpio.wakeup()
-Configuring wake-from-sleep-on-GPIO-level.
+Configure whether the given pin should trigger wake up from light sleep initiated by [`node.sleep()`](node.md#nodesleep).
+
+Note that the `level` specified here overrides the interrupt type set by `gpio.trig()`, and wakeup only supports the level-triggered options `gpio.INTR_LOW` and `gpio.INTR_HIGH`. Therefore it is not possible to configure an edge-triggered GPIO callback in combination with wake from light sleep, at least not without reconfiguring the pin immediately before and after the call to `node.sleep()`.
+
+The call to `node.sleep()` must additionally include `gpio = true` in the `options` in order for any GPIO to trigger wakeup.
 
 #### Syntax
 `gpio.wakeup(pin, level)`
@@ -118,12 +123,15 @@ Configuring wake-from-sleep-on-GPIO-level.
 #### Parameters
 - `pin`, see [GPIO Overview](#gpio-overview)
 - `level` wake-up level, one of
-    - `gpio.INTR_NONE` to disable wake-up
-    - `gpio.INTR_LOW` for wake-up on low level
-    - `gpio.INTR_HIGH` for wake-up on high level
+    - `gpio.INTR_NONE` changes to the level of this pin will not trigger wake from light sleep
+    - `gpio.INTR_LOW` if this pin is low it should trigger wake from light sleep 
+    - `gpio.INTR_HIGH` if this pin is high it should trigger wake from light sleep 
 
 #### Returns
 `nil`
+
+#### See also
+[`node.sleep()`](node.md#nodesleep)
 
 
 ## gpio.write()

--- a/docs/modules/uart.md
+++ b/docs/modules/uart.md
@@ -175,6 +175,30 @@ Set UART controllers communication mode
 #### Returns
 `nil`
 
+
+## uart.wakeup()
+
+Configure the light sleep wakeup threshold. This is the number of positive edges that must be seen on the UART RX pin before a light sleep wakeup will be triggered. The minimum value is 3. The default value is undefined, therefore you should always call this function before the first time you call `node.sleep()` with the uart option set.
+
+#### Syntax
+`uart.wakeup(id, val)`
+
+#### Parameters
+- `id` uart id
+- `val` the new value 
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+uart.wakeup(0, 5)
+```
+
+#### See also
+[`node.sleep()`](node/#nodesleep)
+
+
 ## uart.write()
 
 Write string or byte to the UART.


### PR DESCRIPTION
Supporting light sleep wakeup from (non-EXT1) GPIO, UART, ULP, timer and touch

Fixes #3179

- [x] This PR is for the `dev-esp32` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well.
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

As noted in the linked issue, the esp32 branch has not until now exposed the light sleep API to Lua code, and this PR addresses that. I've tested GPIO, touch, UART and timer wakeups with a adafruit huzzah32 and verified that everything appears to work as per the documentation I've added. (I've never played with the ULP so haven't tested that, no idea if it's even possible to use it with NodeMCU). I haven't yet been able to test if my project has gained any real power saving from using the light sleep state though!

I had to add a new API `uart.wakeup()` to get UART wakeup to work, I'm not sure if I've put the code in the right place since the uart module seems to have a slightly different structure to all the others, with most functions going through a `platform_xyz()` API abstraction. I've not done that and have called `uart_set_wakeup_threshold()` directly. Let me know if I'm doing that wrong. I've also updated the docs for `gpio.wakeup()` to make it clearer it's specific to the `node.sleep()` API.