### PR TITLE
Support sending strings with multi-byte-wide SPI

### DIFF
--- a/app/modules/spi.c
+++ b/app/modules/spi.c
@@ -140,13 +140,21 @@ static int spi_send_recv( lua_State *L )
     else
     {
       luaL_Buffer b;
+      size_t datachars = spi_databits[id] / 8;
 
+      if (spi_databits[id] % 8 != 0) {
+        return luaL_error( L, "attempt to send string with non-character-divisible databits" );
+      }
+      if (datalen % datachars != 0) {
+        return luaL_error( L, "attempt to send string with non-databits-divisible length" );
+      }
+	    
       pdata = luaL_checklstring( L, argn, &datalen );
       if (recv > 0) {
         luaL_buffinit( L, &b );
       }
 
-      for( i = 0; i < datalen; i ++ )
+      for( i = 0; i < datalen; i += datachars )
       {
         if (recv > 0)
         {


### PR DESCRIPTION
The iteration in the loop in the prior version of spi.send assumes that the value of databits is the width of  `char` when sending any string value.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I haven't thoroughly tested my contribution - it's a simple enough change that, if it compiles and passes existing tests, it works (it only fixes behavior that was previously broken).
- [x] The code changes are reflected in the documentation at `docs/*`. (This only fixes the function to more closely match the expected documented behavior.)

