### PR TITLE
docs: update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
-Fixes #\<GitHub-issue-number\>.
+Fixes #<GITHUB_ISSUE_NUMBER>.
 
-Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.
+_Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so._
 
 - [ ] This PR is for the `dev` branch rather than for the `release` branch.
-- [ ] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
+- [ ] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
 - [ ] I have thoroughly tested my contribution.
 - [ ] The code changes are reflected in the documentation at `docs/*`.
 
-\<Description of and rationale behind this PR\>
+_To be completed below: Description of and rationale behind this PR._


### PR DESCRIPTION
Note that there is no need to escape as `#\<GitHub-issue-number\>` if you use _underscores_ instead of dashes.

e.g.

    Fixes #<GITHUB_ISSUE_NUMBER>.

Fixes #<GITHUB_ISSUE_NUMBER>.

---

Though, `\<Description of and rationale behind this PR\>` needs escaping or it will disappear. I made it italics instead.
