### PR TITLE
Auto create additional partition for SPIFFS

### DIFF
--- a/components/platform/partitions.csv
+++ b/components/platform/partitions.csv
@@ -4,4 +4,4 @@ phy_init,      data, phy,      0xf000,   0x1000
 factory,       app,  factory, 0x10000, 0x180000
 # Type 0xC2 => NodeMCU. SubTypes: 0x00 = SPIFFS, 0x01 = LFS
 lfs,           0xC2, 0x01,          ,   0x10000
-nodemcuspiffs, 0xC2, 0x00,          ,   0x70000
+# nodemcuspiffs, 0xC2, 0x00,          ,   0x70000


### PR DESCRIPTION
The default partition table from `components/platform/partitions.csv`，which allocates 0x70000 byte for SPIFFS exactly.
This commit makes sure "During the first boot, the firmware creates an additional partition for SPIFFS in the remaining flash space."

- [x] This PR is for the `dev-esp32` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

