### PR TITLE
ESP32: IDF 4.4.2 upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Prepare cache key
         run: git rev-parse HEAD:sdk/esp32-esp-idf > idf.rev
         shell: bash
       - name: Cache Espressif tools
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.espressif
           key: ${{ runner.os }}-espressif-tools-${{ hashFiles('idf.rev') }}
@@ -58,7 +58,7 @@ jobs:
           echo lua_build_opts="$(expr "$(./build/luac_cross/luac.cross -v)" : '.*\[\(.*\)\]')" >> $GITHUB_ENV
         shell: bash
       - name: Upload luac.cross
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ success() }}
         with:
           name: luac.cross-${{ env.lua_build_opts }}-${{ matrix.target }}

--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -111,9 +111,9 @@ static int node_bootreason( lua_State *L)
 #endif
 #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
     case GLITCH_RTC_RESET:
+    case EFUSE_RESET:
 #endif
 #if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
-    case EFUSE_RESET:
     case USB_UART_CHIP_RESET:
     case USB_JTAG_CHIP_RESET:
     case POWER_GLITCH_RESET:

--- a/components/platform/ws2812.c
+++ b/components/platform/ws2812.c
@@ -104,10 +104,12 @@ static void ws2812_isr(void *arg)
       RMT.int_clr.val = BIT(channel+24);
 
       ws2812_chain_t *chain = &(ws2812_chains[channel]);
-#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32S2)
+#if defined(CONFIG_IDF_TARGET_ESP32)
       uint32_t data_sub_len = RMT.tx_lim_ch[channel].limit/8;
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
       uint32_t data_sub_len = RMT.chn_tx_lim[channel].tx_lim_chn/8;
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+      uint32_t data_sub_len = RMT.tx_lim_ch[channel].tx_lim/8;
 #else
       uint32_t data_sub_len = RMT.tx_lim[channel].limit/8;
 #endif

--- a/tools/embed_lfs.sh
+++ b/tools/embed_lfs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-LUA_APP_SRC="$@"
+LUA_APP_SRC=("$@")
 
 MAP_FILE=build/nodemcu.map
 LUAC_OUTPUT=build/luac.out
@@ -15,43 +15,49 @@ if [ ! -f "${LUAC_CROSS}" ]; then
 	exit 1
 fi
 
-LFS_ADDR_SIZE=$(grep -E "0x[0-9a-f]+[ ]+0x[0-9a-f]+[ ]+esp-idf/embedded_lfs/libembedded_lfs.a\(lua.flash.store.reserved.S.obj\)" "${MAP_FILE}" | grep -v -w 0x0 | grep -v -w 0x24 | tr -s ' ')
-if [ -z "${LFS_ADDR_SIZE}" ]; then
+# Extract the line containing the data size of the LFS object, filtering out
+# lines for .bss/.data/.text, sorting the remaining two entries (actual LFS
+# data and (optional) riscv attributes) so we can discard the latter if
+# present. If the map file was a bit saner with its line breaks this would
+# have been a straight forward grep for for .rodata.embedded.*lua.flash.store
+LFS_SIZE_ADDR=$(grep -E "0x[0-9a-f]+[ ]+0x[0-9a-f]+[ ]+esp-idf/embedded_lfs/libembedded_lfs.a\(lua.flash.store.reserved.S.obj\)" "${MAP_FILE}" | grep -v '^ \.' | awk '{print $2,$1}' | sort -n -k 1.3 | tail -1)
+if [ -z "${LFS_SIZE_ADDR}" ]; then
 	echo "Error: LFS segment not found. Use 'make clean; make' perhaps?"
 	exit 1
 fi
 
-LFS_ADDR=$(echo "${LFS_ADDR_SIZE}" | cut -d ' ' -f 2)
+LFS_ADDR=$(echo "${LFS_SIZE_ADDR}" | cut -d ' ' -f 2)
 if [ -z "${LFS_ADDR}" ]; then
 	echo "Error: LFS segment address not found"
 	exit 1
 fi
 # The reported size is +4 due to the length field added by the IDF
-LFS_SIZE=$(( $(echo "${LFS_ADDR_SIZE}" | cut -d ' ' -f 3) - 4 ))
+LFS_SIZE=$(( $(echo "${LFS_SIZE_ADDR}" | cut -d ' ' -f 1) - 4 ))
 if [ -z "${LFS_SIZE}" ]; then
 	echo "Error: LFS segment size not found"
 	exit 1
 fi
 
-echo "LFS segment address ${LFS_ADDR}, length ${LFS_SIZE}"
+printf "LFS segment address %s, length %s (0x%x)\n" "${LFS_ADDR}" "${LFS_SIZE}" "${LFS_SIZE}"
 
 if ${LUAC_CROSS} -v | grep -q 'Lua 5.1'
 then
   echo "Generating Lua 5.1 LFS image..."
-  ${LUAC_CROSS} -a ${LFS_ADDR} -m ${LFS_SIZE} -o ${LUAC_OUTPUT} ${LUA_APP_SRC}
+  ${LUAC_CROSS} -a "${LFS_ADDR}" -m ${LFS_SIZE} -o ${LUAC_OUTPUT} "${LUA_APP_SRC[@]}"
 else
   set -e
   echo "Generating intermediate Lua 5.3 LFS image..."
-  ${LUAC_CROSS} -f -m ${LFS_SIZE} -o ${LUAC_OUTPUT}.tmp ${LUA_APP_SRC}
+  ${LUAC_CROSS} -f -m ${LFS_SIZE} -o ${LUAC_OUTPUT}.tmp "${LUA_APP_SRC[@]}"
   echo "Converting to absolute LFS image..."
-  ${LUAC_CROSS} -F ${LUAC_OUTPUT}.tmp -a ${LFS_ADDR} -o ${LUAC_OUTPUT}
+  ${LUAC_CROSS} -F ${LUAC_OUTPUT}.tmp -a "${LFS_ADDR}" -o ${LUAC_OUTPUT}
   rm ${LUAC_OUTPUT}.tmp
 fi
+# shellcheck disable=SC2181
 if [ $? != 0 ]; then
 	echo "Error: luac.cross failed"
 	exit 1
 else
-  echo "Generated $(ls -l ${LUAC_OUTPUT} | cut -f5 -d' ') bytes of LFS data"
+  echo "Generated $(stat -c "%s" ${LUAC_OUTPUT}) bytes of LFS data"
 fi
 # cmake depencies don't seem to pick up the change to luac.out?
 rm -f build/lua.flash.store.reserved


### PR DESCRIPTION
Just a maintenance PR - upgrades the used IDF to latest 4.4.2 release, and updates the github actions version per github recommendations.

A couple of small adjustments required due to minor changes in the IDF. Adjusted the embed_lfs.sh script to hopefully be more future-proof now.

Testing done on C3 only at this point.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.