### PR TITLE
handle impact of excluding pixbuf from build

### DIFF
--- a/app/modules/apa102.c
+++ b/app/modules/apa102.c
@@ -91,6 +91,7 @@ static int apa102_write(lua_State* L) {
     nbr_frames = buf_len / 4;
     break;
    }
+#ifdef LUA_USE_MODULES_PIXBUF      
   case LUA_TUSERDATA: {
     pixbuf *buffer = pixbuf_from_lua_arg(L, 3);
     luaL_argcheck(L, buffer->nchan == 4, 3, "Pixbuf not 4-channel");
@@ -98,6 +99,7 @@ static int apa102_write(lua_State* L) {
     nbr_frames = buffer->npix;
     break;
    }
+#endif
   default:
     return luaL_argerror(L, 3, "String or pixbuf expected");
   }

--- a/app/modules/tm1829.c
+++ b/app/modules/tm1829.c
@@ -77,6 +77,7 @@ static int ICACHE_FLASH_ATTR tm1829_write(lua_State* L)
     pixels = luaL_checklstring(L, 2, &length);
     break;
    }
+#ifdef LUA_USE_MODULES_PIXBUF      
   case LUA_TUSERDATA: {
     pixbuf *buffer = pixbuf_from_lua_arg(L, 2);
     luaL_argcheck(L, pixbuf_channels(buffer) == 3, 2, "Bad pixbuf format");
@@ -84,6 +85,7 @@ static int ICACHE_FLASH_ATTR tm1829_write(lua_State* L)
     length = 3 * buffer->npix;
     break;
    }
+#endif
   default:
     return luaL_argerror(L, 2, "String or pixbuf expected");
   }

