### PR TITLE
Explicitly set RMT config::flags.

### DIFF
--- a/components/platform/dht.c
+++ b/components/platform/dht.c
@@ -86,6 +86,7 @@ static int dht_init( uint8_t gpio_num )
     rmt_rx.channel = dht_rmt.channel;
     rmt_rx.gpio_num = gpio_num;
     rmt_rx.clk_div = 80;  // base period is 1us
+    rmt_rx.flags = 0;
     rmt_rx.mem_block_num = 1;
     rmt_rx.rmt_mode = RMT_MODE_RX;
     rmt_rx.rx_config.filter_en = true;

--- a/components/platform/onewire.c
+++ b/components/platform/onewire.c
@@ -126,6 +126,7 @@ static int onewire_rmt_init( uint8_t gpio_num )
       rmt_tx.gpio_num = gpio_num;
       rmt_tx.mem_block_num = 1;
       rmt_tx.clk_div = 80;
+      rmt_tx.flags = 0;
       rmt_tx.tx_config.loop_en = false;
       rmt_tx.tx_config.carrier_en = false;
       rmt_tx.tx_config.idle_level = 1;
@@ -138,6 +139,7 @@ static int onewire_rmt_init( uint8_t gpio_num )
           rmt_rx.channel = ow_rmt.rx;
           rmt_rx.gpio_num = gpio_num;
           rmt_rx.clk_div = 80;
+          rmt_rx.flags = 0;
           rmt_rx.mem_block_num = 1;
           rmt_rx.rmt_mode = RMT_MODE_RX;
           rmt_rx.rx_config.filter_en = true;

--- a/components/platform/ws2812.c
+++ b/components/platform/ws2812.c
@@ -187,6 +187,7 @@ int platform_ws2812_send( void )
   // common settings
   rmt_tx.mem_block_num = 1;
   rmt_tx.clk_div = WS2812_CLKDIV;
+  rmt_tx.flags = 0;
   rmt_tx.tx_config.loop_en = false;
   rmt_tx.tx_config.carrier_en = false;
   rmt_tx.tx_config.idle_level = 0;


### PR DESCRIPTION

- [X] This PR is for the `dev` branch rather than for the `release` branch.
- [X] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.


If this variable is not set in the config it may contain random data and set the clock source to the REF_CLK
resulting in timing errors, the DHTx, DS18B20 and ws2812 devices to not communicate.
