### PR TITLE
Add support for the USB CDC Serial JTAG console

### DIFF
--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -148,16 +148,18 @@ static int node_bootreason( lua_State *L)
 // Lua: node.chipid()
 static int node_chipid( lua_State *L )
 {
-#ifdef EFUSE_BLK0_DATA1_REG
+#ifdef EFUSE_BLK0_RDATA1_REG
   // This matches the way esptool.py generates a chipid for the ESP32 as of
   // esptool commit e9e9179f6fc3f2ecfc568987d3224b5e53a05f06
   // Oddly, this drops the lowest byte what's effectively the MAC address, so
   // it would seem plausible to encounter up to 256 chips with the same chipid
-  uint64_t word16 = REG_READ(EFUSE_BLK0_DATA1_REG);
-  uint64_t word17 = REG_READ(EFUSE_BLK0_DATA2_REG);
+  uint64_t word16 = REG_READ(EFUSE_BLK0_RDATA1_REG);
+  uint64_t word17 = REG_READ(EFUSE_BLK0_RDATA2_REG);
   const uint64_t MAX_UINT24 = 0xffffff;
   uint64_t cid = ((word17 & MAX_UINT24) << 24) | ((word16 >> 8) & MAX_UINT24);
 #else
+  // This makes the chipid the same as the mac on parts which don't have the 
+  // EFUSE layout defined.
   uint8_t mac[8];
   esp_read_mac(mac, ESP_MAC_WIFI_STA);
   uint64_t cid = ((uint64_t) mac[0] << 40) | ((uint64_t) mac[1] << 32) | (mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | mac[5];

--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -145,24 +145,28 @@ static int node_bootreason( lua_State *L)
   return 2;
 }
 
-#if defined(CONFIG_IDF_TARGET_ESP32)
 // Lua: node.chipid()
 static int node_chipid( lua_State *L )
 {
+#ifdef EFUSE_BLK0_DATA1_REG
   // This matches the way esptool.py generates a chipid for the ESP32 as of
   // esptool commit e9e9179f6fc3f2ecfc568987d3224b5e53a05f06
   // Oddly, this drops the lowest byte what's effectively the MAC address, so
   // it would seem plausible to encounter up to 256 chips with the same chipid
-  uint64_t word16 = REG_READ(EFUSE_BLK0_RDATA1_REG);
-  uint64_t word17 = REG_READ(EFUSE_BLK0_RDATA2_REG);
+  uint64_t word16 = REG_READ(EFUSE_BLK0_DATA1_REG);
+  uint64_t word17 = REG_READ(EFUSE_BLK0_DATA2_REG);
   const uint64_t MAX_UINT24 = 0xffffff;
   uint64_t cid = ((word17 & MAX_UINT24) << 24) | ((word16 >> 8) & MAX_UINT24);
+#else
+  uint8_t mac[8];
+  esp_read_mac(mac, ESP_MAC_WIFI_STA);
+  uint64_t cid = ((uint64_t) mac[0] << 40) | ((uint64_t) mac[1] << 32) | (mac[2] << 24) | (mac[3] << 16) | (mac[4] << 8) | mac[5];
+#endif
   char chipid[17] = { 0 };
   sprintf(chipid, "0x%llx", cid);
   lua_pushstring(L, chipid);
   return 1;
 }
-#endif
 
 // Lua: node.heap()
 static int node_heap( lua_State* L )
@@ -850,9 +854,7 @@ LROT_END(node_wakeup, NULL, 0)
 
 LROT_BEGIN(node, NULL, 0)
   LROT_FUNCENTRY( bootreason, node_bootreason )
-#if defined(CONFIG_IDF_TARGET_ESP32)
   LROT_FUNCENTRY( chipid,     node_chipid )
-#endif
   LROT_FUNCENTRY( compile,    node_compile )
   LROT_FUNCENTRY( dsleep,     node_dsleep )
 #if defined(CONFIG_LUA_VERSION_51)

--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -189,11 +189,6 @@ static void task_usbcdc(void *pvParameters) {
     int len = usb_serial_jtag_read_bytes(post->data, 64, portMAX_DELAY);
 
     if (len > 0) {
-      for (int i = 0; i < len; i++) {
-        if (post->data[i] == '\r') {
-          post->data[i] = '\n';
-        }
-      }
       post->size = len;
       xSemaphoreTake(usbcdc_sem, portMAX_DELAY);
       if (!task_post_medium(usbcdc_event_task_id, (task_param_t)post))
@@ -419,7 +414,7 @@ int platform_uart_start( unsigned id )
       /* Disable buffering on stdin */
       setvbuf(stdin, NULL, _IONBF, 0);
 
-      /* Minicom, screen, idf_monitor send CR when ENTER key is pressed */
+      /* Minicom, screen, idf_monitor, esplorer send CR when ENTER key is pressed */
       esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
       /* Move the caret to the beginning of the next line on '\n' */
       esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);

--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -434,18 +434,19 @@ int platform_uart_start( unsigned id )
 
       /* Tell vfs to use usb-serial-jtag driver */
       esp_vfs_usb_serial_jtag_use_driver();
-    }
-    usbcdc_status.line_buffer = malloc(LUA_MAXINPUT);
-    usbcdc_status.line_position = 0;
-    if(usbcdc_status.line_buffer == NULL) {
-      return -1;
-    }
 
-    const char *pcName = "usbcdc";
-    if(xTaskCreate(task_usbcdc, pcName, 4096, (void*)id, ESP_TASK_MAIN_PRIO + 1, &usbcdc_status.taskHandle) != pdPASS) {
-      free(usbcdc_status.line_buffer);
-      usbcdc_status.line_buffer = NULL;
-      return -1;
+      usbcdc_status.line_buffer = malloc(LUA_MAXINPUT);
+      usbcdc_status.line_position = 0;
+      if(usbcdc_status.line_buffer == NULL) {
+        return -1;
+      }
+
+      const char *pcName = "usbcdc";
+      if(xTaskCreate(task_usbcdc, pcName, 4096, (void*)id, ESP_TASK_MAIN_PRIO + 1, &usbcdc_status.taskHandle) != pdPASS) {
+        free(usbcdc_status.line_buffer);
+        usbcdc_status.line_buffer = NULL;
+        return -1;
+      }
     }
     return 0;
   }

