### PR TITLE
ESP32: IDFv5.0 Fix mqtt module

### DIFF
--- a/components/modules/mqtt.c
+++ b/components/modules/mqtt.c
@@ -368,14 +368,13 @@ static int mqtt_connect(lua_State* L) {
         if (is_mqtt_uri || is_mqtts_uri)
           return luaL_error(L, "port arg must be nil if giving full uri");
         port = luaL_checknumber(L, n);
-        n++;
     }
+    n++;
 
     if (lua_isnumber(L, n)) {
         if (is_mqtt_uri || is_mqtts_uri)
           return luaL_error(L, "secure on/off determined by uri");
         secure = !!luaL_checkinteger(L, n);
-        n++;
 
     } else {
         if (lua_istable(L, n)) {
@@ -397,10 +396,9 @@ static int mqtt_connect(lua_State* L) {
                 luaX_set_ref(L, -1, &mqtt_context->client_key_pem);
             }
             lua_pop(L, 1);
-            //
-            n++;
         }
     }
+    n++;
 
     if (lua_isnumber(L, n)) {
         reconnect = !!luaL_checkinteger(L, n);

--- a/components/modules/mqtt.c
+++ b/components/modules/mqtt.c
@@ -368,14 +368,19 @@ static int mqtt_connect(lua_State* L) {
         if (is_mqtt_uri || is_mqtts_uri)
           return luaL_error(L, "port arg must be nil if giving full uri");
         port = luaL_checknumber(L, n);
+        n++;
+    } else if (lua_type(L, n) == LUA_TNIL) {
+        n++;
     }
-    n++;
 
     if (lua_isnumber(L, n)) {
         if (is_mqtt_uri || is_mqtts_uri)
           return luaL_error(L, "secure on/off determined by uri");
         secure = !!luaL_checkinteger(L, n);
+        n++;
 
+    } else if (lua_type(L, n) == LUA_TNIL) {
+        n++;
     } else {
         if (lua_istable(L, n)) {
             secure = true;
@@ -396,9 +401,10 @@ static int mqtt_connect(lua_State* L) {
                 luaX_set_ref(L, -1, &mqtt_context->client_key_pem);
             }
             lua_pop(L, 1);
+            //
+            n++;
         }
     }
-    n++;
 
     if (lua_isnumber(L, n)) {
         reconnect = !!luaL_checkinteger(L, n);

--- a/components/modules/mqtt.c
+++ b/components/modules/mqtt.c
@@ -419,7 +419,7 @@ static int mqtt_connect(lua_State* L) {
 
     ESP_LOGD(TAG, "connect: mqtt_context*: %p", mqtt_context);
 
-    if (config.broker.address.uri != NULL)
+    if (config.broker.address.uri == NULL)
     {
       config.broker.address.port = port;
       config.broker.address.transport =

--- a/docs/modules/mqtt.md
+++ b/docs/modules/mqtt.md
@@ -86,7 +86,7 @@ Closes connection to the broker.
 none
 
 #### Returns
-`true` on success, `false` otherwise
+`nil`
 
 ## mqtt.client:connect()
 
@@ -138,22 +138,6 @@ This is the description of how the `autoreconnect` functionality may (or may not
 > very first connection fails, then no reconnect attempt is made, and the error is signalled through the callback (if any). The first connection
 > is considered a success if the client connects to a server and gets back a good response packet in response to its MQTT connection request.
 > This implies (for example) that the username and password are correct.
-
-#### Connection failure callback reason codes:
-
-| Constant | Value | Description |
-|----------|-------|-------------|
-|`mqtt.CONN_FAIL_SERVER_NOT_FOUND`|-5|There is no broker listening at the specified IP Address and Port|
-|`mqtt.CONN_FAIL_NOT_A_CONNACK_MSG`|-4|The response from the broker was not a CONNACK as required by the protocol|
-|`mqtt.CONN_FAIL_DNS`|-3|DNS Lookup failed|
-|`mqtt.CONN_FAIL_TIMEOUT_RECEIVING`|-2|Timeout waiting for a CONNACK from the broker|
-|`mqtt.CONN_FAIL_TIMEOUT_SENDING`|-1|Timeout trying to send the Connect message|
-|`mqtt.CONNACK_ACCEPTED`|0|No errors. _Note: This will not trigger a failure callback._|
-|`mqtt.CONNACK_REFUSED_PROTOCOL_VER`|1|The broker is not a 3.1.1 MQTT broker.|
-|`mqtt.CONNACK_REFUSED_ID_REJECTED`|2|The specified ClientID was rejected by the broker. (See `mqtt.Client()`)|
-|`mqtt.CONNACK_REFUSED_SERVER_UNAVAILABLE`|3|The server is unavailable.|
-|`mqtt.CONNACK_REFUSED_BAD_USER_OR_PASS`|4|The broker refused the specified username or password.|
-|`mqtt.CONNACK_REFUSED_NOT_AUTHORIZED`|5|The username is not authorized.|
 
 ## mqtt.client:lwt()
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

The mqtt module does not work with IDFv5.0
I think an additional user_config checks were added in new espressif/esp-mqtt submodule.

Error log:
```
NodeMCU ESP32 build unspecified powered by Lua 5.3.5 [5.3-int32-singlefp] on IDF v5.0.2

new m: 	userdata: 0x3ffcac84

> m:connect('mqtt://192.168.1.31')
W (131404) mqtt_client: Transport config set, but overridden by scheme from URI: transport = 1, uri scheme = mqtt
W (131404) mqtt_client: Client asked to stop, but was not started
Lua error: 	stdin:1: MQTT library failed to start
stack traceback:
	[C]: in method 'connect'
	stdin:1: in main chunk
	[C]: in ?
	[C]: in ?

> m:connect('192.168.1.31')
E (159984) mqtt_client: No scheme found
E (159984) mqtt_client: Failed to create transport list
Lua error: 	stdin:1: Error starting mqtt client
stack traceback:
	[C]: in method 'connect'
	stdin:1: in main chunk
	[C]: in ?
	[C]: in ?
```
This PR fixes that error.