### PR TITLE
Doc update for bme280.lua

### DIFF
--- a/docs/lua-modules/bme280.md
+++ b/docs/lua-modules/bme280.md
@@ -5,11 +5,19 @@
 
 This module communicates with [BME280/BMP280 temperature/air presssure/humidity sensors](http://www.bosch-sensortec.com/bst/products/all_products/bme280) (Bosch Sensortec) through [I2C](../modules/i2c.md) interface. 
 
-Note: the module works only with the [bme280_math](../modules/bme280_math) module.
+!!! note
+
+    The module works only with the [bme280_math](../modules/bme280_math) module.
+
+!!! caution
+
+    The BMP280 only supports temperature and air pressure measurements. It will give wrong readings for humidity but no warnings or errors. Sometimes sellers of breakout boards for these sensors confuse the two and sell one as the other.
+    
+    To easily check if you have a BMP280 or a BME280 look at the shape of the sensor: The BMP280 has rectangular shape, whereas the BME280 has a square one.
 
 ## bme280.setup()
 
-Creates bme280sensor object and initializes module. Initialization is mandatory before read values. Note that there has to be a delay between some tens to hundreds of milliseconds between calling `setup()` and reading measurements.
+Creates bme280sensor object and initializes the module. Initialization is mandatory before reading values. Note that there has to be a delay between some tens to hundreds of milliseconds between calling `setup()` and reading measurements.
 
 Functions supported by bme280sensor object:
 - [setup()](#sobjsetup)


### PR DESCRIPTION
Fixes #3383.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

1. Changed the note about bme280_math dependency into a blue note box, like in the [bh1750 documentation](https://nodemcu.readthedocs.io/en/release/lua-modules/bh1750/)
2. Added a pagragraph on differentiating between BMP280 and BME280 sensors. It put it in an orange caution box for now, might be too visible for what's a rare problem.
3. Small fixes in bme280.setup() description

