### PR TITLE
MQTT connfail fix

### DIFF
--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -1021,7 +1021,12 @@ static void socket_dns_found(const char *name, ip_addr_t *ipaddr, void *arg)
   NODE_DBG(IPSTR, IP2STR(&(ipaddr->addr)));
   NODE_DBG("\n");
 
-  mqtt_socket_do_connect(mud);
+  if(mqtt_socket_do_connect(mud) != ESPCONN_OK) {
+      NODE_DBG("socket_dns_found, got DNS but connect failed\n");
+      mqtt_connack_fail(mud, MQTT_CONN_FAIL_DNS);
+      mqtt_socket_disconnected(arg);
+      return;
+  }
 }
 
 #include "pm/swtimer.h"


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

Noticed that cb_connect_fail_ref was not properly called sometimes, after wifi was reconnected (for example, explicit clearconfig + config). Seems DNS is resolved fine but the espconn returned -4. Since return value was ignored, the failure callback was never trigged, and LUA code could not see react properly (i.e. re-trigger connect attempt in my case)