### PR TITLE
Ensure flash address is set before obtaining memory mapped address.

### DIFF
--- a/components/lua/common/lfs.c
+++ b/components/lua/common/lfs.c
@@ -31,8 +31,8 @@ bool lfs_get_location(lfs_location_info_t *out)
     return false; // Nothing to do if no LFS partition available
 
   out->size      = part->size; // in bytes
-  out->addr_mem  = spi_flash_phys2cache(out->addr_phys, SPI_FLASH_MMAP_DATA);
   out->addr_phys = part->address;
+  out->addr_mem  = spi_flash_phys2cache(out->addr_phys, SPI_FLASH_MMAP_DATA);
   if (!out->addr_mem) { // not already mmap'd, have to do it ourselves
     spi_flash_mmap_handle_t ignored;
     esp_err_t err = spi_flash_mmap(


### PR DESCRIPTION

- [X] This PR is for the `dev` branch rather than for the `release` branch.
- [X] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

Before this change the struck member add_phys would contain random data and the call to spi_flash_phys2cache
could return an incorrect memory address.
