### PR TITLE
Lua tidy-up to reduce delta against esp32 branch.

### DIFF
--- a/app/lua/lbaselib.c
+++ b/app/lua/lbaselib.c
@@ -24,7 +24,7 @@
 ** model but changing `fputs' to put the strings at a proper place
 ** (a console window or a log file, for instance).
 */
-#ifdef LUA_CROSS_COMPILER
+#if defined(LUA_USE_ESP8266)
 #undef puts
 #define puts(s) printf("%s",s)
 #endif

--- a/app/lua/ldebug.c
+++ b/app/lua/ldebug.c
@@ -248,6 +248,7 @@ static int stripdebug (lua_State *L, Proto *f, int level) {
         f->packedlineinfo = luaM_freearray(L, f->packedlineinfo, sizepackedlineinfo, unsigned char);
         len += sizepackedlineinfo;
       }
+      // fall-through
     case 1:
       f->locvars = luaM_freearray(L, f->locvars, f->sizelocvars, struct LocVar);
       f->upvalues = luaM_freearray(L, f->upvalues, f->sizeupvalues, TString *);
@@ -501,7 +502,7 @@ static Instruction symbexec (const Proto *pt, int lastpc, int reg) {
       case OP_FORLOOP:
       case OP_FORPREP:
         checkreg(pt, a+3);
-        /* go through */
+        /* fall-through */
       case OP_JMP: {
         int dest = pc+1+b;
         /* not full check and jump is forward and do not skip `lastpc'? */

