### PR TITLE
Add sodium.generichash() API (ESP32)

### DIFF
--- a/components/modules/crypto.c
+++ b/components/modules/crypto.c
@@ -37,7 +37,7 @@ static const algo_info_t algorithms[] = {
     { "SHA384",    64, MBEDTLS_MD_SHA384 },
     { "SHA512",    64, MBEDTLS_MD_SHA512 },
 #ifdef CONFIG_NODEMCU_CMODULE_SODIUM
-    { "BLAKE2b",     0, SODIUM_BLAKE2B }, // 0 because no fixed size for BLAKE2b hashes
+    { "BLAKE2b",   64, SODIUM_BLAKE2B }, // The hash size isn't fixed with BLAKE2b, but 64 is the maximum
 #endif
 };
 

--- a/components/modules/sodium.c
+++ b/components/modules/sodium.c
@@ -129,6 +129,97 @@ static int l_crypto_box_seal_open(lua_State *L)
   return 1;
 }
 
+// See https://download.libsodium.org/doc/hashing/generic_hashing
+
+static void get_key_and_outlen(lua_State* L, int idx, const uint8_t **key, size_t* key_len, int* out_len)
+{
+  *key = (const uint8_t *)luaL_optlstring(L, idx, NULL, key_len);
+  if (*key && (*key_len < crypto_generichash_KEYBYTES_MIN || *key_len > crypto_generichash_KEYBYTES_MAX)) {
+    luaL_error(L, "key length must be between %d and %d",
+      crypto_generichash_KEYBYTES_MIN,
+      crypto_generichash_KEYBYTES_MAX);
+  }
+
+  *out_len = luaL_optint(L, idx + 1, crypto_generichash_BYTES);
+  if (*out_len < crypto_generichash_BYTES_MIN || *out_len > crypto_generichash_BYTES_MAX) {
+    luaL_error(L, "outlen must be between %d and %d",
+      crypto_generichash_BYTES_MIN,
+      crypto_generichash_BYTES_MAX);
+  }
+}
+
+// sodium.generichash(data, [key [, outlen]])
+static int l_crypto_generichash(lua_State* L)
+{
+  check_init(L);
+  size_t data_len;
+  const uint8_t *data = (const uint8_t *)luaL_checklstring(L, 1, &data_len);
+  size_t key_len;
+  const uint8_t *key;
+  int out_len;
+  get_key_and_outlen(L, 2, &key, &key_len, &out_len);
+  
+  uint8_t out[crypto_generichash_BYTES_MAX];
+  int err = crypto_generichash(out, out_len, data, data_len, key, key_len);
+  if (err) {
+    lua_pushnil(L);
+  } else {
+    lua_pushlstring(L, (char *)out, out_len);
+  }
+  return 1;
+}
+
+static const char generichash_state_mt[] = "sodium.hashstate";
+
+// Bah why does crypto_generichash_state not store outlen?
+typedef struct
+{
+  crypto_generichash_state crypto_state;
+  int out_len;
+} sodium_generichash_state;
+
+// sodium.generichash_init([key [, outlen]])
+static int l_crypto_generichash_init(lua_State* L)
+{
+  check_init(L);
+  size_t key_len;
+  const uint8_t *key;
+  int out_len;
+  get_key_and_outlen(L, 1, &key, &key_len, &out_len);
+
+  sodium_generichash_state *state = (sodium_generichash_state *)lua_newuserdata(L, sizeof(sodium_generichash_state));
+  luaL_getmetatable(L, generichash_state_mt);
+  lua_setmetatable(L, -2);
+
+  int err = crypto_generichash_init(&state->crypto_state, key, key_len, out_len);
+  if (err) {
+    return luaL_error(L, "crypto_generichash_init failed with %d", err);
+  }
+  state->out_len = out_len;
+  return 1;
+}
+
+static int l_crypto_generichash_update(lua_State* L)
+{
+  sodium_generichash_state *state = (sodium_generichash_state *)luaL_checkudata(L, 1, generichash_state_mt);
+  size_t data_len;
+  const uint8_t* data = (const uint8_t*)luaL_checklstring(L, 2, &data_len);
+  crypto_generichash_update(&state->crypto_state, data, data_len);
+  return 0;
+}
+
+static int l_crypto_generichash_final(lua_State* L)
+{
+  sodium_generichash_state *state = (sodium_generichash_state *)luaL_checkudata(L, 1, generichash_state_mt);
+  uint8_t out[crypto_generichash_BYTES_MAX];
+  int err = crypto_generichash_final(&state->crypto_state, out, state->out_len);
+  if (err) {
+    return luaL_error(L, "crypto_generichash_final failed with %d", err);
+  }
+  lua_pushlstring(L, (char *)out, state->out_len);
+  return 1;
+}
+
 LROT_BEGIN(random)
   LROT_FUNCENTRY(random,  l_randombytes_random)
   LROT_FUNCENTRY(uniform, l_randombytes_uniform)
