### PR TITLE
uart: feed rx data to both lua console and on-data callback

### DIFF
--- a/components/modules/uart.c
+++ b/components/modules/uart.c
@@ -10,6 +10,10 @@
 
 static lua_State *gL = NULL;
 
+bool uart_has_on_data_cb(unsigned id){
+  return uart_status[id].receive_rf != LUA_NOREF;
+}
+
 bool uart_on_data_cb(unsigned id, const char *buf, size_t len){
   if(!buf || len==0)
     return false;

--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -65,6 +65,7 @@ uart_status_t uart_status[NUM_UART];
 task_handle_t uart_event_task_id = 0;
 SemaphoreHandle_t sem = NULL;
 
+extern bool uart_has_on_data_cb(unsigned id);
 extern bool uart_on_data_cb(unsigned id, const char *buf, size_t len);
 extern bool uart_on_error_cb(unsigned id, const char *buf, size_t len);
 
@@ -81,7 +82,7 @@ void uart_event_task( task_param_t param, task_prio_t prio ) {
         unsigned used = feed_lua_input(post->data + i, post->size - i);
         i += used;
       }
-      else {
+      if (uart_has_on_data_cb(id)) {
         char ch = post->data[i];
         us->line_buffer[us->line_position] = ch;
         us->line_position++;


### PR DESCRIPTION
UART on-data example usage with `run_input` set to 1:
```
uart.on(0, "data", 0,
  function(data)
    print("receive from uart:", data)
end, 1)
```

According to documentation for `run_input`:
>If 1, input from UART will go into Lua interpreter, **_and_** run.

Currently, UART data either go into Lua interpreter **_or_** on-data callback. This PR fixes that.