### PR TITLE
Added missing attributes to lua wifi access point configuration table

### DIFF
--- a/components/modules/wifi_sta.c
+++ b/components/modules/wifi_sta.c
@@ -244,7 +244,23 @@ static int wifi_sta_config (lua_State *L)
     len = sizeof (cfg.sta.password);
   strncpy ((char *)cfg.sta.password, str, len);
 
-  lua_getfield (L, 1, "bssid");
+  lua_getfield(L, 1, "scan_mode");
+  int sm = luaL_optint(L, -1, WIFI_ALL_CHANNEL_SCAN);
+  cfg.sta.scan_method  = sm & WIFI_ALL_CHANNEL_SCAN;
+
+  lua_getfield(L, 1, "sort_method");
+  sm = luaL_optint(L, -1, WIFI_CONNECT_AP_BY_SECURITY);
+  cfg.sta.sort_method  = sm & WIFI_CONNECT_AP_BY_SECURITY;
+
+  lua_getfield(L, 1, "threshold_rssi");
+  const int rssi = luaL_optint(L, -1, -60);
+  cfg.sta.threshold.rssi  = rssi;
+
+  lua_getfield(L, 1, "threshold_authmode");
+  const int am = luaL_optint(L, -1, WIFI_AUTH_WPA2_PSK);
+  cfg.sta.threshold.authmode  = am > WIFI_AUTH_MAX ? WIFI_AUTH_WPA2_PSK : am;
+
+  lua_getfield(L, 1, "bssid");
   cfg.sta.bssid_set = false;
   if (lua_isstring (L, -1))
   {


### PR DESCRIPTION
Fixes #<GITHUB_ISSUE_NUMBER>.

_Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so._

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [ ] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

_To be completed below: Description of and rationale behind this PR._

wifi station mode not functional, after reviewing v4 idf example to establish wifi connection I noticed missing attributes in lua station mode configuration table.
