### PR TITLE
Support interface-specific hostname on ethernet interface.

### DIFF
--- a/components/modules/eth.c
+++ b/components/modules/eth.c
@@ -230,6 +230,18 @@ static int leth_set_ip( lua_State *L )
   return 0;
 }
 
+static int leth_set_hostname(lua_State *L)
+{
+  const char *hostname = luaL_checkstring(L, 1);
+
+  esp_err_t err = esp_netif_set_hostname(eth, hostname);
+
+  if (err != ESP_OK)
+    return luaL_error (L, "failed to set hostname, code %d", err);
+
+  return 0;
+}
+
 static int leth_on( lua_State *L )
 {
   const char *event_name = luaL_checkstring( L, 1 );
@@ -338,6 +350,7 @@ LROT_BEGIN(eth, NULL, 0)
   LROT_FUNCENTRY( get_mac,    leth_get_mac )
   LROT_FUNCENTRY( set_mac,    leth_set_mac )
   LROT_FUNCENTRY( set_ip,     leth_set_ip )
+  LROT_FUNCENTRY( set_hostname, leth_set_hostname )
 
   LROT_NUMENTRY( PHY_DP83848, ETH_PHY_DP83848 )
   LROT_NUMENTRY( PHY_IP101,   ETH_PHY_IP101 )

--- a/docs/modules/eth.md
+++ b/docs/modules/eth.md
@@ -200,3 +200,21 @@ eth.set_ip({
   dns = "8.8.8.8"
 })
 ```
+
+## eth.set_hostname()
+Configures the interface specific hostname for the ethernet interface. The ethernet interface must be initialized before the hostname can be configured.
+
+By default the system hostname is used, as configured in the menu config.
+
+#### Syntax
+```lua
+eth.set_hostname(hostname)
+```
+
+#### Parameters
+- `hostname` the hostname to use on the ethernet interface
+
+#### Returns
+`nil`
+
+An error is thrown in case the hostname cannot be set.


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

Currently only the WiFi station interface supports setting a custom hostname, overriding the system default. This PR extends the functionality to the Ethernet interface as well.