### PR TITLE
Fix i2c.setup() for pins >= 32

### DIFF
--- a/components/driver_i2c/i2c_sw_master.c
+++ b/components/driver_i2c/i2c_sw_master.c
@@ -112,7 +112,7 @@ void i2c_sw_master_gpio_init(uint8_t sda, uint8_t scl)
 
   gpio_config_t cfg;
 
-  cfg.pin_bit_mask = 1 << sda | 1 << scl;
+  cfg.pin_bit_mask = 1ULL << sda | 1ULL << scl;
   cfg.mode = GPIO_MODE_INPUT_OUTPUT_OD;
   cfg.pull_up_en = GPIO_PULLUP_ENABLE;
   cfg.pull_down_en = GPIO_PULLDOWN_DISABLE;


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

`pin_bit_mask` in i2c_sw_master.c is a 64bit value and the current code shifts an `int` sized `1`, so doesn't work for any pin numbers >= 32 because it's only shifting a 32-bit value. The upshot is software i2c doesn't work (on the default pins) on esp32s2 ~~and later~~ and probably some others too.

This change fixes that, by using a 64-bit `1` meaning the `pin_bit_mask` gets correctly set even for pin numbers above 32.

Tested on adafruit feather esp32s2 using pins 41 and 42 (Sda and Scl)
