### PR TITLE
Ported the rtcmem over to ESP32

### DIFF
--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -23,6 +23,7 @@ set(module_srcs
   "otaupgrade.c"
   "ow.c"
   "pipe.c"
+  "rtcmem.c"
   "qrcodegen.c"
   "sigma_delta.c"
   "sjson.c"

--- a/components/modules/Kconfig
+++ b/components/modules/Kconfig
@@ -226,7 +226,7 @@ menu "NodeMCU modules"
             remote control hardware.
 
     config NODEMCU_CMODULE_RTCMEM
-        bool "Access to a limited amount of battery backed memory"
+        bool "Access to a limited amount of battery backed memory (rtcmem)"
         default "n"
         help
             Includes the rtcmem module to allow access to 

--- a/components/modules/Kconfig
+++ b/components/modules/Kconfig
@@ -225,6 +225,13 @@ menu "NodeMCU modules"
             Includes the rmt module to use the ESP32's built-in 
             remote control hardware.
 
+    config NODEMCU_CMODULE_RTCMEM
+        bool "Access to a limited amount of battery backed memory"
+        default "n"
+        help
+            Includes the rtcmem module to allow access to 
+            the battery backed memory.
+
     config NODEMCU_CMODULE_SDMMC
         depends on IDF_TARGET_ESP32
         bool "SD-MMC module"

--- a/components/modules/rtcmem.c
+++ b/components/modules/rtcmem.c
@@ -1,0 +1,52 @@
+// Module for RTC user memory access
+
+#include "module.h"
+#include "lauxlib.h"
+#include "esp_attr.h"
+
+#define RTC_USER_MEM_NUM_DWORDS 128
+
+RTC_NOINIT_ATTR uint32_t rtc_memory[RTC_USER_MEM_NUM_DWORDS];
+
+static int rtcmem_read32 (lua_State *L)
+{
+  int idx = luaL_checkinteger (L, 1);
+  int n = (lua_gettop(L) < 2) ? 1 : lua_tointeger (L, 2);
+  if (n == 0 || !lua_checkstack (L, n)) {
+        return 0;
+  }
+
+  int ret  = 0;
+  while (n > 0 && idx >= 0 && idx < RTC_USER_MEM_NUM_DWORDS)
+  {
+    lua_pushinteger (L, rtc_memory[idx++]);
+    --n;
+    ++ret;
+  }
+  return ret;
+}
+
+
+static int rtcmem_write32 (lua_State *L)
+{
+  int idx = luaL_checkinteger (L, 1);
+  int n = lua_gettop (L) - 1;
+  luaL_argcheck (
+    L, idx + n <= RTC_USER_MEM_NUM_DWORDS, 1, "RTC mem would overrun");
+  int src = 2;
+  while (n-- > 0)
+  {
+    rtc_memory[idx++] = (uint32_t) lua_tointeger(L, src++);
+  }
+  return 0;
+}
+
+
+// Module function map
+LROT_BEGIN(rtcmem, NULL, 0)
+  LROT_FUNCENTRY( read32, rtcmem_read32 )
+  LROT_FUNCENTRY( write32, rtcmem_write32 )
+LROT_END(rtcmem, NULL, 0)
+
+
+NODEMCU_MODULE(RTCMEM, "rtcmem", rtcmem, NULL);

--- a/docs/modules/rtcmem.md
+++ b/docs/modules/rtcmem.md
@@ -1,0 +1,64 @@
+# RTC User Memory Module
+| Since  | Origin / Contributor  | Maintainer  | Source  |
+| :----- | :-------------------- | :---------- | :------ |
+| 2015-06-25 | [DiUS](https://github.com/DiUS), [Johny Mattsson](https://github.com/jmattsson) | [Johny Mattsson](https://github.com/jmattsson) | [rtcmem.c](../../app/modules/rtcmem.c)|
+
+The rtcmem module provides basic access to the battery backed memory.
+
+This memory is preserved while power is applied, making them highly useful for keeping state across sleep cycles. Some of this memory is reserved for system use, but 128 slots (each 32bit wide) are available for application use. This module provides read and write access to these.
+
+Due to the very limited amount of memory available, there is no mechanism for arbitrating use of particular slots. It is up to the end user to be aware of which memory is used for what, and avoid conflicts. Note that some Lua modules lay claim to certain slots.
+
+Note that this memory is not necessary preserved across reflashing the firmware. It is the responsibility of the
+developer to deal with getting inconsistent data.
+
+## rtcmem.read32()
+
+Reads one or more 32bit values from RTC user memory.
+
+#### Syntax
+`rtcmem.read32(idx [, num])`
+
+#### Parameters
+  - `idx` zero-based index to start reading from
+  - `num` number of slots to read (default 1)
+
+#### Returns
+The value(s) read from RTC user memory.
+
+If `idx` is outside the valid range [0,127] this function returns nothing.
+
+If `num` results in overstepping the end of available memory, the function only returns the data from the valid slots.
+
+#### Example
+```lua
+val = rtcmem.read32(0) -- Read the value in slot 0
+val1, val2 = rtcmem.read32(42, 2) -- Read the values in slots 42 and 43
+```
+#### See also
+[`rtcmem.write32()`](#rtcmemwrite32)
+
+## rtcmem.write32()
+
+Writes one or more values to RTC user memory, starting at index `idx`.
+
+Writing to indices outside the valid range [0,127] has no effect.
+
+#### Syntax
+`rtcmem.write32(idx, val [, val2, ...])`
+
+#### Parameters
+  - `idx` zero-based index to start writing to. Auto-increments if multiple values are given.
+  - `val` value to store (32bit)
+  - `val2...` additional values to store (optional)
+
+#### Returns
+`nil`
+
+#### Example
+```lua
+rtcmem.write32(0, 53) -- Store the value 53 in slot 0
+rtcmem.write32(42, 2, 5, 7) -- Store the values 2, 5 and 7 into slots 42, 43 and 44, respectively.
+```
+#### See also
+[`rtcmem.read32()`](#rtcmemread32)

--- a/docs/modules/rtcmem.md
+++ b/docs/modules/rtcmem.md
@@ -1,13 +1,15 @@
 # RTC User Memory Module
 | Since  | Origin / Contributor  | Maintainer  | Source  |
 | :----- | :-------------------- | :---------- | :------ |
-| 2015-06-25 | [DiUS](https://github.com/DiUS), [Johny Mattsson](https://github.com/jmattsson) | [Johny Mattsson](https://github.com/jmattsson) | [rtcmem.c](../../app/modules/rtcmem.c)|
+| 2015-06-25 | [DiUS](https://github.com/DiUS), [Johny Mattsson](https://github.com/jmattsson) | [PJSG](https://github.com/pjsg) | [rtcmem.c](../../app/modules/rtcmem.c)|
 
-The rtcmem module provides basic access to the battery backed memory.
+The rtcmem module provides basic access to the RTC memory. 
 
-This memory is preserved while power is applied, making them highly useful for keeping state across sleep cycles. Some of this memory is reserved for system use, but 128 slots (each 32bit wide) are available for application use. This module provides read and write access to these.
+This memory is preserved while power is applied, making them highly useful for keeping state across sleep cycles. Some of this memory is reserved for system use, 
+and, for compatibility with NodeMCU on the ESP8266, 128 slots (each 32bit wide) of RTC memory are reserved by this module.
+This module then provides read and write access to these slots.
 
-Due to the very limited amount of memory available, there is no mechanism for arbitrating use of particular slots. It is up to the end user to be aware of which memory is used for what, and avoid conflicts. Note that some Lua modules lay claim to certain slots.
+This module is 100% compatible with the ESP8266 version, and this means that, there is no mechanism for arbitrating use of particular slots. It is up to the end user to be aware of which memory is used for what, and avoid conflicts. Unlike the ESP8266 version, no other NodeMCU module uses any of these slots.
 
 Note that this memory is not necessary preserved across reflashing the firmware. It is the responsibility of the
 developer to deal with getting inconsistent data.


### PR DESCRIPTION
Fixes #3543.



- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This is a pretty simple port of the existing code. The only difference is that the ESP32 memory is memory mapped.
