### PR TITLE
Minor sntp.sync() bug fix

### DIFF
--- a/app/modules/sntp.c
+++ b/app/modules/sntp.c
@@ -806,7 +806,7 @@ static int sntp_sync (lua_State *L)
   } else if (server_count == 0) {
     lua_newtable(L);
     struct netif *iface = (struct netif *)eagle_lwip_getif(0x00);
-    if (iface->dhcp && iface->dhcp->offered_ntp_addr.addr) {
+    if (iface && iface->dhcp && iface->dhcp->offered_ntp_addr.addr) {
 		ip_addr_t ntp_addr = iface->dhcp->offered_ntp_addr;
         lua_pushinteger(L, 1);
         lua_pushstring(L, inet_ntoa(ntp_addr));


### PR DESCRIPTION
Fixes #3449.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Fixes a crash reported in #3449.

Code causing crash:
```Lua
wifi.setmode(wifi.SOFTAP)
sntp.sync()
```