### PR TITLE
Minor Lua fixes.

### DIFF
--- a/app/lua/lflash.c
+++ b/app/lua/lflash.c
@@ -473,7 +473,7 @@ static int loadLFS (lua_State *L) {
   vfs_lseek(in->fd, 0, VFS_SEEK_SET);
 
   /* Allocate the out buffers */
-  for(i = 0;  i <= WRITE_BLOCKS; i++)
+  for(i = 0;  i < WRITE_BLOCKS; i++)
     out->block[i] = luaM_new(L, outBlock);
 
   /* first inflate pass */
@@ -497,8 +497,9 @@ static int loadLFS (lua_State *L) {
   flashErase(0,(out->flashLen - 1)/FLASH_PAGE_SIZE);
   flashSetPosition(0);
 
-  if ((res = uzlib_inflate(get_byte, put_byte, recall_byte,
-                    in->len, &crc, &in->inflate_state)) != UZLIB_DONE) {
+  res = uzlib_inflate(get_byte, put_byte, recall_byte,
+    in->len, &crc, &in->inflate_state);
+  if (res < 0) { // UZLIB_OK == 0, UZLIB_DONE == 1
     const char *err[] = {"Data_error during decompression",
                          "Chksum_error during decompression",
                          "Dictionary error during decompression",


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution*.
- [n/a] The code changes are reflected in the documentation at `docs/*`.


Issues discovered over on the dev-esp32-idf4 branch while getting the 5.1+5.3 support across to that branch.

- Off by one error in loadLFS, leading to slight memory leak and
  potential corruption.

- Insufficient return value check in loadLFS, where uzlib may return
  one of two success conditions, one of which would result in an
  out-of-bounds access and related pain.

- One case of a side effect within a lua_assert(), leading to
  silently broken LFS image handling when compiling without asserts
  enabled, the issue showing up as module names being shuffled around.

- Incorrect encoding of TValues in LFS when 64bit numbers in use.


_*) predominantly tested on ESP32_