### PR TITLE
Make UART buffer sizes configurable.

### DIFF
--- a/components/platform/Kconfig
+++ b/components/platform/Kconfig
@@ -64,4 +64,82 @@ menu "NodeMCU platform config"
             Embedded LUA Flash Store size. Set to zero to use an LFS partition
             instead of embedding the LFS within the NodeMCU firmware itself.
 
+    menu "UART buffer size configuration"
+
+        config NODEMCU_UART_AT_LEAST_2
+            bool
+            default y if IDF_TARGET_ESP32
+            default y if IDF_TARGET_ESP32S2
+            default y if IDF_TARGET_ESP32S3
+            default y if IDF_TARGET_ESP32C3
+            default y if IDF_TARGET_ESP32H2
+
+        config NODEMCU_UART_AT_LEAST_3
+            bool
+            default y if IDF_TARGET_ESP32
+            default y if IDF_TARGET_ESP32S3
+
+        config NODEMCU_UART_DRIVER_BUF_SIZE_RX0
+            int "RX buffer size for UART0"
+            default 512
+            help
+                The rx buffer size to use for UART0.
+                This is a buffer used to/from the UART ISR. For high-speed scenarios,
+                it can be very helpful to increase the rx size.  The ISR trying
+                to write to a full rx buffer results in lost data and an error
+                event posted.
+
+        config NODEMCU_UART_DRIVER_BUF_SIZE_TX0
+            int "TX buffer size for UART0"
+            default 512
+            help
+                The tx buffer size to use for UART0.
+                This is a buffer used to/from the UART ISR. In some scenarios it
+                can be helpful to increase the tx size. Writing to a full tx buffer
+                blocks the calling RTOS task.
+
+        config NODEMCU_UART_DRIVER_BUF_SIZE_RX1
+            int "RX buffer size for UART1"
+            depends on NODEMCU_UART_AT_LEAST_2
+            default 512
+            help
+                The rx buffer size to use for UART1.
+                This is a buffer used to/from the UART ISR. For high-speed scenarios,
+                it can be very helpful to increase the rx size.  The ISR trying
+                to write to a full rx buffer results in lost data and an error
+                event posted.
+
+        config NODEMCU_UART_DRIVER_BUF_SIZE_TX1
+            int "TX buffer size for UART1"
+            depends on NODEMCU_UART_AT_LEAST_2
+            default 512
+            help
+                The tx buffer size to use for UART1.
+                This is a buffer used to/from the UART ISR. In some scenarios it
+                can be helpful to increase the tx size. Writing to a full tx buffer
+                blocks the calling RTOS task.
+
+        config NODEMCU_UART_DRIVER_BUF_SIZE_RX2
+            int "RX buffer size for UART2"
+            depends on NODEMCU_UART_AT_LEAST_3
+            default 512
+            help
+                The rx buffer size to use for UART2.
+                This is a buffer used to/from the UART ISR. For high-speed scenarios,
+                it can be very helpful to increase the rx size.  The ISR trying
+                to write to a full rx buffer results in lost data and an error
+                event posted.
+
+        config NODEMCU_UART_DRIVER_BUF_SIZE_TX2
+            int "TX buffer size for UART2"
+            depends on NODEMCU_UART_AT_LEAST_3
+            default 512
+            help
+                The tx buffer size to use for UART2.
+                This is a buffer used to/from the UART ISR. In some scenarios it
+                can be helpful to increase the tx size. Writing to a full tx buffer
+                blocks the calling RTOS task.
+
+    endmenu
+
 endmenu

--- a/components/platform/include/cpu_esp32.h
+++ b/components/platform/include/cpu_esp32.h
@@ -4,7 +4,7 @@
 #include "sdkconfig.h"
 #include "esp_spi_flash.h"
 
-#define NUM_UART 3
+#define NUM_UART SOC_UART_NUM
 
 #define INTERNAL_FLASH_SECTOR_SIZE      SPI_FLASH_SEC_SIZE
 #define INTERNAL_FLASH_WRITE_UNIT_SIZE  4

--- a/components/platform/include/platform.h
+++ b/components/platform/include/platform.h
@@ -48,8 +48,6 @@ int platform_gpio_output_exists( unsigned gpio );
 // *****************************************************************************
 // UART subsection
 
-#define UART_BUFFER_SIZE    512
-
 enum 
 {
 	PLATFORM_UART_MODE_UART = 0x0,

--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -35,6 +35,24 @@ int platform_gpio_output_exists( unsigned gpio ) { return GPIO_IS_VALID_OUTPUT_G
 #define PLATFORM_UART_EVENT_BREAK    (UART_EVENT_MAX + 4)
 
 typedef struct {
+  unsigned rx_buf_sz;
+  unsigned tx_buf_sz;
+} uart_buf_sz_cfg_t;
+
+static const uart_buf_sz_cfg_t uart_buf_sz_cfg[] = {
+{ .rx_buf_sz = CONFIG_NODEMCU_UART_DRIVER_BUF_SIZE_RX0 +0,
+  .tx_buf_sz = CONFIG_NODEMCU_UART_DRIVER_BUF_SIZE_TX0 +0 },
+#if NUM_UART > 1
+{ .rx_buf_sz = CONFIG_NODEMCU_UART_DRIVER_BUF_SIZE_RX1 +0,
+  .tx_buf_sz = CONFIG_NODEMCU_UART_DRIVER_BUF_SIZE_TX1 +0 },
+#endif
+#if NUM_UART > 2
+{ .rx_buf_sz = CONFIG_NODEMCU_UART_DRIVER_BUF_SIZE_RX2 +0,
+  .tx_buf_sz = CONFIG_NODEMCU_UART_DRIVER_BUF_SIZE_TX2 +0 },
+#endif
+};
+
+typedef struct {
   unsigned id;
   int type;
   size_t size;
@@ -295,7 +313,7 @@ int platform_uart_start( unsigned id )
 
   uart_status_t *us = & uart_status[id];
 
-  esp_err_t ret = uart_driver_install(id, UART_BUFFER_SIZE, UART_BUFFER_SIZE, 3, & us->queue, 0);
+  esp_err_t ret = uart_driver_install(id, uart_buf_sz_cfg[id].rx_buf_sz, uart_buf_sz_cfg[id].tx_buf_sz, 3, & us->queue, 0);
   if(ret != ESP_OK) {
     return -1;
   }


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [n/a] The code changes are reflected in the documentation at `docs/*`.

This PR adds the ability to configure the UART buffer sizes via Kconfig. We've had a need for this feature a couple of times here at $work, so it seems worthwhile to PR it.

It also corrects an outdated assumption about the number of UARTs available in the system - some of the more recent models only have 2 UARTs instead of the original 3.