### PR TITLE
Add the invert option for the ledc module

### DIFF
--- a/components/modules/ledc.c
+++ b/components/modules/ledc.c
@@ -43,6 +43,8 @@ static int lledc_new_channel( lua_State *L )
 
   channel_config.gpio_num = opt_checkint_range(L, "gpio", -1, 0, GPIO_NUM_MAX-1);
 
+  channel_config.flags.output_invert = opt_checkbool(L, "invert", 0);
+
   lua_settop(L, top);
 
   esp_err_t timerErr = ledc_timer_config(&ledc_timer);

--- a/docs/modules/ledc.md
+++ b/docs/modules/ledc.md
@@ -22,6 +22,7 @@ myChannel = ledc.newChannel({
   timer=ledc.TIMER_0 || ledc.TIMER_1 || ledc.TIMER_2 || ledc.TIMER_3,
   channel=ledc.CHANNEL_0 || ledc.CHANNEL_1 || ledc.CHANNEL_2 || ledc.CHANNEL_3 || ledc.CHANNEL_4 || ledc.CHANNEL_5 || ledc.CHANNEL_6 || ledc.CHANNEL_7,
   frequency=x,
+  invert=false,
   duty=x
 });
 ```
@@ -46,6 +47,7 @@ List of configuration tables:
     - ...
     - `ledc.CHANNEL_7`
 - `frequency` Timer frequency(Hz)
+- `invert` Inverts the output. False, with duty 0, is always low.
 - `duty` Channel duty, the duty range is [0, (2**bit_num) - 1]. Example: if ledc.TIMER_13_BIT is used maximum value is 4096 x 2 -1 = 8091
 
 #### Returns


### PR DESCRIPTION


- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

The latest version of the IDF adds support to invert the output sense of the ledc channel. This is useful if you are driving an active low device (such as an LED connected to VCC)