@@ -144,6 +235,20 @@ LROT_END(crypto_box, NULL, 0)
 LROT_BEGIN(sodium)
   LROT_TABENTRY(random,     random)
   LROT_TABENTRY(crypto_box, crypto_box)
+  LROT_FUNCENTRY(generichash, l_crypto_generichash)
+  LROT_FUNCENTRY(generichash_init, l_crypto_generichash_init)
 LROT_END(sodium, NULL, 0)
 
-NODEMCU_MODULE(SODIUM, "sodium", sodium, NULL);
+LROT_BEGIN(generichash_state)
+  LROT_FUNCENTRY(update, l_crypto_generichash_update)
+  LROT_FUNCENTRY(final, l_crypto_generichash_final)
+  LROT_TABENTRY(__index, generichash_state)
+LROT_END(generichash_state, NULL, 0)
+
+static int luaopen_sodium(lua_State *L)
+{
+  luaL_rometatable(L, generichash_state_mt, (void *)generichash_state_map);
+  return 0;
+}
+
+NODEMCU_MODULE(SODIUM, "sodium", sodium, luaopen_sodium);

--- a/components/modules/sodium.c
+++ b/components/modules/sodium.c
@@ -2,6 +2,7 @@
 #include "lauxlib.h"
 #include "lmem.h"
 
+#include "sodium_module.h"
 #include "sodium.h"
 
 static void check_init(lua_State *L)
@@ -149,7 +150,7 @@ static void get_key_and_outlen(lua_State* L, int idx, const uint8_t **key, size_
 }
 
 // sodium.generichash(data, [key [, outlen]])
-static int l_crypto_generichash(lua_State* L)
+int l_sodium_generichash(lua_State* L)
 {
   check_init(L);
   size_t data_len;
@@ -179,7 +180,7 @@ typedef struct
 } sodium_generichash_state;
 
 // sodium.generichash_init([key [, outlen]])
-static int l_crypto_generichash_init(lua_State* L)
+int l_sodium_generichash_init(lua_State* L)
 {
   check_init(L);
   size_t key_len;
@@ -199,7 +200,7 @@ static int l_crypto_generichash_init(lua_State* L)
   return 1;
 }
 
-static int l_crypto_generichash_update(lua_State* L)
+static int l_sodium_generichash_update(lua_State* L)
 {
   sodium_generichash_state *state = (sodium_generichash_state *)luaL_checkudata(L, 1, generichash_state_mt);
   size_t data_len;
@@ -208,7 +209,7 @@ static int l_crypto_generichash_update(lua_State* L)
   return 0;
 }
 
