### PR TITLE
exemple of init.lua with wifi portal

### DIFF
--- a/lua_examples/init.lua
+++ b/lua_examples/init.lua
@@ -1,0 +1,34 @@
+-- init.lua example, with wifi portal
+--
+-- Waits 10 sec to allow stopping the boot process, and get wifi activated
+-- When wifi not activated, setup a portal to select a network
+-- In all cases, wifi ends up activated and the main task main.lua is executed
+--
+-- module needed: enduser_setup
+
+print("Waiting 10sec... use t:stop() to cancel init.lua")
+t=tmr.create()
+t:alarm(10000,tmr.ALARM_SINGLE,function ()
+	t=nil -- free the timer
+	if wifi.sta.getip() then
+		print("Wifi activated",wifi.sta.getip())
+		dofile("main.lua")
+	else
+		print("No Wifi. Starting portal...")
+		enduser_setup.start(
+		  "SuperBidule",
+		  function()
+			wifi.sta.autoconnect(1)
+			print("Wifi activated",wifi.sta.getip())
+			dofile("main.lua")
+		  end,
+		  function(err, str)
+		    print("enduser_setup: Err #" .. err .. ": " .. str)
+		  end,
+		  function(str)
+		    print("Debug " .. str)
+		  end
+		)
+	end
+end)
+


### PR DESCRIPTION
Fixes no specific issue,

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

Following a suggestion in #3374 , this is an example for a init.lua that uses a wifi portal to configure wifi if needed.
I put it inside lua_examples, but I don't know how and where to refer to this in the docs. Suggestions?

Also, I wonder if it would be interesting to provide complete examples for some common IOT setups:
- robust mqtt to light up a LED remotely
- robust mqtt sensor reading (temperature) every 10 minutes, with deep sleep in between
- robust mqtt IOT identification using [Homie](https://homieiot.github.io/)
- ...
( Here robust means that it will survive power outage, network outage, etc, and always restart properly. )
Such examples could make it much simpler to setup IOT by providing a good template.
Juste wondering if this is something that would be considered useful.
