### PR TITLE
Give the SPI module a chance of working...

### DIFF
--- a/docs/modules/spi.md
+++ b/docs/modules/spi.md
@@ -148,7 +148,7 @@ device:transfer(txdata)
 `trans` table containing the elements of the transaction:
 
 - `command` data for command phase, amount of bits was defined during device creation, optional
-- `address` data for address phase, amount of bits was defined during device creation, optional
+- `addr` data for address phase, amount of bits was defined during device creation, optional
 - `txdata` string of data to be sent to the device, optional
 - `rxlen` number of bytes to be received, optional
 - `mode` optional, one of

--- a/docs/modules/spi.md
+++ b/docs/modules/spi.md
@@ -147,7 +147,7 @@ device:transfer(txdata)
 #### Parameters
 `trans` table containing the elements of the transaction:
 
-- `command` data for command phase, amount of bits was defined during device creation, optional
+- `cmd` data for command phase, amount of bits was defined during device creation, optional
 - `addr` data for address phase, amount of bits was defined during device creation, optional
 - `txdata` string of data to be sent to the device, optional
 - `rxlen` number of bytes to be received, optional


### PR DESCRIPTION
Fixes #3494.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

There were a number of things broken about the `spi` support.

* The parameter to `transfer` for the address was actually `addr` rather than `address`
* If specified, the `cs` line has to be configured as a gpio and set to the inactive value
* The `txdata` argument to `transfer` didn't work.

This PR fixes all of the above and it appears to work (at least it drives the one device that I have tried it on!)
