### PR TITLE
Fix node.compile fwrite size check.

### DIFF
--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -603,7 +603,7 @@ static int writer(lua_State* L, const void* p, size_t size, void* u)
   if (!file)
     return 1;
 
-  if (size != 0 && (size != fwrite((const char *)p, size, 1, file)) )
+  if (size != 0 && (fwrite((const char *)p, size, 1, file) != 1) )
     return 1;
 
   return 0;


### PR DESCRIPTION

- [X] This PR is for the `dev` branch rather than for the `release` branch.
- [X] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

The return value from fwrite was being checked against the size of the data rather than the number of bytes written.
This caused node.compile() to falsely return failure.