--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -12,6 +12,14 @@
 #include "task/task.h"
 #include "linput.h"
 
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#include "driver/usb_serial_jtag.h"
+#include "esp_vfs_usb_serial_jtag.h"
+#include "esp_vfs_dev.h"
+#include <fcntl.h>
+#include <errno.h>
+#endif
+
 int platform_init (void)
 {
   platform_ws2812_init();
@@ -33,6 +41,16 @@ int platform_gpio_output_exists( unsigned gpio ) { return GPIO_IS_VALID_OUTPUT_G
 #define PLATFORM_UART_EVENT_OOM      (UART_EVENT_MAX + 2)
 #define PLATFORM_UART_EVENT_RX       (UART_EVENT_MAX + 3)
 #define PLATFORM_UART_EVENT_BREAK    (UART_EVENT_MAX + 4)
+
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+#define ADJUST_IDR(id,retval)   if (id-- == 0) return retval
+#define ADJUST_ID(id)   if (id-- == 0) return
+#define UNADJUST_ID(id)   id++
+#else
+#define ADJUST_IDR(id, retval)
+#define ADJUST_ID(id)
+#define UNADJUST_ID(id)
+#endif
 
 typedef struct {
   unsigned rx_buf_sz;
@@ -65,59 +83,124 @@ uart_status_t uart_status[NUM_UART];
 task_handle_t uart_event_task_id = 0;
 SemaphoreHandle_t sem = NULL;
 
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+task_handle_t usbcdc_event_task_id = 0;
+static uart_status_t usbcdc_status;
+SemaphoreHandle_t usbcdc_sem = NULL;
+#endif
+
 extern bool uart_on_data_cb(unsigned id, const char *buf, size_t len);
 extern bool uart_on_error_cb(unsigned id, const char *buf, size_t len);
 
-void uart_event_task( task_param_t param, task_prio_t prio ) {
+static void handle_uart_data(unsigned int id, uart_event_post_t *post, uart_status_t *us) {
+  size_t i = 0;
+  while (i < post->size) {
+    if (id == CONFIG_ESP_CONSOLE_UART_NUM && run_input) {
+      unsigned used = feed_lua_input(post->data + i, post->size - i);
+      i += used;
+    } else {
+      char ch = post->data[i];
+      us->line_buffer[us->line_position] = ch;
+      us->line_position++;
+
+      uint16_t need_len = us->need_len;
+      int16_t end_char = us->end_char;
+      size_t max_wanted =
+        (end_char >= 0 && need_len == 0) ? LUA_MAXINPUT : need_len;
+      bool at_end = (us->line_position >= max_wanted);
+      bool end_char_found =
+        (end_char >= 0 && (uint8_t)ch == (uint8_t)end_char);
+      if (at_end || end_char_found) {
+        uart_on_data_cb(id, us->line_buffer, us->line_position);
+        us->line_position = 0;
+      }
+      ++i;
+    }
+  }
+}
+
+void uart_event_task(task_param_t param, task_prio_t prio)
+{
   uart_event_post_t *post = (uart_event_post_t *)param;
   unsigned id = post->id;
   uart_status_t *us = &uart_status[id];
+  UNADJUST_ID(id);
   xSemaphoreGive(sem);
-  if(post->type == PLATFORM_UART_EVENT_DATA) {
-    size_t i = 0;
-    while (i < post->size)
-    {
-      if (id == CONFIG_ESP_CONSOLE_UART_NUM && run_input) {
-        unsigned used = feed_lua_input(post->data + i, post->size - i);
-        i += used;
-      }
-      else {
-        char ch = post->data[i];
-        us->line_buffer[us->line_position] = ch;
-        us->line_position++;
-
-        uint16_t need_len = us->need_len;
-        int16_t end_char = us->end_char;
-        size_t max_wanted =
-          (end_char >= 0 && need_len == 0) ? LUA_MAXINPUT : need_len;
-        bool at_end = (us->line_position >= max_wanted);
-        bool end_char_found =
-          (end_char >= 0 && (uint8_t)ch == (uint8_t)end_char);
-        if (at_end || end_char_found) {
-          uart_on_data_cb(id, us->line_buffer, us->line_position);
-          us->line_position = 0;
-        }
-        ++i;
-      }
-    }
+  if (post->type == PLATFORM_UART_EVENT_DATA)
+  {
+    handle_uart_data(id, post, us);
     free(post->data);
-  } else {
+  }
+  else
+  {
     const char *err;
-    switch(post->type) {
-      case PLATFORM_UART_EVENT_OOM:
-        err = "out_of_memory";
-        break;
-      case PLATFORM_UART_EVENT_BREAK:
-        err = "break";
-        break;
-      case PLATFORM_UART_EVENT_RX:
-      default:
-        err = "rx_error";
+    switch (post->type)
+    {
+    case PLATFORM_UART_EVENT_OOM:
+      err = "out_of_memory";
+      break;
+    case PLATFORM_UART_EVENT_BREAK:
+      err = "break";
+      break;
+    case PLATFORM_UART_EVENT_RX:
+    default:
+      err = "rx_error";
     }
     uart_on_error_cb(id, err, strlen(err));
   }
   free(post);
 }
+
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+void usbcdc_event_task(task_param_t param, task_prio_t prio)
+{
+  uart_event_post_t *post = (uart_event_post_t *)param;
+  xSemaphoreGive(usbcdc_sem);
+  handle_uart_data(0, post, &usbcdc_status);
+  free(post);
+}
+
+static void task_usbcdc(void *pvParameters) {
+  // 4 chosen as a number smaller than the number of nodemcu task slots
+  // available, to make it unlikely we encounter a task_post failing
+  if (usbcdc_sem == NULL)
+    usbcdc_sem = xSemaphoreCreateCounting(4, 4);
+
+  uart_event_post_t *post = NULL;
+
+  for (;;) {
+    if (post == NULL) {
+      post = (uart_event_post_t *)malloc(sizeof(uart_event_post_t) + 64 * sizeof(char));
+      if (post == NULL) {
+        ESP_LOGE(UART_TAG, "Can not alloc memory in task_usbcdc()");
+        // reboot here?
+        continue;
+      }
+      post->data = (void *)(post + 1);
+      post->type = PLATFORM_UART_EVENT_DATA;
+    }
+
+    int len = usb_serial_jtag_read_bytes(post->data, 64, portMAX_DELAY);
+
+    if (len > 0) {
+      for (int i = 0; i < len; i++) {
+        if (post->data[i] == '\r') {
+          post->data[i] = '\n';
+        }
+      }
+      post->size = len;
+      xSemaphoreTake(usbcdc_sem, portMAX_DELAY);
+      if (!task_post_medium(usbcdc_event_task_id, (task_param_t)post))
+      {
+        ESP_LOGE(UART_TAG, "Task event overrun in task_usbcdc()");
+        xSemaphoreGive(usbcdc_sem);
+      } else {
+        post = NULL;
+      }
+    }
+  }
+}
+#endif
 
 static void task_uart( void *pvParameters ){
   unsigned id = (unsigned)pvParameters;
@@ -207,6 +290,7 @@ static void task_uart( void *pvParameters ){
 // pins must not be null for non-console uart
 uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int parity, int stopbits, uart_pins_t* pins )
 {
+  ADJUST_IDR(id, baud);
   int flow_control = UART_HW_FLOWCTRL_DISABLE;
   if(pins->flow_control & PLATFORM_UART_FLOW_CTS) flow_control |= UART_HW_FLOWCTRL_CTS;
   if(pins->flow_control & PLATFORM_UART_FLOW_RTS) flow_control |= UART_HW_FLOWCTRL_RTS;
@@ -258,23 +342,25 @@ uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int pari
 
 void platform_uart_setmode(unsigned id, unsigned mode)
 {
-	uart_mode_t uartMode;
-	
-	switch(mode)
-	{
-		case PLATFORM_UART_MODE_IRDA:
-			uartMode = UART_MODE_IRDA; break;
-		case PLATFORM_UART_MODE_RS485_COLLISION_DETECT:
-			uartMode = UART_MODE_RS485_COLLISION_DETECT; break;
-		case PLATFORM_UART_MODE_RS485_APP_CONTROL:
-			uartMode = UART_MODE_RS485_APP_CTRL; break;
-		case PLATFORM_UART_MODE_HALF_DUPLEX:
-			uartMode = UART_MODE_RS485_HALF_DUPLEX; break;
-		case PLATFORM_UART_MODE_UART:
-		default:
-			uartMode = UART_MODE_UART; break;
-	}
-	uart_set_mode(id, uartMode);
+  uart_mode_t uartMode;
+
+  ADJUST_IDR(id,);
+  
+  switch(mode)
+  {
+    case PLATFORM_UART_MODE_IRDA:
+      uartMode = UART_MODE_IRDA; break;
+    case PLATFORM_UART_MODE_RS485_COLLISION_DETECT:
+      uartMode = UART_MODE_RS485_COLLISION_DETECT; break;
+    case PLATFORM_UART_MODE_RS485_APP_CONTROL:
+      uartMode = UART_MODE_RS485_APP_CTRL; break;
+    case PLATFORM_UART_MODE_HALF_DUPLEX:
+      uartMode = UART_MODE_RS485_HALF_DUPLEX; break;
+    case PLATFORM_UART_MODE_UART:
+    default:
+      uartMode = UART_MODE_UART; break;
+  }
+  uart_set_mode(id, uartMode);
 }
 
 void platform_uart_send_multi( unsigned id, const char *data, size_t len )
@@ -285,6 +371,7 @@ void platform_uart_send_multi( unsigned id, const char *data, size_t len )
         putchar (data[ i ]);
     }
   } else {
+    ADJUST_ID(id);
     uart_write_bytes(id, data, len);
   }
 }
@@ -293,16 +380,20 @@ void platform_uart_send( unsigned id, uint8_t data )
 {
   if (id == CONFIG_ESP_CONSOLE_UART_NUM)
     putchar (data);
-  else
+  else {
+    ADJUST_ID(id);
     uart_write_bytes(id, (const char *)&data, 1);
+  }
 }
 
 void platform_uart_flush( unsigned id )
 {
   if (id == CONFIG_ESP_CONSOLE_UART_NUM)
     fflush (stdout);
-  else
+  else {
+    ADJUST_ID(id);
     uart_tx_flush(id);
+  }
 }
 
 
@@ -310,6 +401,57 @@ int platform_uart_start( unsigned id )
 {
   if(uart_event_task_id == 0)
     uart_event_task_id = task_get_id( uart_event_task );
+
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+  if (id == 0) {
+    if (usbcdc_event_task_id == 0) {
+      usbcdc_event_task_id = task_get_id(usbcdc_event_task);
+
+
+      /* Disable buffering on stdin */
+      setvbuf(stdin, NULL, _IONBF, 0);
+
+      /* Minicom, screen, idf_monitor send CR when ENTER key is pressed */
+      esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
+      /* Move the caret to the beginning of the next line on '\n' */
+      esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+
+      /* Enable blocking mode on stdin and stdout */
+      fcntl(fileno(stdout), F_SETFL, 0);
+      fcntl(fileno(stdin), F_SETFL, 0);
+
+      usb_serial_jtag_driver_config_t usb_serial_jtag_config;
+      usb_serial_jtag_config.rx_buffer_size = 1024;
+      usb_serial_jtag_config.tx_buffer_size = 1024;
+
+      esp_err_t ret = ESP_OK;
+      /* Install USB-SERIAL-JTAG driver for interrupt-driven reads and writes */
+      ret = usb_serial_jtag_driver_install(&usb_serial_jtag_config);
+      if (ret != ESP_OK)
+      {
+        return -1;
+      }
+
+      /* Tell vfs to use usb-serial-jtag driver */
+      esp_vfs_usb_serial_jtag_use_driver();
+    }
+    usbcdc_status.line_buffer = malloc(LUA_MAXINPUT);
+    usbcdc_status.line_position = 0;
+    if(usbcdc_status.line_buffer == NULL) {
+      return -1;
+    }
+
+    const char *pcName = "usbcdc";
+    if(xTaskCreate(task_usbcdc, pcName, 4096, (void*)id, ESP_TASK_MAIN_PRIO + 1, &usbcdc_status.taskHandle) != pdPASS) {
+      free(usbcdc_status.line_buffer);
+      usbcdc_status.line_buffer = NULL;
+      return -1;
+    }
+    return 0;
+  }
+#endif
+
+  ADJUST_IDR(id, -1);
 
   uart_status_t *us = & uart_status[id];
 
@@ -342,6 +484,7 @@ void platform_uart_stop( unsigned id )
   if (id == CONFIG_ESP_CONSOLE_UART_NUM)
     ;
   else {
+    ADJUST_IDR(id,);
     uart_status_t *us = & uart_status[id];  
     uart_driver_delete(id);
     if(us->line_buffer) free(us->line_buffer);
@@ -353,6 +496,19 @@ void platform_uart_stop( unsigned id )
 
 int platform_uart_get_config(unsigned id, uint32_t *baudp, uint32_t *databitsp, uint32_t *parityp, uint32_t *stopbitsp) {
     int err;
+
+#if CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
+    if (id == 0) {
+      // Return dummy values
+      *baudp = 115200;
+      *databitsp = 8;
+      *parityp = PLATFORM_UART_PARITY_NONE;
+      *stopbitsp = PLATFORM_UART_STOPBITS_1;
+      return 0;
+    }
+#endif
+
+    ADJUST_IDR(id, -1);
 
     err = uart_get_baudrate(id, baudp);
     if (err != ESP_OK) return -1;
@@ -403,6 +559,7 @@ int platform_uart_get_config(unsigned id, uint32_t *baudp, uint32_t *databitsp, 
 
 int platform_uart_set_wakeup_threshold(unsigned id, unsigned threshold)
 {
+  ADJUST_IDR(id, 0);
   esp_err_t err = uart_set_wakeup_threshold(id, threshold);
   return (err == ESP_OK) ? 0 : -1;
 }


### PR DESCRIPTION
Fixes #3526.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

If the USB CDC console is configured, then it appears as the default console for the Lua REPL. It also appears as UART 0 and bumps the other uart(s) down one. The baud rate cannot be configured as there is no actual serial line.

When configured this way, stdin and stdout are connected to this device. Unfortunately, async reading is not possible at the moment. Thus the input side is handled by doing blocking reads in a seperate thread, and then posting the data into the Lua environment. Happily this is very similar to how the uart code works.

