### PR TITLE
Add support for open networks to enduser_setup

### DIFF
--- a/app/modules/enduser_setup.c
+++ b/app/modules/enduser_setup.c
@@ -832,9 +832,14 @@ static int enduser_setup_http_handle_credentials(char *data, unsigned short data
   state->success = 0;
   state->lastStationStatus = 0;
 
+
   char *name_str = strstr(data, "wifi_ssid=");
   char *pwd_str = strstr(data, "wifi_password=");
-  if (name_str == NULL || pwd_str == NULL)
+
+  // in case we dont get a passwd (for open networks)
+  if (pwd_str == NULL) { pwd_str="wifi_password="; }
+
+  if (name_str == NULL)
   {
     ENDUSER_SETUP_DEBUG("Password or SSID string not found");
     return 1;

--- a/app/modules/enduser_setup.c
+++ b/app/modules/enduser_setup.c
@@ -837,11 +837,14 @@ static int enduser_setup_http_handle_credentials(char *data, unsigned short data
   char *pwd_str = strstr(data, "wifi_password=");
 
   // in case we dont get a passwd (for open networks)
-  if (pwd_str == NULL) { pwd_str="wifi_password="; }
+  if (pwd_str == NULL) {
+    pwd_str="wifi_password=";
+    ENDUSER_SETUP_DEBUG("No passord provided. Assuming open network");
+  }
 
   if (name_str == NULL)
   {
-    ENDUSER_SETUP_DEBUG("Password or SSID string not found");
+    ENDUSER_SETUP_DEBUG("SSID string not found");
     return 1;
   }
 

--- a/docs/modules/enduser-setup.md
+++ b/docs/modules/enduser-setup.md
@@ -54,6 +54,7 @@ Then the `eus_params.lua` file will contain the following:
 
 ```lua
 -- those wifi_* are the base parameters that are saved anyway
+-- if network is open, then there is no wifi_password
 local p = {}
 p.wifi_ssid="ssid"
 p.wifi_password="password"


### PR DESCRIPTION
Fixes #3374.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

I fixed the bug, making sure an open network (without password) is handled correctly.
I tested it and it works perfectly.
