### PR TITLE
Make sodium.random API behave consistently on all build types

### DIFF
--- a/components/modules/sodium.c
+++ b/components/modules/sodium.c
@@ -17,7 +17,7 @@ static int l_randombytes_random(lua_State *L)
 {
   check_init(L);
   uint32_t ret = randombytes_random();
-  lua_pushnumber(L, (lua_Number)ret);
+  lua_pushinteger(L, (int32_t)ret);
   return 1;
 }
 
@@ -26,7 +26,7 @@ static int l_randombytes_uniform(lua_State *L)
   check_init(L);
   uint32_t upper_bound = (uint32_t)luaL_checkinteger(L, 1);
   uint32_t ret = randombytes_uniform(upper_bound);
-  lua_pushnumber(L, (lua_Number)ret);
+  lua_pushinteger(L, (int32_t)ret);
   return 1;
 }
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well.
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

The `sodium.random` APIs didn't behave consistently on all build types - on `5.1-integral` you'd get negative numbers returned, due to casting a `uint32_t` to a `lua_Number` (which is `int32_t`), but you wouldn't on `5.1-doublefp`. On `5.3-xxx` builds you'd get numbers returned instead of ints, and on `5.3-intXX-singlefp` the API was basically unusable due to 32-bit floats only being able to represent ~1% of the 32-bit integer space.

This change makes the result of `random()` return potentially-negative integers between INT32_MIN and INT32_MAX on all configurations. Which is a change in behaviour on `5.1-doublefp` but one that I think is worthwhile, to get consistency across all build configs.

I updated the documentation for this function, and also clarified the randomness constraints (ie you don't need wifi on if you're OK with only having pseudorandom guarantees) and fixed some links.