### PR TITLE
Add the RMT device to the ESP32-C3

### DIFF
--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -59,13 +59,11 @@ if(IDF_TARGET STREQUAL "esp32")
 elseif(IDF_TARGET STREQUAL "esp32s2")
   list(APPEND module_srcs
     "dac.c"
-    "touch.c"
     "rmt.c"
     "pulsecnt.c"
   )
 elseif(IDF_TARGET STREQUAL "esp32s3")
   list(APPEND module_srcs
-    "touch.c"
     "rmt.c"
     "pulsecnt.c"
     "sdmmc.c"

--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -66,7 +66,6 @@ elseif(IDF_TARGET STREQUAL "esp32s3")
   list(APPEND module_srcs
     "rmt.c"
     "pulsecnt.c"
-    "sdmmc.c"
   )
 elseif(IDF_TARGET STREQUAL "esp32c3")
   list(APPEND module_srcs

--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -59,14 +59,12 @@ if(IDF_TARGET STREQUAL "esp32")
 elseif(IDF_TARGET STREQUAL "esp32s2")
   list(APPEND module_srcs
     "dac.c"
-    "i2s.c"
     "touch.c"
     "rmt.c"
     "pulsecnt.c"
   )
 elseif(IDF_TARGET STREQUAL "esp32s3")
   list(APPEND module_srcs
-    "i2s.c"
     "touch.c"
     "rmt.c"
     "pulsecnt.c"

--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -59,12 +59,22 @@ if(IDF_TARGET STREQUAL "esp32")
 elseif(IDF_TARGET STREQUAL "esp32s2")
   list(APPEND module_srcs
     "dac.c"
+    "i2s.c"
+    "touch.c"
+    "rmt.c"
+    "pulsecnt.c"
   )
 elseif(IDF_TARGET STREQUAL "esp32s3")
   list(APPEND module_srcs
+    "i2s.c"
+    "touch.c"
+    "rmt.c"
+    "pulsecnt.c"
+    "sdmmc.c"
   )
 elseif(IDF_TARGET STREQUAL "esp32c3")
   list(APPEND module_srcs
+    "rmt.c"
   )
 endif()
 


### PR DESCRIPTION
Fixes #3537 


- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This fixes the config files so that modules are included where they are supported.