--- a/app/modules/ws2801.c
+++ b/app/modules/ws2801.c
@@ -118,6 +118,7 @@ static int ICACHE_FLASH_ATTR ws2801_writergb(lua_State* L) {
     case LUA_TSTRING:
       values = (const uint8_t*) luaL_checklstring(L, 1, &length);
       break;
+#ifdef LUA_USE_MODULES_PIXBUF      
     case LUA_TUSERDATA: {
       pixbuf *buffer = pixbuf_from_lua_arg(L, 1);
       luaL_argcheck(L, buffer->nchan == 3, 1, "Pixbuf not 3-channel");
@@ -125,6 +126,7 @@ static int ICACHE_FLASH_ATTR ws2801_writergb(lua_State* L) {
       length = pixbuf_size(buffer);
       break;
     }
+#endif    
     default:
       return luaL_argerror(L, 1, "pixbuf or string expected");
     }

--- a/app/modules/ws2812.c
+++ b/app/modules/ws2812.c
@@ -134,6 +134,7 @@ static int ws2812_write(lua_State* L) {
   {
     buffer1 = lua_tolstring(L, 1, &length1);
   }
+#ifdef LUA_USE_MODULES_PIXBUF      
   else if (type == LUA_TUSERDATA)
   {
     pixbuf *buffer = pixbuf_from_lua_arg(L, 1);
@@ -141,6 +142,7 @@ static int ws2812_write(lua_State* L) {
     buffer1 = buffer->values;
     length1 = pixbuf_size(buffer);
   }
+#endif
   else
   {
     luaL_argerror(L, 1, "pixbuf or string expected");
@@ -157,6 +159,7 @@ static int ws2812_write(lua_State* L) {
   {
     buffer2 = lua_tolstring(L, 2, &length2);
   }
+#ifdef LUA_USE_MODULES_PIXBUF      
   else if (type == LUA_TUSERDATA)
   {
     pixbuf *buffer = pixbuf_from_lua_arg(L, 2);
@@ -164,6 +167,7 @@ static int ws2812_write(lua_State* L) {
     buffer2 = buffer->values;
     length2 = pixbuf_size(buffer);
   }
+#endif
   else
   {
     luaL_argerror(L, 2, "pixbuf or string expected");
@@ -177,14 +181,16 @@ static int ws2812_write(lua_State* L) {
 
 LROT_BEGIN(ws2812, NULL, 0)
   LROT_FUNCENTRY( init, ws2812_init )
+#ifdef LUA_USE_MODULES_PIXBUF      
   LROT_FUNCENTRY( newBuffer, pixbuf_new_lua ) // backwards compatibility
-  LROT_FUNCENTRY( write, ws2812_write )
   LROT_NUMENTRY( FADE_IN, PIXBUF_FADE_IN )    // BC
   LROT_NUMENTRY( FADE_OUT, PIXBUF_FADE_OUT )  // BC
-  LROT_NUMENTRY( MODE_SINGLE, MODE_SINGLE )
-  LROT_NUMENTRY( MODE_DUAL, MODE_DUAL )
   LROT_NUMENTRY( SHIFT_LOGICAL, PIXBUF_SHIFT_LOGICAL ) // BC
   LROT_NUMENTRY( SHIFT_CIRCULAR, PIXBUF_SHIFT_CIRCULAR ) // BC
+#endif
+  LROT_FUNCENTRY( write, ws2812_write )
+  LROT_NUMENTRY( MODE_SINGLE, MODE_SINGLE )
+  LROT_NUMENTRY( MODE_DUAL, MODE_DUAL )
 LROT_END(ws2812, NULL, 0)
 
 static int luaopen_ws2812(lua_State *L) {

--- a/app/modules/ws2812_effects.c
+++ b/app/modules/ws2812_effects.c
@@ -13,6 +13,15 @@
 #include "pixbuf.h"
 #include "color_utils.h"
 
+#ifdef LUA_USE_MODULES_WS2812_EFFECTS
+#ifndef LUA_USE_MODULES_PIXBUF
+#  error module pixbuf is required for ws2812_effects
+#endif
+#ifndef LUA_USE_MODULES_COLOR_UTILS
+#  error module color_utilsf is required for ws2812_effects
+#endif
+#endif
+
 #define CANARY_VALUE 0x32372132
 
 #define DEFAULT_MODE 0

--- a/docs/modules/apa102.md
+++ b/docs/modules/apa102.md
@@ -9,6 +9,10 @@ This module provides Lua access to [APA102 RGB LEDs](https://youtu.be/UYvC-hukz-
 
 source: [Adafruit](https://www.adafruit.com/products/2343)
 
+!!! caution
+
+    This module will work without the [pixbuf module](pixbuf.md). The respective parts will just not be available.
+
 ## apa102.write()
 Send ABGR data in 8 bits to a APA102 chain.
 
@@ -18,7 +22,7 @@ Send ABGR data in 8 bits to a APA102 chain.
 #### Parameters
 - `data_pin` any GPIO pin 0, 1, 2, ...
 - `clock_pin` any GPIO pin 0, 1, 2, ...
-- `string` payload to be sent to one or more APA102 LEDs.
+- `data` payload to be sent to one or more APA102 LEDs.
 
   It may be a [pixbuf](pixbuf) with four channels or a string,
   composed from a ABGR quadruplet per element:

--- a/docs/modules/apa102.md
+++ b/docs/modules/apa102.md
@@ -11,7 +11,7 @@ source: [Adafruit](https://www.adafruit.com/products/2343)
 
 !!! caution
 
-    This module will work without the [pixbuf module](pixbuf.md). The respective parts will just not be available.
+    This module has an _optional_ dependency to the [pixbuf module](pixbuf.md) i.e. it can work without. However, if you compile the firmware without pixbuf the respective features will be missing from this module.
 
 ## apa102.write()
 Send ABGR data in 8 bits to a APA102 chain.

--- a/docs/modules/tm1829.md
+++ b/docs/modules/tm1829.md
@@ -10,7 +10,7 @@ The library uses any GPIO to bitstream the led control commands.
 
 !!! caution
 
-    This module will work without the [pixbuf module](pixbuf.md). The respective parts will just not be available.
+    This module has an _optional_ dependency to the [pixbuf module](pixbuf.md) i.e. it can work without. However, if you compile the firmware without pixbuf the respective features will be missing from this module.
 
 ## tm1829.write()
 Send data to a led strip using native chip format.

--- a/docs/modules/tm1829.md
+++ b/docs/modules/tm1829.md
@@ -8,14 +8,18 @@ led controller.
 
 The library uses any GPIO to bitstream the led control commands.
 
+!!! caution
+
+    This module will work without the [pixbuf module](pixbuf.md). The respective parts will just not be available.
+
 ## tm1829.write()
 Send data to a led strip using native chip format.
 
 #### Syntax
-`tm1829.write(string)`
+`tm1829.write(data)`
 
 #### Parameters
-- `string` payload to be sent to one or more TM1829 leds.  It is either
+- `data` payload to be sent to one or more TM1829 leds.  It is either
   a 3-channel [pixbuf](pixbuf) (e.g., `pixbuf.TYPE_RGB`) or a string of
   raw byte values to be sent.
 

--- a/docs/modules/ws2801.md
+++ b/docs/modules/ws2801.md
@@ -3,6 +3,9 @@
 | :----- | :-------------------- | :---------- | :------ |
 | 2015-07-12 | [Espressif example](https://github.com/CHERTS/esp8266-devkit/blob/master/Espressif/examples/ESP8266/EspLightNode/user/ws2801.c), [Konrad Beckmann](https://github.com/kbeckmann) | [Konrad Beckmann](https://github.com/kbeckmann) | [ws2801.c](../../app/modules/ws2801.c)|
 
+!!! caution
+
+    This module will work without the [pixbuf module](pixbuf.md). The respective parts will just not be available.
 
 ## ws2801.init()
 Initializes the module and sets the pin configuration.
@@ -18,19 +21,24 @@ Initializes the module and sets the pin configuration.
 `nil`
 
 ## ws2801.write()
-Sends a string of RGB Data in 24 bits to WS2801. Don't forget to call `ws2801.init()` before.
+Sends data of RGB Data in 24 bits to WS2801. Don't forget to call `ws2801.init()` before.
 
 #### Syntax
-`ws2801.write(string)`
+`ws2801.write(data)`
 
 ####Parameters
-- `string` payload to be sent to one or more WS2801.
+- `data` payload to be sent to one or more WS2801.
+
+Payload type could be:
+
+- `string` representing bytes to send
   It should be composed from an RGB triplet per element.
     - `R1` the first pixel's red channel value (0-255)
     - `G1` the first pixel's green channel value (0-255)
     - `B1` the first pixel's blue channel value (0-255)<br />
     ... You can connect a lot of WS2801...
     - `R2`, `G2`, `B2` are the next WS2801's Red, Green, and Blue channel values
+- a [pixbuf](pixbuf) object containing the bytes to send.  The pixbuf's type is not checked!
 
 #### Returns
 `nil`

--- a/docs/modules/ws2801.md
+++ b/docs/modules/ws2801.md
@@ -5,7 +5,7 @@
 
 !!! caution
 
-    This module will work without the [pixbuf module](pixbuf.md). The respective parts will just not be available.
+    This module has an _optional_ dependency to the [pixbuf module](pixbuf.md) i.e. it can work without. However, if you compile the firmware without pixbuf the respective features will be missing from this module.
 
 ## ws2801.init()
 Initializes the module and sets the pin configuration.

--- a/docs/modules/ws2812-effects.md
+++ b/docs/modules/ws2812-effects.md
@@ -15,7 +15,7 @@ Note that dual mode is currently not supported for effects.
 
 !!! caution
 
-    This module depends on the [color utils module](color-utils.md). Things **will** fail if that module is missing in the firmware!
+    This module depends on the [color utils module](color-utils.md) and [pixbuf module](pixbuf.md). Things **will** fail if those modules are missing in the firmware!
 
 #### Example usage
 ```lua

--- a/docs/modules/ws2812.md
+++ b/docs/modules/ws2812.md
@@ -17,7 +17,7 @@ use an other input channel like a TCP server (see [example](https://github.com/n
 
 !!! caution
 
-    This module will work without the [pixbuf module](pixbuf.md). The respective parts will just not be available.
+    This module has an _optional_ dependency to the [pixbuf module](pixbuf.md) i.e. it can work without. However, if you compile the firmware without pixbuf the respective features will be missing from this module.
 
 ## ws2812.init()
 Initialize UART1 and GPIO2, should be called once and before write().

--- a/docs/modules/ws2812.md
+++ b/docs/modules/ws2812.md
@@ -15,6 +15,10 @@ through the serial port (it will be reconfigured to support WS2812-like
 protocol). If you want to keep access to Lua's console, you will have to
 use an other input channel like a TCP server (see [example](https://github.com/nodemcu/nodemcu-firmware/blob/release/lua_modules/telnet/telnet.lua))
 
+!!! caution
+
+    This module will work without the [pixbuf module](pixbuf.md). The respective parts will just not be available.
+
 ## ws2812.init()
 Initialize UART1 and GPIO2, should be called once and before write().
 Initialize UART0 (TXD0) too if `ws2812.MODE_DUAL` is set.
@@ -54,6 +58,7 @@ and the next invocation thereof.
 - `data2` (optional) payload to be sent to one or more WS2812 like leds through TXD0 (`ws2812.MODE_DUAL` mode required)
 
 Payload type could be:
+
 - `nil` nothing is done
 - `string` representing bytes to send
 - a [pixbuf](pixbuf) object containing the bytes to send.  The pixbuf's type is not checked!
@@ -90,7 +95,7 @@ For this purpose, the [pixbuf](pixbuf) library offers a read/write buffer and
 convenient functions for pixel value manipulation.
 
 For backwards-compatibility, `pixbuf.newBuffer()` is aliased as
-`ws2812.newBuffer`, but this will be removed in the next nodemcu-firmware
+`ws2812.newBuffer()`, but this will be removed in the next nodemcu-firmware
 release.
 
 #### Example


### PR DESCRIPTION
Fixes discussion in https://github.com/nodemcu/nodemcu-firmware/pull/3158#issuecomment-774209480.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This will break the build if ws2812_effects is used without pixbuf.
It will allow to write to the 4 LED strip types with string param only.
