### PR TITLE
Consider RMT channel limitations at allocation time.

### DIFF
--- a/components/platform/dht.c
+++ b/components/platform/dht.c
@@ -76,7 +76,7 @@ static void dht_deinit( void )
 static int dht_init( uint8_t gpio_num )
 {
   // acquire an RMT module for RX
-  if ((dht_rmt.channel = platform_rmt_allocate( 1 )) >= 0) {
+  if ((dht_rmt.channel = platform_rmt_allocate( 1, 0 )) >= 0) {
 
 #ifdef DHT_DEBUG
     ESP_LOGI("dht", "RMT RX channel: %d", dht_rmt.channel);

--- a/components/platform/dht.c
+++ b/components/platform/dht.c
@@ -76,7 +76,7 @@ static void dht_deinit( void )
 static int dht_init( uint8_t gpio_num )
 {
   // acquire an RMT module for RX
-  if ((dht_rmt.channel = platform_rmt_allocate( 1, 0 )) >= 0) {
+  if ((dht_rmt.channel = platform_rmt_allocate( 1, RMT_MODE_RX )) >= 0) {
 
 #ifdef DHT_DEBUG
     ESP_LOGI("dht", "RMT RX channel: %d", dht_rmt.channel);

--- a/components/platform/include/platform_rmt.h
+++ b/components/platform/include/platform_rmt.h
@@ -14,14 +14,14 @@
  * @brief Allocate an RMT channel.
  *
  * @param num_mem Number of memory blocks.
- * @param is_tx Mode of the channel, !=0 allocates a TX channel, ==0 an RX channel.
+ * @param mode Mode of the channel, RMT_MODE_TX allocates a TX channel, RMT_MODE_RX an RX channel.
  *
  * @return
  *     - Channel number when successful
  *     - -1 if no channel available
  *
  */
-int platform_rmt_allocate( uint8_t num_mem, uint8_t is_tx );
+int platform_rmt_allocate( uint8_t num_mem, rmt_mode_t mode );
 
 /**
  * @brief Release a previously allocated RMT channel.

--- a/components/platform/include/platform_rmt.h
+++ b/components/platform/include/platform_rmt.h
@@ -14,13 +14,14 @@
  * @brief Allocate an RMT channel.
  *
  * @param num_mem Number of memory blocks.
+ * @param is_tx Mode of the channel, !=0 allocates a TX channel, ==0 an RX channel.
  *
  * @return
  *     - Channel number when successful
  *     - -1 if no channel available
  *
  */
-int platform_rmt_allocate( uint8_t num_mem );
+int platform_rmt_allocate( uint8_t num_mem, uint8_t is_tx );
 
 /**
  * @brief Release a previously allocated RMT channel.

--- a/components/platform/onewire.c
+++ b/components/platform/onewire.c
@@ -113,8 +113,8 @@ static int onewire_rmt_init( uint8_t gpio_num )
   }
 
   // acquire an RMT module for TX and RX each
-  if ((ow_rmt.tx = platform_rmt_allocate( 1 )) >= 0) {
-    if ((ow_rmt.rx = platform_rmt_allocate( 1 )) >= 0) {
+  if ((ow_rmt.tx = platform_rmt_allocate( 1, 1 )) >= 0) {
+    if ((ow_rmt.rx = platform_rmt_allocate( 1, 0 )) >= 0) {
 
 #ifdef OW_DEBUG
       ESP_LOGI("ow", "RMT TX channel: %d", ow_rmt.tx);

--- a/components/platform/onewire.c
+++ b/components/platform/onewire.c
@@ -113,8 +113,8 @@ static int onewire_rmt_init( uint8_t gpio_num )
   }
 
   // acquire an RMT module for TX and RX each
-  if ((ow_rmt.tx = platform_rmt_allocate( 1, 1 )) >= 0) {
-    if ((ow_rmt.rx = platform_rmt_allocate( 1, 0 )) >= 0) {
+  if ((ow_rmt.tx = platform_rmt_allocate( 1, RMT_MODE_TX )) >= 0) {
+    if ((ow_rmt.rx = platform_rmt_allocate( 1, RMT_MODE_RX )) >= 0) {
 
 #ifdef OW_DEBUG
       ESP_LOGI("ow", "RMT TX channel: %d", ow_rmt.tx);

--- a/components/platform/platform_rmt.c
+++ b/components/platform/platform_rmt.c
@@ -24,12 +24,33 @@ static bool rmt_channel_check( uint8_t channel, uint8_t num_mem )
   return rmt_channel_check( channel-1, num_mem-1);
 }
 
-int platform_rmt_allocate( uint8_t num_mem )
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+int platform_rmt_allocate( uint8_t num_mem, uint8_t is_tx )
+#else
+int platform_rmt_allocate( uint8_t num_mem, uint8_t is_tx __attribute__((unused)))
+#endif
 {
   int channel;
+  int alloc_min;
+  int alloc_max;
   uint8_t tag = 1;
 
-  for (channel = RMT_CHANNEL_MAX-1; channel >= 0; channel--) {
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+  /* The ESP32-C3 is limited to TX on channel 0-1 and RX on channel 2-3. */
+  if( is_tx ) {
+    alloc_min = 0;
+    alloc_max = SOC_RMT_TX_CANDIDATES_PER_GROUP - 1;
+  } else {
+    alloc_min = RMT_CHANNEL_MAX - SOC_RMT_RX_CANDIDATES_PER_GROUP;
+    alloc_max = RMT_CHANNEL_MAX - 1;
+  }
+#else
+  /* The other ESP32 devices can do RX and TX on all channels. */
+  alloc_min = 0;
+  alloc_max = RMT_CHANNEL_MAX - 1;
+#endif
+
+  for (channel = alloc_max; channel >= alloc_min; channel--) {
     if (rmt_channel_alloc[channel] == 0) {
       if (rmt_channel_check( channel, num_mem )) {
         rmt_channel_alloc[channel] = tag++;

--- a/components/platform/platform_rmt.c
+++ b/components/platform/platform_rmt.c
@@ -25,9 +25,9 @@ static bool rmt_channel_check( uint8_t channel, uint8_t num_mem )
 }
 
 #if defined(CONFIG_IDF_TARGET_ESP32C3)
-int platform_rmt_allocate( uint8_t num_mem, uint8_t is_tx )
+int platform_rmt_allocate( uint8_t num_mem, rmt_mode_t mode )
 #else
-int platform_rmt_allocate( uint8_t num_mem, uint8_t is_tx __attribute__((unused)))
+int platform_rmt_allocate( uint8_t num_mem, rmt_mode_t mode __attribute__((unused)))
 #endif
 {
   int channel;
@@ -37,7 +37,7 @@ int platform_rmt_allocate( uint8_t num_mem, uint8_t is_tx __attribute__((unused)
 
 #if defined(CONFIG_IDF_TARGET_ESP32C3)
   /* The ESP32-C3 is limited to TX on channel 0-1 and RX on channel 2-3. */
-  if( is_tx ) {
+  if( mode==RMT_MODE_TX ) {
     alloc_min = 0;
     alloc_max = SOC_RMT_TX_CANDIDATES_PER_GROUP - 1;
   } else {

--- a/components/platform/ws2812.c
+++ b/components/platform/ws2812.c
@@ -138,7 +138,7 @@ int platform_ws2812_setup( uint8_t gpio_num, uint8_t num_mem, const uint8_t *dat
 {
   int channel;
 
-  if ((channel = platform_rmt_allocate( num_mem, 1 )) >= 0) {
+  if ((channel = platform_rmt_allocate( num_mem, RMT_MODE_TX )) >= 0) {
     ws2812_chain_t *chain = &(ws2812_chains[channel]);
 
     chain->valid = true;

--- a/components/platform/ws2812.c
+++ b/components/platform/ws2812.c
@@ -138,7 +138,7 @@ int platform_ws2812_setup( uint8_t gpio_num, uint8_t num_mem, const uint8_t *dat
 {
   int channel;
 
-  if ((channel = platform_rmt_allocate( num_mem )) >= 0) {
+  if ((channel = platform_rmt_allocate( num_mem, 1 )) >= 0) {
     ws2812_chain_t *chain = &(ws2812_chains[channel]);
 
     chain->valid = true;


### PR DESCRIPTION
The ESP32-C3 is limited to TX on channel 0-1 and RX on channel 2-3.

Fixes #3480 .

Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](https://github.com/nodemcu/nodemcu-firmware/blob/dev/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [] The code changes are reflected in the documentation at `docs/*`.
