### PR TITLE
Allow LUA_INIT_STRING to be set in menuconfig

### DIFF
--- a/components/lua/Kconfig
+++ b/components/lua/Kconfig
@@ -132,4 +132,35 @@ menu "Lua configuration"
       select NODEMCU_CMODULE_UART
       select LUA_BUILTIN_DEBUG
 
+    choice LUA_INIT_STRING
+        prompt "Boot command"
+        default LUA_INIT_STRING_INIT_LUA
+        help
+            Command to run on boot. This can be a .lua file, an LFS module, or
+            any valid Lua expression. By default init.lua is loaded and run
+            from the SPIFFS filesystem.
+        config LUA_INIT_STRING_INIT_LUA
+            bool "init.lua from SPIFFS"
+        config LUA_INIT_STRING_INIT_LFS
+            bool "init module from LFS"
+        config LUA_INIT_STRING_CUSTOM
+            bool "Custom"
+    endchoice
+
+    config LUA_INIT_STRING_CUSTOM_STRING
+        string "Custom boot command" if LUA_INIT_STRING_CUSTOM
+        default ""
+        help
+            Run a custom command on boot.
+
+            Specify @filename.lua to load "filename.lua" from SPIFFS.
+            Specify node.LFS.get('foo')() to load the module "foo" from LFS.
+            Or specify any other valid Lua expression to execute that on boot.
+
+    config LUA_INIT_STRING
+        string
+        default "@init.lua" if LUA_INIT_STRING_INIT_LUA
+        default "node.LFS.get('init')()" if LUA_INIT_STRING_INIT_LFS
+        default LUA_INIT_STRING_CUSTOM_STRING if LUA_INIT_STRING_CUSTOM
+
 endmenu

--- a/components/lua/lua-5.3/lua.c
+++ b/components/lua/lua-5.3/lua.c
@@ -30,11 +30,7 @@
 #endif
 
 #ifndef LUA_INIT_STRING
-# if defined(CONFIG_NODEMCU_EMBED_LFS)
-#  define LUA_INIT_STRING "node.LFS.get('init')()"
-# else
-#  define LUA_INIT_STRING "@init.lua"
-# endif
+# define LUA_INIT_STRING CONFIG_LUA_INIT_STRING
 #endif
 
 #if !defined(STARTUP_COUNT)


### PR DESCRIPTION
- [x] This PR is for the `dev-esp32-idf4` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.
_The old option wasn't documented anywhere I could find, so I haven't added anything other than describing the new option in Kconfig._

With the build system changes in the idf4 branch, it's no longer possible to set `LUA_INIT_STRING` using `MORE_CFLAGS="-DLUA_INIT_STRING=..."`. So instead, make it a menuconfig option.

```
(Top) → Component config → Lua configuration

    Lua version (Lua 5.1)  --->
[*] Integer-only build
    Core Lua modules  --->
    Lua compilation  --->
    Boot command (init.lua from SPIFFS)  --->
```

which expands to:

```
(Top) → Component config → Lua configuration → Boot command

(X) init.lua from SPIFFS
( ) init module from LFS
( ) Custom
```

This removes the previous hard-coded setting when CONFIG_NODEMCU_EMBED_LFS is defined - meaning anyone relying on that setting to also configure LUA_INIT_STRING, will need to rerun `make menuconfig` to select `init module from LFS`. I couldn't seem to find a good way of expressing "if CONFIG_NODEMCU_EMBED_LFS is enabled default to LFS otherwise init.lua" in Kconfig without making the setting really weird.