### PR TITLE
Added mkdir/rmdir support to file module.

### DIFF
--- a/components/modules/file.c
+++ b/components/modules/file.c
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <errno.h>
 
 static const char *default_fs_label =
   ((CONFIG_NODEMCU_DEFAULT_SPIFFS_LABEL &&
@@ -116,6 +117,29 @@ static int file_fsinfo( lua_State* L )
 }
 
 
+static int file_mkdir( lua_State *L )
+{
+  const char *name = luaL_checkstring(L, 1);
+  unsigned mode = luaL_optint(L, 2, 0777);
+  if (mkdir(name, mode) != 0) {
+    return
+      luaL_error(L, "failed to create directory '%s'; code %d", name, errno);
+  }
+  return 0;
+}
+
+
+static int file_rmdir( lua_State *L )
+{
+  const char *name = luaL_checkstring(L, 1);
+  if (rmdir(name) != 0) {
+    return
+      luaL_error(L, "failed to remove directory '%s'; code %d", name, errno);
+  }
+  return 0;
+}
+
+
 // Module function map
 LROT_BEGIN(file, NULL, 0)
   LROT_FUNCENTRY( list,      file_list )
@@ -124,6 +148,8 @@ LROT_BEGIN(file, NULL, 0)
   LROT_FUNCENTRY( rename,    file_rename )
   LROT_FUNCENTRY( exists,    file_exists )
   LROT_FUNCENTRY( fsinfo,    file_fsinfo )
+  LROT_FUNCENTRY( mkdir,     file_mkdir )
+  LROT_FUNCENTRY( rmdir,     file_rmdir )
 LROT_END(file, NULL, 0)
 
 

--- a/docs/modules/file.md
+++ b/docs/modules/file.md
@@ -115,6 +115,39 @@ for k,v in pairs(l) do
 end
 ```
 
+## file.mkdir()
+
+Creates a directory, provided the underlying file system supports directories. SPIFFS does not, but FAT (which you may have on an attached SD card) does.
+
+#### Syntax
+`file.mkdir(path [, mode])
+```
+
+#### Parameters
+- `path` the full path name of the directory to create. E.g. "/SD0/MYDIR".
+- `mode` optional, only used for file systems which use mode permissions. Defaults to 0777 (octal).
+
+#### Returns
+`nil`
+
+Throws an error if the directory could not be created. Error code 134 (at the
+time of writing) indicates that the filesystem at the given path does not
+support directories.
+
+## file.rmdir()
+
+Removes an empty directory, provided the underlying file system supports directories. SPIFFS does not, but FAT (which you may have on an attached SD card) does.
+
+#### Syntax
+`file.rmdir(path)`
+
+#### Parameters
+- `path` the path to the directory to remove. The directory must be empty.
+
+#### Returns
+`nil`
+
+Throws an error if the directory could not be removed.
 
 ## file.remove()
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

When working with SD cards formatting with FAT, having the ability to create and remove directories become important. This PR exposes the IDF's `mkdir` and `rmdir` functions via the `file` module, since there is no standard Lua interface for it.