### PR TITLE
Fix Typo in ds18b20-web.lua

### DIFF
--- a/lua_modules/ds18b20/ds18b20-web.lua
+++ b/lua_modules/ds18b20/ds18b20-web.lua
@@ -11,7 +11,7 @@ local function readout(temps)
     "<b>ESP8266</b></br>"
 
   for addr, temp in pairs(temps) do
-    resp = resp .. string.format("Sensor %s: %s &#8451</br>",
+    resp = resp .. string.format("Sensor %s: %s &#8451;</br>",
       ('%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X '):format(addr:byte(1,8)), temp)
   end
 


### PR DESCRIPTION
Fixes #<GITHUB_ISSUE_NUMBER>.

_Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so._

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

_To be completed below: Description of and rationale behind this PR._

Fix a missing simicolon for special char °C (&#8451;)
