### PR TITLE
Update rmt translator

### DIFF
--- a/components/modules/ws2812.c
+++ b/components/modules/ws2812.c
@@ -83,7 +83,7 @@ static int ws2812_write( lua_State* L )
     lua_pop( L, 1 );
 
     // prepare channel
-    if (platform_ws2812_setup( gpio_num, 1, (const uint8_t *)data, length ) != PLATFORM_OK) {
+    if (platform_ws2812_setup( gpio_num, (const uint8_t *)data, length ) != PLATFORM_OK) {
       ws2812_cleanup( L, 0 );
       return luaL_argerror( L, stack, "can't set up chain" );
     }

--- a/components/modules/ws2812.c
+++ b/components/modules/ws2812.c
@@ -11,6 +11,12 @@
 #define SHIFT_LOGICAL  0
 #define SHIFT_CIRCULAR 1
 
+// The default bit H & L durations in multiples of 100ns.
+#define WS2812_DURATION_T0H 4
+#define WS2812_DURATION_T0L 7
+#define WS2812_DURATION_T1H 8
+#define WS2812_DURATION_T1L 6
+
 
 typedef struct {
   int size;
@@ -33,6 +39,7 @@ static void ws2812_cleanup( lua_State *L, int pop )
 // ws2812.write({pin = 4, data = string.char(255, 0, 0, 255, 255, 255)}) first LED green, second LED white.
 static int ws2812_write( lua_State* L )
 {
+  int type;
   int top = lua_gettop( L );
 
   for (int stack = 1; stack <= top; stack++) {
@@ -54,6 +61,86 @@ static int ws2812_write( lua_State* L )
       return luaL_argerror( L, stack, "invalid pin" );
     }
     int gpio_num = luaL_checkint( L, -1 );
+    lua_pop( L, 1 );
+
+    //
+    // retrieve t0h
+    // This is an optional parameter which defaults to WS2812_DURATION_T0H.
+    //
+    int t0h = WS2812_DURATION_T0H;
+    type = lua_getfield( L, stack, "t0h" );
+    if (type!=LUA_TNIL )
+    {
+      if (!lua_isnumber( L, -1 )) {
+        ws2812_cleanup( L, 1 );
+        return luaL_argerror( L, stack, "invalid t0h" );
+      }
+      t0h = luaL_checkint( L, -1 );
+      if ((t0h<1) || (t0h>0x7fff)) {
+        ws2812_cleanup( L, 1 );
+        return luaL_argerror( L, stack, "t0h must be 1<=t0h<=32767" );
+      }
+    }
+    lua_pop( L, 1 );
+
+    //
+    // retrieve t0l
+    // This is an optional parameter which defaults to WS2812_DURATION_T0L.
+    //
+    int t0l = WS2812_DURATION_T0L;
+    type = lua_getfield( L, stack, "t0l" );
+    if (type!=LUA_TNIL )
+    {
+      if (!lua_isnumber( L, -1 )) {
+        ws2812_cleanup( L, 1 );
+        return luaL_argerror( L, stack, "invalid t0l" );
+      }
+      t0l = luaL_checkint( L, -1 );
+      if ((t0l<1) || (t0l>0x7fff)) {
+        ws2812_cleanup( L, 1 );
+        return luaL_argerror( L, stack, "t0l must be 1<=t0l<=32767" );
+      }
+    }
+    lua_pop( L, 1 );
+
+    //
+    // retrieve t1h
+    // This is an optional parameter which defaults to WS2812_DURATION_T1H.
+    //
+    int t1h = WS2812_DURATION_T1H;
+    type = lua_getfield( L, stack, "t1h" );
+    if (type!=LUA_TNIL )
+    {
+      if (!lua_isnumber( L, -1 )) {
+        ws2812_cleanup( L, 1 );
+        return luaL_argerror( L, stack, "invalid t1h" );
+      }
+      t1h = luaL_checkint( L, -1 );
+      if ((t1h<1) || (t1h>0x7fff)) {
+        ws2812_cleanup( L, 1 );
+        return luaL_argerror( L, stack, "t1h must be 1<=t1h<=32767" );
+      }
+    }
+    lua_pop( L, 1 );
+
+    //
+    // retrieve t1l
+    // This is an optional parameter which defaults to WS2812_DURATION_T1L.
+    //
+    int t1l = WS2812_DURATION_T1L;
+    type = lua_getfield( L, stack, "t1l" );
+    if (type!=LUA_TNIL )
+    {
+      if (!lua_isnumber( L, -1 )) {
+        ws2812_cleanup( L, 1 );
+        return luaL_argerror( L, stack, "invalid t1l" );
+      }
+      t1l = luaL_checkint( L, -1 );
+      if ((t1l<1) || (t1l>0x7fff)) {
+        ws2812_cleanup( L, 1 );
+        return luaL_argerror( L, stack, "t1l must be 1<=t1l<=32767" );
+      }
+    }
     lua_pop( L, 1 );
 
     //
@@ -83,7 +170,7 @@ static int ws2812_write( lua_State* L )
     lua_pop( L, 1 );
 
     // prepare channel
-    if (platform_ws2812_setup( gpio_num, (const uint8_t *)data, length ) != PLATFORM_OK) {
+    if (platform_ws2812_setup( gpio_num, t0h, t0l, t1h, t1l, (const uint8_t *)data, length ) != PLATFORM_OK) {
       ws2812_cleanup( L, 0 );
       return luaL_argerror( L, stack, "can't set up chain" );
     }

--- a/components/platform/include/platform.h
+++ b/components/platform/include/platform.h
@@ -209,7 +209,7 @@ int platform_dht_read( uint8_t gpio_num, uint8_t wakeup_ms, uint8_t *data );
 // WS2812 platform interface
 
 void platform_ws2812_init( void );
-int platform_ws2812_setup( uint8_t gpio_num, const uint8_t *data, size_t len );
+int platform_ws2812_setup( uint8_t gpio_num, uint32_t bit0h, uint32_t bit0l, uint32_t bit1h, uint32_t bit1l, const uint8_t *data, size_t len );
 int platform_ws2812_release( void );
 int platform_ws2812_send( void );
 

--- a/components/platform/include/platform.h
+++ b/components/platform/include/platform.h
@@ -209,7 +209,7 @@ int platform_dht_read( uint8_t gpio_num, uint8_t wakeup_ms, uint8_t *data );
 // WS2812 platform interface
 
 void platform_ws2812_init( void );
-int platform_ws2812_setup( uint8_t gpio_num, uint8_t num_mem, const uint8_t *data, size_t len );
+int platform_ws2812_setup( uint8_t gpio_num, const uint8_t *data, size_t len );
 int platform_ws2812_release( void );
 int platform_ws2812_send( void );
 

--- a/components/platform/include/platform.h
+++ b/components/platform/include/platform.h
@@ -209,7 +209,7 @@ int platform_dht_read( uint8_t gpio_num, uint8_t wakeup_ms, uint8_t *data );
 // WS2812 platform interface
 
 void platform_ws2812_init( void );
-int platform_ws2812_setup( uint8_t gpio_num, uint32_t bit0h, uint32_t bit0l, uint32_t bit1h, uint32_t bit1l, const uint8_t *data, size_t len );
+int platform_ws2812_setup( uint8_t gpio_num, uint32_t reset, uint32_t bit0h, uint32_t bit0l, uint32_t bit1h, uint32_t bit1l, const uint8_t *data, size_t len );
 int platform_ws2812_release( void );
 int platform_ws2812_send( void );
 

--- a/components/platform/ws2812.c
+++ b/components/platform/ws2812.c
@@ -126,11 +126,11 @@ static void ws2812_sample_to_rmt(const void *src, rmt_item32_t *dest, size_t src
   // ESP_DRAM_LOGW("ws2812", "src bytes consumed: %u total rmt items: %u", *translated_size, *item_num);
 }
 
-int platform_ws2812_setup( uint8_t gpio_num, uint8_t num_mem, const uint8_t *data, size_t len )
+int platform_ws2812_setup( uint8_t gpio_num, const uint8_t *data, size_t len )
 {
   int channel;
 
-  if ((channel = platform_rmt_allocate( num_mem, RMT_MODE_TX )) >= 0) {
+  if ((channel = platform_rmt_allocate( 1, RMT_MODE_TX )) >= 0) {
     ws2812_chain_t *chain = &(ws2812_chains[channel]);
 
     chain->valid = true;

--- a/docs/modules/ws2812.md
+++ b/docs/modules/ws2812.md
@@ -24,6 +24,7 @@ Variable number of tables, each describing a single strip. Required elements are
 
 Optional elements are:
 
+- `reset` duration of the reset signal in multiples of 100ns. A duration of 0 generates no reset. The minimum possible value is 0. The maximum is 65534. The default value is 512 which generates a reset of 51.2us.
 - `t0h` duration of the high period for a 0 code in multiples of 100ns. The minimum possible value is 1. The maximum is 32767. The default value is 4 which results in a high period of 400ns for each 0 code.
 - `t0l` duration of the low period for a 0 code in multiples of 100ns. The minimum possible value is 1. The maximum is 32767. The default value is 7 which results in a low period of 700ns for each 0 code.
 - `t1h` duration of the high period for a 1 code in multiples of 100ns. The minimum possible value is 1. The maximum is 32767. The default value is 8 which results in a high period of 800ns for each 1 code.
@@ -52,7 +53,7 @@ ws2812.write({pin =  4, data = string.char(255, 0, 0, 255, 0, 0)},
 ```
 
 ```lua
-ws2812.write({pin = 8, t0h = 3, t0l = 9, t1h = 6, t1l = 6, data = string.char(1, 0, 0)}) -- turn the SK6812 RGB led on the ESP32-C3-DevKitM-1 to green
+ws2812.write({pin = 8, reset = 800, t0h = 3, t0l = 9, t1h = 6, t1l = 6, data = string.char(1, 0, 0)}) -- turn the SK6812 RGB led on the ESP32-C3-DevKitM-1 to green
 ```
 
 # Buffer module

--- a/docs/modules/ws2812.md
+++ b/docs/modules/ws2812.md
@@ -1,7 +1,7 @@
 # WS2812 Module
 | Since  | Origin / Contributor  | Maintainer  | Source  |
 | :----- | :-------------------- | :---------- | :------ |
-| 2015-02-05 | [Till Klocke](https://github.com/dereulenspiegel), [Thomas Soëte](https://github.com/Alkorin) | [Arnim Läuger](https://github.com/devsaurus) | [ws2812.c](../../components/modules/ws2812.c)|
+| 2015-02-05 | [Till Klocke](https://github.com/dereulenspiegel), [Thomas Soëte](https://github.com/Alkorin), [Christoph Thelen](https://github.com/docbacardi) | [Arnim Läuger](https://github.com/devsaurus) | [ws2812.c](../../components/modules/ws2812.c)|
 
 ws2812 is a library to handle ws2812-like led strips.
 It works at least on WS2812, WS2812b, APA104, SK6812 (RGB or RGBW).
@@ -21,6 +21,13 @@ Variable number of tables, each describing a single strip. Required elements are
 
 - `pin` IO index, see [GPIO Overview](gpio.md#gpio-overview)
 - `data` payload to be sent to one or more WS2812 like leds through GPIO2
+
+Optional elements are:
+
+- `t0h` duration of the high period for a 0 code in multiples of 100ns. The minimum possible value is 1. The maximum is 32767. The default value is 4 which results in a high period of 400ns for each 0 code.
+- `t0l` duration of the low period for a 0 code in multiples of 100ns. The minimum possible value is 1. The maximum is 32767. The default value is 7 which results in a low period of 700ns for each 0 code.
+- `t1h` duration of the high period for a 1 code in multiples of 100ns. The minimum possible value is 1. The maximum is 32767. The default value is 8 which results in a high period of 800ns for each 1 code.
+- `t1l` duration of the low period for a 1 code in multiples of 100ns. The minimum possible value is 1. The maximum is 32767. The default value is 6 which results in a low period of 600ns for each 1 code.
 
 Payload type could be:
 
@@ -42,6 +49,10 @@ ws2812.write({pin = 4, string.char(0, 0, 0, 255, 0, 0, 0, 255)}) -- turn the two
 ```lua
 ws2812.write({pin =  4, data = string.char(255, 0, 0, 255, 0, 0)},
              {pin = 14, data = string.char(0, 255, 0, 0, 255, 0)}) -- turn the two first RGB leds to green on the first strip and red on the second strip
+```
+
+```lua
+ws2812.write({pin = 8, t0h = 3, t0l = 9, t1h = 6, t1l = 6, data = string.char(1, 0, 0)}) -- turn the SK6812 RGB led on the ESP32-C3-DevKitM-1 to green
 ```
 
 # Buffer module

--- a/docs/modules/ws2812.md
+++ b/docs/modules/ws2812.md
@@ -53,7 +53,7 @@ ws2812.write({pin =  4, data = string.char(255, 0, 0, 255, 0, 0)},
 ```
 
 ```lua
-ws2812.write({pin = 8, reset = 800, t0h = 3, t0l = 9, t1h = 6, t1l = 6, data = string.char(1, 0, 0)}) -- turn the SK6812 RGB led on the ESP32-C3-DevKitM-1 to green
+ws2812.write({pin = 8, reset = 800, t0h = 3, t0l = 9, t1h = 6, t1l = 6, data = string.char(1, 0, 0)}) -- turn the SK6812 GRB led on the ESP32-C3-DevKitM-1 to green
 ```
 
 # Buffer module


### PR DESCRIPTION
Fixes #3628 .

- [x] This PR is for the `dev-esp32` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

This set of patches adds optional parameters to the WS2812 module to set the duration of the reset signal and the duration for the high and low phase of the 0 and 1 symbols. This allows to control many other RGB LEDs besides the WS2812.
The main intention of this patch is to control the RGB LED of the ESP32-C3 dev kit.
