### PR TITLE
Fix auto create release.yml

### DIFF
--- a/.github/workflows/AutoCreateRelease.yml
+++ b/.github/workflows/AutoCreateRelease.yml
@@ -9,7 +9,7 @@ jobs:
 
   build_luac_cross_win:
 
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     steps:
     - uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
   Create_Release:
     name: Create Release
     needs: build_luac_cross_win
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Set release name


### PR DESCRIPTION
Fixes #<GITHUB_ISSUE_NUMBER>.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [ ] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

for the prepare release note workflow to work it has to run on specific os versions