-static int l_crypto_generichash_final(lua_State* L)
+static int l_sodium_generichash_final(lua_State* L)
 {
   sodium_generichash_state *state = (sodium_generichash_state *)luaL_checkudata(L, 1, generichash_state_mt);
   uint8_t out[crypto_generichash_BYTES_MAX];
@@ -235,13 +236,14 @@ LROT_END(crypto_box, NULL, 0)
 LROT_BEGIN(sodium)
   LROT_TABENTRY(random,     random)
   LROT_TABENTRY(crypto_box, crypto_box)
-  LROT_FUNCENTRY(generichash, l_crypto_generichash)
-  LROT_FUNCENTRY(generichash_init, l_crypto_generichash_init)
+  LROT_FUNCENTRY(generichash, l_sodium_generichash)
+  LROT_FUNCENTRY(generichash_init, l_sodium_generichash_init)
 LROT_END(sodium, NULL, 0)
 
 LROT_BEGIN(generichash_state)
-  LROT_FUNCENTRY(update, l_crypto_generichash_update)
-  LROT_FUNCENTRY(final, l_crypto_generichash_final)
+  LROT_FUNCENTRY(update, l_sodium_generichash_update)
+  LROT_FUNCENTRY(final, l_sodium_generichash_final)
+  LROT_FUNCENTRY(finalize, l_sodium_generichash_final) // for compat with crypto hasher API
   LROT_TABENTRY(__index, generichash_state)
 LROT_END(generichash_state, NULL, 0)
 

--- a/components/modules/sodium_module.h
+++ b/components/modules/sodium_module.h
@@ -1,0 +1,9 @@
+#ifndef sodium_module_h
+#define sodium_module_h
+
+typedef struct lua_State lua_State;
+
+int l_sodium_generichash(lua_State* L);
+int l_sodium_generichash_init(lua_State* L);
+
+#endif

--- a/docs/modules/crypto.md
+++ b/docs/modules/crypto.md
@@ -6,6 +6,7 @@
 The crypto module provides various functions for working with cryptographic algorithms.
 
 The following algorithms are supported, both in digest mode and in HMAC mode:
+
 * MD5
 * SHA1
 * RIPEMD160
@@ -13,6 +14,41 @@ The following algorithms are supported, both in digest mode and in HMAC mode:
 * SHA256
 * SHA384
 * SHA512
+
+The following algorithms are supported only in digest (hash) mode:
+
+* BLAKE2b
+
+The BLAKE2b hash algorithm is only available if the ROM has been built with the Sodium module enabled.
+
+## crypto.hash()
+
+Compute a cryptographic hash of a Lua string.
+
+#### Syntax
+`hash = crypto.hash(algo, str)`
+
+or if `algo` is `"BLAKE2b"`:
+
+`hash = crypto.hash(algo, str, [key[, out_len])`
+
+#### Parameters
+- `algo` the hash algorithm to use, case insensitive string
+- `str` string to hash contents of
+- `key` only applicable if `algo` is `"BLAKE2b"`, optional. See [`sodium.generichash()`](sodium.md#sodiumgenerichash) for more info.
+- `out_len` only applicable if `algo` is `"BLAKE2b"`, optional. See [`sodium.generichash()`](sodium.md#sodiumgenerichash) for more info.
+
+#### Returns
+A binary string containing the message digest. To obtain the textual version (ASCII hex characters), use [`encoder.toHex()`](encoder.md#encodertohex).
+
+#### Example
+```lua
+print(encoder.toHex(crypto.hash("SHA1", "abc")))
+```
+
+#### See also
+[`crypto.new_hash()`](#cryptonew_hash) if the entire data to be hashed is not available in a single string.
+
 
 ## crypto.new_hash()
 
@@ -25,8 +61,14 @@ the resulting digest.
 #### Syntax
 `hashobj = crypto.new_hash(algo)`
 
+or if `algo` is `"BLAKE2b"`:
+
+`hashobj = crypto.new_hash(algo, [key[, out_len])`
+
 #### Parameters
 - `algo` the hash algorithm to use, case insensitive string
+- `key` only applicable if `algo` is `"BLAKE2b"`, optional. See [`sodium.generichash()`](sodium.md#sodiumgenerichash) for more info.
+- `out_len` only applicable if `algo` is `"BLAKE2b"`, optional. See [`sodium.generichash()`](sodium.md#sodiumgenerichash) for more info.
 
 #### Returns
 Hasher object with `update` and `finalize` functions available.
@@ -39,6 +81,33 @@ hashobj:update("SecondString")
 digest = hashobj:finalize()
 print(encoder.toHex(digest))
 ```
+
+
+## crypto.hmac()
+
+Calculate a HMAC (Hashed Message Authentication Code, aka "signature"). A HMAC
+can be used to simultaneously verify both integrity and authenticity of data.
+
+#### Syntax
+`hmac = crypto.hmac(algo, key, data)`
+
+#### Parameters
+- `algo` the hash algorithm to use, case insensitive string
+- `key` the signing key (may be a binary string)
+- `data` the data to calculate the HMAC for
+
+#### Returns
+A binary string containing the signature. To obtain the textual version (ASCII hex characters), use [`encoder.toHex()`](encoder.md#encodertohex).
+
+#### Example
+```lua
+signature = crypto.hmac("SHA1", "top s3cr3t key", "Some data")
+print(encoder.toHex(signature))
+```
+
+#### See also
+[`crypto.new_hmac()`](#cryptonew_hmac) if the entire data to be hashed is not available in a single string.
+
 
 ## crypto.new_hmac()
 

--- a/docs/modules/sodium.md
+++ b/docs/modules/sodium.md
@@ -135,8 +135,8 @@ Provides a way to calculate a hash in chunks, so that not all the data needs to 
 `sodium.generichash_init([key[, out_len]])`
 
 #### Parameters
-- `key` - Optional. As per sodium.generichash().
-- `out_len` - Optional. As per sodium.generichash().
+- `key` - Optional. As per [`sodium.generichash()`](#sodiumgenerichash).
+- `out_len` - Optional. As per [`sodium.generichash()`](#sodiumgenerichash).
 
 #### Returns
 An object with 2 methods, `update(data)` and `final()`. Call `update()` with each data chunk in turn, then call `final()` to fetch the resulting hash. Do not call `update()` again after calling `final()`: to calculate another hash, call `generichash_init()` again to get a new object.

--- a/docs/modules/sodium.md
+++ b/docs/modules/sodium.md
@@ -106,3 +106,50 @@ The decrypted plain text of the message. Returns `nil` if the `ciphertext` could
 ```lua
 message = sodium.crypto_box.seal_open(ciphertext, public_key, secret_key)
 ```
+
+# Hashing
+See also [https://download.libsodium.org/doc/hashing/generic_hashing](https://download.libsodium.org/doc/hashing/generic_hashing).
+
+The hash functions are implemented using BLAKE2b, a simple, standardized ([RFC 7693](https://www.rfc-editor.org/rfc/rfc7693.txt)) secure hash function that is as strong as SHA-3 but faster than SHA-1 and MD5.
+
+## sodium.generichash()
+Computes a hash of the given data. The same data will always produce the same hash (providing `key` and `out_len` parameters are the same).
+
+#### Syntax
+`sodium.generichash(data[, key[, out_len]])`
+
+#### Parameters
+- `data` - the data to hash
+- `key` - Optional. A string to use as the key. A key parameter can be used for example to make sure that different applications generate different hashes even if they process the same data. If specified, must be between 16 and 64 bytes.
+- `out_len` - Optional. The length of hash to output, which must be between 16 and 64. If not specified, defaults to 32 bytes (`crypto_generichash_BYTES`).
+
+#### Returns
+The hash of the data, as an unencoded string of `out_len` bytes. Use something like `encoder.toHex(result)` if you need it as ASCII text.
+
+#### Example
+```lua
+hash = sodium.generichash("Some data")
+print("Result:", encoder.toHex(hash))
+```
+
+## sodium.generichash_init()
+Provides a way to calculate a hash in chunks, so that not all the data needs to be in memory at once.
+
+#### Syntax
+`sodium.generichash_init([key[, out_len]])`
+
+#### Parameters
+- `key` - Optional. As per sodium.generichash().
+- `out_len` - Optional. As per sodium.generichash().
+
+#### Returns
+An object with 2 methods, `update(data)` and `final()`. Call `update()` with each data chunk in turn, then call `final()` to fetch the resulting hash. Do not call `update()` again after calling `final()`: to calculate another hash, call `generichash_init()` again to get a new object.
+
+#### Example
+```lua
+hasher = sodium.generichash_init()
+hasher:update(data_chunk_1)
+hasher:update(data_chunk_2)
+hash = hasher:final()
+print("Result:", encoder.toHex(hash))
+```


### PR DESCRIPTION
Fixes #3386.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well.
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Expose the libsodium generichash API to Lua via the `sodium` module, see #3386 for more info.
