### PR TITLE
Add note about ESP32 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ NodeMCU is an open source [Lua](https://www.lua.org/) based firmware for the [ES
 
 The firmware was initially developed as is a companion project to the popular ESP8266-based [NodeMCU development modules]((https://github.com/nodemcu/nodemcu-devkit-v1.0)), but the project is now community-supported, and the firmware can now be run on _any_ ESP module.
 
+**The NodeMCU `release` and `dev` branches target the ESP8266. The `dev-esp32` branch targets the ESP32.**
+
 ## Summary
 
 - Easy to program wireless node and/or access point


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

For some reason we never explicitly mentioned in the README which hardware our branches target. We do have such [a note in the docs](https://nodemcu.readthedocs.io/en/release/), though (for the relevant branches).

! For this to be effective we should also snap this to `release` immediately after merging.