### PR TITLE
Slight clean up of uart.setup code

### DIFF
--- a/components/modules/uart.c
+++ b/components/modules/uart.c
@@ -140,12 +140,10 @@ static int uart_setup( lua_State* L )
   databits = luaL_checkinteger( L, 3 );
   parity = luaL_checkinteger( L, 4 );
   stopbits = luaL_checkinteger( L, 5 );
-  if(id == CONFIG_ESP_CONSOLE_UART_NUM){
-    if (!lua_isnoneornil(L, 6)) {
+  if (!lua_isnoneornil(L, 6)) {
+    if(id == CONFIG_ESP_CONSOLE_UART_NUM){
       input_echo = luaL_checkinteger(L, 6) > 0;
-    }
-  } else {
-    if (!lua_isnoneornil(L, 6)) {
+    } else {
       luaL_checktable(L, 6);
 
       lua_getfield (L, 6, "tx");

--- a/components/modules/uart.c
+++ b/components/modules/uart.c
@@ -131,7 +131,9 @@ static int uart_setup( lua_State* L )
   unsigned id, databits, parity, stopbits, echo = 1;
   uint32_t baud, res;
   uart_pins_t pins;
+  uart_pins_t* pins_to_use = NULL;
   
+  memset(&pins, 0, sizeof(pins));
   id = luaL_checkinteger( L, 1 );
   MOD_CHECK_ID( uart, id );
   baud = luaL_checkinteger( L, 2 );
@@ -165,9 +167,11 @@ static int uart_setup( lua_State* L )
       
       lua_getfield (L, 6, "flow_control");
       pins.flow_control = luaL_optint(L, -1, PLATFORM_UART_FLOW_NONE);
+
+      pins_to_use = &pins;
   }
 
-  res = platform_uart_setup( id, baud, databits, parity, stopbits, &pins );
+  res = platform_uart_setup( id, baud, databits, parity, stopbits, pins_to_use );
   lua_pushinteger( L, res );
   return 1;
 }


### PR DESCRIPTION
The current code is a little confusing to read and doesn't return error when given an invalid input.
There are 2 code paths here:
1. uart port is our console. In this case, we accept an optional `echo` parameter. If `echo` is not provided, we leave the existing `input_echo` flag unchanged.
2. uart port is **_NOT_** our console. We accept an optional `pins config table` parameter.

This PR cleans up the code a bit to make it clearer.

This PR makes changes on top of PR #3540

@jmattsson Please review.