### PR TITLE
Don't error from node.sleep() when a sleep reject occurs

### DIFF
--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -282,6 +282,13 @@ static int node_sleep (lua_State *L)
   int err = esp_light_sleep_start();
   if (err == ESP_ERR_INVALID_STATE) {
     return luaL_error(L, "WiFi and BT must be stopped before sleeping");
+  } else if (err == 1) {
+    // Not documented, and not a esp_err_t, but '1' here means a sleep reject
+    // occurred. Usually because a GPIO is already in a state that would cause
+    // an immediate wakeup (in IDFv3 this situation would just cause an
+    // immediate wakeup and return 0). This isn't really an error condition and
+    // we should just treat it as OK. esp_sleep_get_wakeup_cause appears to
+    // still return the correct value when this happens.
   } else if (err) {
     return luaL_error(L, "Error %d returned from esp_light_sleep_start()", err);
   }


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

In IDFv4 there's a new return value from esp_light_sleep_start which needs handling in node.sleep(). It's not really documented as far as I can see, but in the IDF source it's termed a "sleep reject" meaning (I think) that the conditions for wakeup already apply so the board doesn't actually ever go to sleep. You see it if you try to sleep with a GPIO low wakeup, and the GPIO is already low, for example. We really don't care about this nuance (compared to sleeping then immediately waking up), so the change is to just ignore the (undocumented) return value from esp_light_sleep_start and treat it the same as slept-then-woke-up, rather than erroring.

Now I think about it some more writing this PR, given it's not documented, maybe we should just return a boolean from node.sleep() indicating whether the sleep succeeded or not. Never error, don't make assumptions about the return value other than zero/nonzero, and get rid of the ESP_ERR_INVALID_STATE check which doesn't appear to actually be used any more?