### PR TITLE
ESP32: IDFv5.0 fix `time` module

### DIFF
--- a/components/modules/time.c
+++ b/components/modules/time.c
@@ -32,8 +32,8 @@ static int time_get(lua_State *L)
 {
   struct timeval  tv;
   gettimeofday (&tv, NULL);
-  lua_pushnumber (L, tv.tv_sec);
-  lua_pushnumber (L, tv.tv_usec);
+  lua_pushinteger (L, tv.tv_sec);
+  lua_pushinteger (L, tv.tv_usec);
   return 2;
 }
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

The **time.get()** function returns an incorrect value of a second in the firmware [5.3-int32-singlefp] on IDF v5.0.2 

test script:
```

// dbg was added in time.c

34  gettimeofday (&tv, NULL);
35  lua_pushnumber (L, tv.tv_sec);
36  lua_pushnumber (L, tv.tv_usec);
37  NODE_DBG("tv_sec:  %llu\n", tv.tv_sec);
38  NODE_DBG("tv_usec: %lu\n", tv.tv_usec);
39  return 2;

-- Lua script

getTime = function()
  ts, tms = time.get()
  print(string.format('%d %d', ts, tms))

  et = time.epoch2cal(time.get())
  print(string.format("%04d-%02d-%02d %02d:%02d:%02d DST:%d",
    et["year"], et["mon"], et["day"],
    et["hour"], et["min"], et["sec"], et["dst"]))

  lt = time.getlocal()
  print(string.format("%04d-%02d-%02d %02d:%02d:%02d DST:%d",
  lt["year"], lt["mon"], lt["day"],
  lt["hour"], lt["min"], lt["sec"], lt["dst"]))
end

tt = tmr.create()
tt:alarm(3000, tmr.ALARM_AUTO, getTime)

tt:stop()
```
test output:
```
tv_sec:  1690272183
tv_usec: 497059
1690272128 497059   <- wrong sec value
tv_sec:  1690272183
tv_usec: 498844
2023-07-25 08:02:08 DST:0  <- wrong time.epoch2cal
2023-07-25 08:03:03 DST:0  <- correct time.getlocal
```
This PR fixes the bug.
I have tested the PR on firmware:

-   Lua 5.3.5 [5.3-int32-singlefp] on IDF v5.0.2
-   Lua 5.3.5 [5.3-int32-doublefp] on IDF v5.0.2
-   Lua 5.3.5 [5.3-int64-singlefp] on IDF v5.0.2
-   Lua 5.3.5 [5.3-int64-doublefp] on IDF v5.0.2

Lua 5.1-fp works correctly as well.
