### PR TITLE
platform uart: really feed uart data to both console and on-data cb

### DIFF
--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -75,14 +75,18 @@ void uart_event_task( task_param_t param, task_prio_t prio ) {
   uart_status_t *us = &uart_status[id];
   xSemaphoreGive(sem);
   if(post->type == PLATFORM_UART_EVENT_DATA) {
-    size_t i = 0;
-    while (i < post->size)
-    {
-      if (id == CONFIG_ESP_CONSOLE_UART_NUM && run_input) {
+    if (id == CONFIG_ESP_CONSOLE_UART_NUM && run_input) {
+      size_t i = 0;
+      while (i < post->size)
+      {
         unsigned used = feed_lua_input(post->data + i, post->size - i);
         i += used;
       }
-      if (uart_has_on_data_cb(id)) {
+    }
+    if (uart_has_on_data_cb(id)) {
+      size_t i = 0;
+      while (i < post->size)
+      {
         char ch = post->data[i];
         us->line_buffer[us->line_position] = ch;
         us->line_position++;


### PR DESCRIPTION
I made a mistake yesterday on the PR #3538 where first byte of uart data is fed to the LUA console and 2nd byte to the on-data callback.
It should have been feeding all bytes to both LUA console and on-data callback.

Sorry my bad.

This PR loops all the uart bytes for the console first, then loops all the uart bytes again for the on-data callback.

@jmattsson Please review.
