### PR TITLE
Fix adc, i2c, file, tmr docs esp32

### DIFF
--- a/docs/modules/adc.md
+++ b/docs/modules/adc.md
@@ -33,10 +33,10 @@ Configuration ADC1 capture attenuation of channels
 - `adc_number` Only `adc.ADC1` now
 - `channel`  When using `adc.ADC1`: `0` to `7`. 0: GPIO36, 1: GPIO37, 2: GPIO38, 3: GPIO39, 4: GPIO32, 5: GPIO33, 6: GPIO34, 7: GPIO35
 - `atten` One of following constants
-    - `adc.ATTEN_0db`    The input voltage of ADC will be reduced to about 1/1    (1.1V when VDD_A=3.3V)
-    - `adc.ATTEN_2_5db`  The input voltage of ADC will be reduced to about 1/1.34 (1.5V when VDD_A=3.3V)
-    - `adc.ATTEN_6db`    The input voltage of ADC will be reduced to about 1/2    (2.2V when VDD_A=3.3V)
-    - `adc.ATTEN_11db`   The input voltage of ADC will be reduced to about 1/3.6  (3.9V when VDD_A=3.3V,  maximum voltage is limited by VDD_A)
+	- `adc.ATTEN_0db`    The input voltage of ADC will be reduced to about 1/1    (1.1V when VDD_A=3.3V)
+	- `adc.ATTEN_2_5db`  The input voltage of ADC will be reduced to about 1/1.34 (1.5V when VDD_A=3.3V)
+	- `adc.ATTEN_6db`    The input voltage of ADC will be reduced to about 1/2    (2.2V when VDD_A=3.3V)
+	- `adc.ATTEN_11db`   The input voltage of ADC will be reduced to about 1/3.6  (3.9V when VDD_A=3.3V,  maximum voltage is limited by VDD_A)
 
 #### Returns
 `nil`

--- a/docs/modules/adc.md
+++ b/docs/modules/adc.md
@@ -19,7 +19,7 @@ The configuration is in effect for all channels of ADC1
 - `bits` One of `9`/`10`/`11`/`12`.
 
 #### Returns
-nil
+`nil`
 
 
 ## adc.setup()
@@ -33,13 +33,13 @@ Configuration ADC1 capture attenuation of channels
 - `adc_number` Only `adc.ADC1` now
 - `channel`  When using `adc.ADC1`: `0` to `7`. 0: GPIO36, 1: GPIO37, 2: GPIO38, 3: GPIO39, 4: GPIO32, 5: GPIO33, 6: GPIO34, 7: GPIO35
 - `atten` One of following constants
-  - `adc.ATTEN_0db`    The input voltage of ADC will be reduced to about 1/1    (1.1V when VDD_A=3.3V)
-  - `adc.ATTEN_2_5db`  The input voltage of ADC will be reduced to about 1/1.34 (1.5V when VDD_A=3.3V)
-  - `adc.ATTEN_6db`    The input voltage of ADC will be reduced to about 1/2    (2.2V when VDD_A=3.3V)
-  - `adc.ATTEN_11db`   The input voltage of ADC will be reduced to about 1/3.6  (3.9V when VDD_A=3.3V,  maximum voltage is limited by VDD_A)
+    - `adc.ATTEN_0db`    The input voltage of ADC will be reduced to about 1/1    (1.1V when VDD_A=3.3V)
+    - `adc.ATTEN_2_5db`  The input voltage of ADC will be reduced to about 1/1.34 (1.5V when VDD_A=3.3V)
+    - `adc.ATTEN_6db`    The input voltage of ADC will be reduced to about 1/2    (2.2V when VDD_A=3.3V)
+    - `adc.ATTEN_11db`   The input voltage of ADC will be reduced to about 1/3.6  (3.9V when VDD_A=3.3V,  maximum voltage is limited by VDD_A)
 
 #### Returns
-nil
+`nil`
 
 
 ## adc.read()
@@ -67,6 +67,9 @@ Read Hall sensor (GPIO36, GPIO39). We recommend using 12-bits width on ADC1.
 
 #### Syntax
 `adc.read_hall_sensor()`
+
+#### Parameters
+none
 
 #### Returns
 the sampled value (number)

--- a/docs/modules/file.md
+++ b/docs/modules/file.md
@@ -93,7 +93,7 @@ none
 #### See also
 [`file.remove()`](#fileremove)
 
-## file.fscfg ()
+## file.fscfg()
 
 Returns the flash address and physical size of the file system area, in bytes.
 
@@ -238,7 +238,7 @@ end
 
 Remove a file from the file system. The file must not be currently open.
 
-###Syntax
+#### Syntax
 `file.remove(filename)`
 
 #### Parameters

--- a/docs/modules/i2c.md
+++ b/docs/modules/i2c.md
@@ -8,6 +8,7 @@
 This module supports 3 different interfaces for I²C communication on a ESP-32.
 
 The interface `id` can be
+
 - `i2c.SW` software based bitbanging, master mode only, immediate execution, synchronous operation, maximum speed 100 KHz (Standard mode)
 - `i2c.HW0` ESP32 hardware bus interface 0, master or slave mode, deferred execution, synchronous or asynchronous operation, maximum speed 1 MHz (Fast-mode Plus)
 - `i2c.HW1` ESP32 hardware bus interface 1, master or slave mode, deferred execution, synchronous or asynchronous operation, maximum speed 1 MHz (Fast-mode Plus)
@@ -140,7 +141,7 @@ Perform (`SW`) or enqueue (`HWx`) an I²C address operation, defining data trans
 - `direction` `i2c.TRANSMITTER` for write mode , `i2c.RECEIVER` for read mode
 - `ack_check_en` enable check for slave ACK with `true` (default), disable check with `false`
 
-This last, optional parameter is only relevant for for hardware interfaces `i2c.HW0` and `i2c.HW1` and defaults to `true'.
+This last, optional parameter is only relevant for for hardware interfaces `i2c.HW0` and `i2c.HW1` and defaults to `true`.
 The I²C `address` operation is enqueued for later execution and this parameter will be used at that later time.
 At that time, if NO slave device produces an ACK to the address operation, the default assumption is that the slave at that address is absent or not functional. Any remaining I²C operations in the queue will be ignored/flushed/discarded and the communication will be stopped.
 This default queue flushing behaviour on slave NACK can be overridden by specifying `false`.
@@ -264,8 +265,9 @@ In this case, this function returns read values and an ACK flag.
 - `to_ms` optional timeout for the synchronous transfer in ms, defaults to 0 (infinite)
 
 The optional callback function should be defined to accept 2 arguments i.e. `function( data , ack )` where
-- `data `is the string from a read operation during the transfer (`nil` if no read or failed ACK )
-- `ack is a boolean (true = ACK received).
+
+- `data` is the string from a read operation during the transfer (`nil` if no read or failed ACK )
+- `ack` is a boolean (`true` = ACK received).
 
 The optional timeout parameter defaults to 0 meaning infinite and is only relevant for synchronous mode. This can be used to define an upper bound to the execution time of `i2c.transfer()`.
 It specifies the maximum delay in mS before `i2c.transfer()` returns, possibly before the complete I²C set of operations is executed. 

--- a/docs/modules/tmr.md
+++ b/docs/modules/tmr.md
@@ -15,6 +15,9 @@ What the tmr module is *not* however, is a time keeping module. While all timeou
 
 Creates a dynamic timer object.
 
+#### Syntax
+`tmr.create()`
+
 #### Parameters
 none
 


### PR DESCRIPTION


Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Fix adc.md, i2c.md, file.md, tmr.md  formatting.
