### PR TITLE
Add go-mcu to the list of upload tools

### DIFF
--- a/docs/upload.md
+++ b/docs/upload.md
@@ -36,6 +36,16 @@ Source: [https://github.com/andidittrich/NodeMCU-Tool](https://github.com/andidi
 
 Supported platforms: macOS, Linux Windows, anything that runs Node.js
 
+### go-mcu
+
+> go-mcu provides an alternative way to work with NodeMCU-based modules like the ESP8266. Inspired by NodeMCU-Tool and nodemcu-uploader. It can be used as a Go package but also as a standalone CLI tool.
+>
+> One of the goals is to take advantage of Go's cross compilation capability while keeping a minimal set of runtime dependencies.
+
+Source: [https://github.com/matiasinsaurralde/go-mcu](https://github.com/matiasinsaurralde/go-mcu)
+
+Supported platforms: macOS, Linux, Windows
+
 ## init.lua
 You will see "lua: cannot open init.lua" printed to the serial console when the device boots after it's been freshly flashed. If NodeMCU finds a `init.lua` in the root of the file system it will execute it as part of the boot sequence (standard Lua feature). Hence, your application is initialized and triggered from `init.lua`. Usually you first set up the WiFi connection and only continue once that has been successful.
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Not sure if a GH issue is required for such a small change.

This PR adds a reference to [`go-mcu`](https://github.com/matiasinsaurralde/go-mcu), a tool that works as an upload tool but also as a standalone Go package that people may use to interact with their NodeMCU-enabled chips.