--- a/app/lua/llex.c
+++ b/app/lua/llex.c
@@ -61,6 +61,7 @@ static void save (LexState *ls, int c) {
 
 
 void luaX_init (lua_State *L) {
+  (void)L;
 }
 
 

--- a/app/lua/lmathlib.c
+++ b/app/lua/lmathlib.c
@@ -359,5 +359,6 @@ LROT_END(math, NULL, 0)
 ** Open math library
 */
 LUALIB_API int luaopen_math (lua_State *L) {
+  (void)L;
   return 0;
 }

--- a/app/lua/lnodemcu.c
+++ b/app/lua/lnodemcu.c
@@ -118,6 +118,7 @@ LUALIB_API int luaL_posttask( lua_State* L, int prio ) {          // [-1, +0, -]
 }
 #else
 LUALIB_API int luaL_posttask( lua_State* L, int prio ) { 
+  (void)L; (void)prio;
   return 0;
 } /* Dummy stub on host */
 #endif

--- a/app/lua/lnodemcu.h
+++ b/app/lua/lnodemcu.h
@@ -45,9 +45,11 @@
   static ROTable_entry LOCK_IN_SECTION(s) rt ## _entries[] = {
 #define LROT_END(rt,mt,f)    {NULL, LRO_NILVAL} }; \
   const ROTable rt ## _ROTable = { \
-    (GCObject *)1, LUA_TROTABLE, LROT_MARKED, \
-    cast(lu_byte, ~(f)), (sizeof(rt ## _entries)/sizeof(ROTable_entry)) - 1, \
-    cast(Table *, mt), cast(ROTable_entry *, rt ## _entries) };
+    .next = (GCObject *)1, .tt = LUA_TROTABLE, .marked = LROT_MARKED, \
+    .flags = cast(lu_byte, ~(f)), \
+    .lsizenode = (sizeof(rt ## _entries)/sizeof(ROTable_entry)) - 1, \
+    .metatable = cast(Table *, mt), \
+    .entry = cast(ROTable_entry *, rt ## _entries) };
 #define LROT_BREAK(rt)       };
 
 #define LROT_MASK(m)         cast(lu_byte, 1<<TM_ ## m)
@@ -65,10 +67,9 @@
 #define LROT_MASK_NEWINDEX   LROT_MASK(NEWINDEX)
 #define LROT_MASK_GC_INDEX   (LROT_MASK_GC | LROT_MASK_INDEX)
 
-/* Maximum length of a rotable name and of a string key*/
+#define LUA_MAX_ROTABLE_NAME 32  /* Maximum length of a rotable name and of a string key*/
 
 #ifdef LUA_CORE
 
 #endif
 #endif
-

--- a/app/lua/loadlib.c
+++ b/app/lua/loadlib.c
@@ -619,6 +619,7 @@ static int ll_seeall (lua_State *L) {
 
 static void setpath (lua_State *L, const char *fieldname, const char *envname,
                                    const char *def) {
+  (void)envname;
   const char *path = NULL;  /* getenv(envname) not used in NodeMCU */;
   if (path == NULL)  /* no environment variable? */
     lua_pushstring(L, def);  /* use default */

--- a/app/lua/lobject.c
+++ b/app/lua/lobject.c
@@ -68,10 +68,7 @@ int luaO_log2 (unsigned int x) {
   while (x >= 256) { l += 8; x >>= 8; }
   return l + log_2[x];
 #else
- /* Use Normalization Shift Amount Unsigned:  0x1=>31 up to 0xffffffff =>0
-  * See Xtensa Instruction Set Architecture (ISA) Refman  P 462 */
-  asm volatile ("nsau %0, %1;" :"=r"(x) : "r"(x));
-  return 31 - x;
+  return 31 - __builtin_clz(x);
 #endif
 }
 

--- a/app/lua/lobject.h
+++ b/app/lua/lobject.h
@@ -28,7 +28,7 @@
 #define LUA_TUPVAL	(LAST_TAG+2)
 #define LUA_TDEADKEY	(LAST_TAG+3)
 
-#ifdef LUA_USE_ESP
+#ifdef LUA_USE_ESP8266
 /*
 ** force aligned access to critical fields in Flash-based structures
 ** wo is the offset of aligned word in bytes 0,4,8,..

--- a/app/lua/ltable.c
+++ b/app/lua/ltable.c
@@ -336,6 +336,7 @@ static Node *find_prev_node(Node *mp, Node *next) {
 ** (colliding node is in its main position), moving node goes to an empty position.
 */
 static int move_node (lua_State *L, Table *t, Node *node) {
+  (void)L;
   Node *mp = mainposition(t, key2tval(node));
   /* if node is in it's main position, don't need to move node. */
   if (mp == node) return 1;
@@ -374,6 +375,7 @@ static int move_node (lua_State *L, Table *t, Node *node) {
 
 
 static int move_number (lua_State *L, Table *t, Node *node) {
+  (void)L;
   int key;
   lua_Number n = nvalue(key2tval(node));
   lua_number2int(key, n);

--- a/app/lua/ltablib.c
+++ b/app/lua/ltablib.c
@@ -277,5 +277,6 @@ LROT_BEGIN(tab_funcs, NULL, 0)
 LROT_END(tab_funcs, NULL, 0)
 
 LUALIB_API int luaopen_table (lua_State *L) {
+  (void)L;
   return 1;
 }

--- a/app/lua53/lauxlib.h
+++ b/app/lua53/lauxlib.h
@@ -144,6 +144,9 @@ LUALIB_API void (luaL_requiref) (lua_State *L, const char *modname,
 #define luaL_loadbuffer(L,s,sz,n)	luaL_loadbufferx(L,s,sz,n,NULL)
 
 
+#define luaL_checkfunction(L,n)        luaL_checktype(L, (n), LUA_TFUNCTION);
+#define luaL_checktable(L,n)   luaL_checktype(L, (n), LUA_TTABLE);
+
 /*
 ** {======================================================
 ** Generic Buffer manipulation
@@ -227,7 +230,8 @@ LUALIB_API void (luaL_openlib) (lua_State *L, const char *libname,
 
 /* print a string */
 #if !defined(lua_writestring)
-#ifdef LUA_USE_ESP8266
+#ifdef LUA_USE_ESP
+void output_redirect(const char *str, size_t l);
 #define lua_writestring(s,l)  output_redirect((s),(l))
 #else
 #define lua_writestring(s,l)   fwrite((s), sizeof(char), (l), stdout)
@@ -290,11 +294,8 @@ LUALIB_API int  (luaL_pushlfsdts) (lua_State *L);
 LUALIB_API void (luaL_lfsreload) (lua_State *L);
 LUALIB_API int  (luaL_posttask) (lua_State* L, int prio);
 LUALIB_API int  (luaL_pcallx) (lua_State *L, int narg, int nres);
-
 #define luaL_pushlfsmodule(l) lua_pushlfsfunc(L)
 
 /* }============================================================ */
 
 #endif
-
-

--- a/app/lua53/ldblib.c
+++ b/app/lua53/ldblib.c
@@ -464,6 +464,7 @@ LROT_BEGIN(dblib, NULL, 0)
 LROT_END(dblib, NULL, 0)
 
 LUAMOD_API int luaopen_debug (lua_State *L) {
+  (void)L;
   return 0;
 }
 

--- a/app/lua53/ldump.c
+++ b/app/lua53/ldump.c
@@ -272,6 +272,7 @@ static int stripdebug (lua_State *L, Proto *f, int level) {
         f->lineinfo = luaM_freearray(L, f->lineinfo, f->sizelineinfo);
         len += f->sizelineinfo;
       }
+      // fall-through
     case 1:
       for (i=0; i<f->sizeupvalues; i++)
         f->upvalues[i].name = NULL;

--- a/app/lua53/lmathlib.c
+++ b/app/lua53/lmathlib.c
@@ -394,6 +394,7 @@ LROT_END(mathlib, NULL, 0)
 ** Open math library
 */
 LUAMOD_API int luaopen_math (lua_State *L) {
+  (void)L;
   return 0;
 }
 

--- a/app/lua53/loadlib.c
+++ b/app/lua53/loadlib.c
@@ -421,7 +421,7 @@ static int ll_loadlib (lua_State *L) {
 ** =======================================================
 */
 
-#ifdef LUA_USE_ESP8266
+#ifdef LUA_USE_ESP
 #define file_t int
 #undef fopen
 #undef fclose

--- a/app/lua53/lobject.c
+++ b/app/lua53/lobject.c
@@ -63,13 +63,7 @@ int luaO_fb2int (int x) {
 ** Computes ceil(log2(x))
 */
 int luaO_ceillog2 (unsigned int x) {
-#ifdef LUA_USE_ESP
- /* Use Normalization Shift Amount Unsigned:  0x1=>31 up to 0xffffffff =>0
-  * See Xtensa Instruction Set Architecture (ISA) Refman  P 462 */
-  x--;
-  asm volatile ("nsau %0, %1;" :"=r"(x) : "r"(x));
-  return 32 - x;
-#else
+#ifdef LUA_CROSS_COMPILER
   static const lu_byte log_2[256] = {  /* log_2[i] = ceil(log2(i - 1)) */
     0,1,2,2,3,3,3,3,4,4,4,4,4,4,4,4,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,
     6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,6,
@@ -84,6 +78,8 @@ int luaO_ceillog2 (unsigned int x) {
   x--;
   while (x >= 256) { l += 8; x >>= 8; }
   return l + log_2[x];
+#else
+  return (x == 1) ? 0 : 32 - __builtin_clz(x - 1);
 #endif
 }
 

--- a/app/lua53/lobject.h
+++ b/app/lua53/lobject.h
@@ -80,7 +80,7 @@
 ** wo is the offset of aligned word in bytes 0,4,8,..
 ** bo is the field within the word in bits 0..31
 */
-#ifdef LUA_USE_ESP
+#if defined(LUA_USE_ESP8266)
 #define GET_BYTE_FN(name,t,wo,bo) \
 static inline lu_int32 get ## name(const void *o) { \
   lu_int32 res;  /* extract named field */ \

--- a/app/lua53/lstate.c
+++ b/app/lua53/lstate.c
@@ -42,12 +42,15 @@
 ** created; the seed is used to randomize hashes.
 */
 #if !defined(luai_makeseed)
-#if defined(LUA_USE_ESP)
+#if defined(LUA_USE_ESP8266)
 static inline unsigned int luai_makeseed(void) {
   unsigned int r;
   asm volatile("rsr %0, ccount" : "=r"(r));
   return r;
 }
+#elif defined(LUA_USE_ESP)
+# include "esp_random.h"
+# define luai_makeseed()    esp_random()
 #else
 #include <time.h>
 #define luai_makeseed()		cast(unsigned int, time(NULL))

--- a/app/lua53/ltablib.c
+++ b/app/lua53/ltablib.c
@@ -438,6 +438,7 @@ LROT_BEGIN(tab_funcs, NULL, 0)
 LROT_END(tab_funcs, NULL, 0)
 
 LUAMOD_API int luaopen_table (lua_State *L) {
+  (void)L;
   return 0;
 }
 

--- a/app/lua53/lua.h
+++ b/app/lua53/lua.h
@@ -465,6 +465,8 @@ struct lua_Debug {
   struct CallInfo *i_ci;  /* active function */
 };
 
+int lua_main(void);
+
 /* }====================================================================== */
 
 /* NodeMCU extensions to the standard API */

--- a/app/lua53/lutf8lib.c
+++ b/app/lua53/lutf8lib.c
@@ -258,6 +258,7 @@ LROT_END(utf8, LROT_TABLEREF(utf8_meta), 0)
 
 
 LUAMOD_API int luaopen_utf8 (lua_State *L) {
+  (void)L;
   return 0;
 }
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [n/a] The code changes are reflected in the documentation at `docs/*`.


These should hopefully be completely uncontentious changes, as there
are no functional changes in this commit.

There is still a delta against the esp32 branch, but to harmonise that fully
requires a bit more work.

This commit includes:

- Some LUA_USE_xxx #ifdef changes, since in many ways the ESP32 is
  closer to a host build than an ESP8266 build.

- A bunch of compiler warnings tidy-ups.

- A couple of readability/maintainability improvements (e.g. LROT_END
  definition using named member initialisation, prototype declarations
  moved to header file(s)).

- Some 64bit correctness for 64bit host builds.
