### PR TITLE
Initial support for ESP32-C6 and ESP32-H2, plus assorted fixes & improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         lua_ver: ['5.1', '5.3']
         numbers: ['default', 'alternate']
-        target: ['esp32', 'esp32s2', 'esp32s3', 'esp32c3']
+        target: ['esp32', 'esp32s2', 'esp32s3', 'esp32c3', 'esp32c6']
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,14 +15,14 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Prepare cache key
         run: git rev-parse HEAD:sdk/esp32-esp-idf > idf.rev
         shell: bash
       - name: Cache Espressif tools
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.espressif
           key: ${{ runner.os }}-espressif-tools-${{ hashFiles('idf.rev') }}
@@ -58,7 +58,7 @@ jobs:
           echo lua_build_opts="$(expr "$(./build/luac_cross/luac.cross -v)" : '.*\[\(.*\)\]')" >> $GITHUB_ENV
         shell: bash
       - name: Upload luac.cross
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ success() }}
         with:
           name: luac.cross-${{ env.lua_build_opts }}-${{ matrix.target }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         lua_ver: ['5.1', '5.3']
         numbers: ['default', 'alternate']
-        target: ['esp32', 'esp32s2', 'esp32s3', 'esp32c3', 'esp32c6']
+        target: ['esp32', 'esp32s2', 'esp32s3', 'esp32c3', 'esp32c6', 'esp32h2']
 
     runs-on: ubuntu-20.04
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,11 @@ jobs:
         run: |
           cp sdkconfig.defaults sdkconfig
         shell: bash
+      - name: Update config for Lua 5.1
+        if: ${{ matrix.lua_ver == '5.1' }}
+        run: |
+          echo CONFIG_LUA_VERSION_51=y >> sdkconfig
+        shell: bash
       - name: Update config for Lua 5.1, integer-only
         if: ${{ matrix.lua_ver == '5.1' && matrix.numbers == 'alternate' }}
         run: |

--- a/components/base_nodemcu/CMakeLists.txt
+++ b/components/base_nodemcu/CMakeLists.txt
@@ -2,6 +2,6 @@ idf_component_register(
   SRCS "ip_fmt.c" "user_main.c"
   INCLUDE_DIRS "include"
   REQUIRES "lua"
-  PRIV_REQUIRES "nvs_flash" "spiffs" "esp_netif" "driver"
+  PRIV_REQUIRES "nvs_flash" "spiffs" "esp_netif" "driver" "vfs"
   LDFRAGMENTS "nodemcu.lf"
 )

--- a/components/base_nodemcu/user_main.c
+++ b/components/base_nodemcu/user_main.c
@@ -156,6 +156,8 @@ static void console_task(void *)
     {
       // If we want to honor run_input, we'd need to check the return val
       feed_lua_input(linebuf, n);
+      // The IDF doesn't seem to honor setvbuf(stdout, NULL, _IONBF, 0) :(
+      fsync(fileno(stdout));
     }
   }
 }

--- a/components/base_nodemcu/user_main.c
+++ b/components/base_nodemcu/user_main.c
@@ -148,14 +148,18 @@ static void nodemcu_init(void)
 
 static void console_task(void *)
 {
-  char linebuf[64];
   for (;;)
   {
-    ssize_t n = read(fileno(stdin), linebuf, sizeof(linebuf));
+    /* We can't use a large read buffer here as some console choices
+     * (e.g. usb-serial-jtag) don't support read timeouts/partial reads,
+     * which breaks the echo support and makes for a bad user experience.
+     */
+    char c;
+    ssize_t n = read(fileno(stdin), &c, 1);
     if (n > 0)
     {
       // If we want to honor run_input, we'd need to check the return val
-      feed_lua_input(linebuf, n);
+      feed_lua_input(&c, 1);
       // The IDF doesn't seem to honor setvbuf(stdout, NULL, _IONBF, 0) :(
       fsync(fileno(stdout));
     }

--- a/components/base_nodemcu/user_main.c
+++ b/components/base_nodemcu/user_main.c
@@ -227,7 +227,7 @@ static void console_init(void)
 #endif
 
   xTaskCreate(
-    console_task, "console", 1024, NULL, ESP_TASK_MAIN_PRIO+1, NULL);
+    console_task, "console", 2048, NULL, ESP_TASK_MAIN_PRIO+1, NULL);
 }
 
 

--- a/components/lua/common/linput.c
+++ b/components/lua/common/linput.c
@@ -11,7 +11,9 @@ static struct input_state {
   size_t      len;
   const char *prompt;
   char last_nl_char;
-} ins = {0};
+} ins = {
+  .prompt = "? ", // prompt should never be allowed to be null
+};
 
 #define NUL '\0'
 #define BS  '\010'
@@ -23,6 +25,15 @@ static struct input_state {
 bool input_echo = true;
 bool run_input = true;
 
+void input_setprompt (const char *prompt) {
+  if (prompt == NULL)
+  {
+    fprintf(stderr, "Error: attempted to set a null prompt?!");
+    return;
+  }
+  ins.prompt = prompt;
+}
+
 /*
 ** The input state (ins) is private, so input_setup() exposes the necessary
 ** access to public properties and is called in user_init() before the Lua
@@ -32,11 +43,8 @@ void input_setup(int bufsize, const char *prompt) {
   // Initialise non-zero elements
   ins.data      = malloc(bufsize);
   ins.len       = bufsize;
-  ins.prompt    = prompt;
-}
-
-void input_setprompt (const char *prompt) {
-  ins.prompt = prompt;
+  // Call to get the prompt error checking
+  input_setprompt(prompt);
 }
 
 

--- a/components/lua/common/linput.c
+++ b/components/lua/common/linput.c
@@ -3,6 +3,7 @@
 #include "lua.h"
 #include "lauxlib.h"
 #include <stdio.h>
+#include <string.h>
 
 static struct input_state {
   char       *data;
@@ -59,7 +60,7 @@ size_t feed_lua_input(const char *buf, size_t n)
     /* backspace key */
     if (ch == DEL || ch == BS) {
       if (ins.line_pos > 0) {
-        if(input_echo) printf(BS_OVER);
+        if(input_echo) fwrite(BS_OVER, strlen(BS_OVER), 1, stdout);
         ins.line_pos--;
       }
       ins.data[ins.line_pos] = 0;
@@ -73,7 +74,7 @@ size_t feed_lua_input(const char *buf, size_t n)
       if (input_echo) putchar(LF);
       if (ins.line_pos == 0) {
         /* Get a empty line, then go to get a new line */
-        printf(ins.prompt);
+        fwrite(ins.prompt, strlen(ins.prompt), 1, stdout);
         fflush(stdout);
       } else {
         ins.data[ins.line_pos++] = LF;

--- a/components/lua/lua-5.1/ldump.c
+++ b/components/lua/lua-5.1/ldump.c
@@ -178,7 +178,7 @@ static void DumpCode(const Proto *f, DumpState* D)
 
 static void DumpString(const TString* s, DumpState* D)
 {
- if (s==NULL || getstr(s)==NULL)
+ if (s==NULL)
  {
   strsize_t size=0;
   DumpSize(size,D);

--- a/components/lua/lua-5.3/lua.c
+++ b/components/lua/lua-5.3/lua.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include "user_version.h"
 #include "linput.h"
 
@@ -211,6 +212,7 @@ static void dojob (lua_State *L) {
   prompt = get_prompt(L, MLref!= LUA_NOREF ? 0 : 1);
   input_setprompt(prompt);
   lua_writestring(prompt,strlen(prompt));
+  fsync(fileno(stdout)); /* work around IDF issue on ACM consoles */
 }
 
 

--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -1,4 +1,11 @@
 # Modules common to all chips
+set(wifi_modules
+  "espnow.c"
+  "wifi.c"
+  "wifi_ap.c"
+  "wifi_common.c"
+  "wifi_sta.c"
+)
 set(module_srcs
   "adc.c"
   "bit.c"
@@ -8,7 +15,6 @@ set(module_srcs
   "dht.c"
   "encoder.c"
   "eromfs.c"
-  "espnow.c"
   "file.c"
   "gpio.c"
   "heaptrace.c"
@@ -38,10 +44,6 @@ set(module_srcs
   "u8g2.c"
   "uart.c"
   "ucg.c"
-  "wifi.c"
-  "wifi_ap.c"
-  "wifi_common.c"
-  "wifi_sta.c"
   "ws2812.c"
 )
 
@@ -56,17 +58,20 @@ if(IDF_TARGET STREQUAL "esp32")
     "pulsecnt.c"
     "sdmmc.c"
     "touch.c"
+    ${wifi_modules}
   )
 elseif(IDF_TARGET STREQUAL "esp32s2")
   list(APPEND module_srcs
     "dac.c"
     "pulsecnt.c"
+    ${wifi_modules}
   )
 elseif(IDF_TARGET STREQUAL "esp32s3")
   list(APPEND module_srcs
     "dac.c"
     "pulsecnt.c"
     "sdmmc.c"
+    ${wifi_modules}
   )
 elseif(IDF_TARGET STREQUAL "esp32c3")
   list(APPEND module_srcs
@@ -75,6 +80,10 @@ elseif(IDF_TARGET STREQUAL "esp32c6")
   list(APPEND module_srcs
     "dac.c"
     "pulsecnt.c"
+    ${wifi_modules}
+  )
+elseif(IDF_TARGET STREQUAL "esp32h2")
+  list(APPEND module_srcs
   )
 endif()
 

--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -24,6 +24,7 @@ set(module_srcs
   "otaupgrade.c"
   "ow.c"
   "pipe.c"
+  "rmt.c"
   "rtcmem.c"
   "qrcodegen.c"
   "sigma_delta.c"
@@ -53,7 +54,6 @@ if(IDF_TARGET STREQUAL "esp32")
     "eth.c"
     "i2s.c"
     "pulsecnt.c"
-    "rmt.c"
     "sdmmc.c"
     "touch.c"
   )
@@ -61,17 +61,20 @@ elseif(IDF_TARGET STREQUAL "esp32s2")
   list(APPEND module_srcs
     "dac.c"
     "pulsecnt.c"
-    "rmt.c"
   )
 elseif(IDF_TARGET STREQUAL "esp32s3")
   list(APPEND module_srcs
+    "dac.c"
     "pulsecnt.c"
-    "rmt.c"
     "sdmmc.c"
   )
 elseif(IDF_TARGET STREQUAL "esp32c3")
   list(APPEND module_srcs
-    "rmt.c"
+  )
+elseif(IDF_TARGET STREQUAL "esp32c6")
+  list(APPEND module_srcs
+    "dac.c"
+    "pulsecnt.c"
   )
 endif()
 

--- a/components/modules/Kconfig
+++ b/components/modules/Kconfig
@@ -83,6 +83,7 @@ menu "NodeMCU modules"
             does.
 
     config NODEMCU_CMODULE_ESPNOW
+        depends on !IDF_TARGET_ESP32H2
         bool "ESP-NOW module"
         default "n"
         help
@@ -309,6 +310,7 @@ menu "NodeMCU modules"
     rsource "../ucg/Kconfig.ucg"
 
     config NODEMCU_CMODULE_WIFI
+        depends on !IDF_TARGET_ESP32H2
         bool "WiFi module"
         default "y"
         help

--- a/components/modules/Kconfig
+++ b/components/modules/Kconfig
@@ -35,7 +35,7 @@ menu "NodeMCU modules"
             Includes the crypto module.
 
     config NODEMCU_CMODULE_DAC
-        depends on IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2
+        depends on IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32_C6
         bool "DAC module"
         default "n"
         help
@@ -210,7 +210,7 @@ menu "NodeMCU modules"
             Includes the pipe module (required by our Lua VM).
 
     config NODEMCU_CMODULE_PULSECNT
-        depends on IDF_TARGET_ESP32
+        depends on IDF_TARGET_ESP32 || IDF_TARGET_ESP32S2 || IDF_TARGET_ESP32S3 || IDF_TARGET_ESP32C6
         bool "Pulse counter module"
         default "n"
         help
@@ -239,7 +239,7 @@ menu "NodeMCU modules"
             the battery backed memory.
 
     config NODEMCU_CMODULE_SDMMC
-        depends on IDF_TARGET_ESP32
+        depends on IDF_TARGET_ESP32 || IDF_TARGET_ESP32S3
         bool "SD-MMC module"
         default "n"
         help

--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -107,21 +107,30 @@ static int node_bootreason( lua_State *L)
     case EXT_CPU_RESET:
 #endif
     case DEEPSLEEP_RESET:
-#if defined(CONFIG_IDF_TARGET_ESP32)
+#if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32C6)
     case SDIO_RESET:
 #endif
 #if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
     case GLITCH_RTC_RESET:
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
     case EFUSE_RESET:
 #endif
-#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+    case JTAG_RESET:
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
     case USB_UART_CHIP_RESET:
     case USB_JTAG_CHIP_RESET:
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
     case POWER_GLITCH_RESET:
 #endif
     case TG0WDT_SYS_RESET:
     case TG1WDT_SYS_RESET:
+#if !defined(CONFIG_IDF_TARGET_ESP32C6)
     case INTRUSION_RESET:
+#endif
     case RTCWDT_BROWN_OUT_RESET:
     case RTCWDT_RTC_RESET:
       rawinfo = 3; break;
@@ -262,7 +271,7 @@ static int node_sleep (lua_State *L)
     esp_sleep_enable_timer_wakeup(usecs);
   }
 
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6)
   // touch option: boolean
   if (opt_checkbool(L, "touch", false)) {
     int err = esp_sleep_enable_touchpad_wakeup();
@@ -335,7 +344,7 @@ static int node_dsleep (lua_State *L)
       }
     }
 
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6)
     bool pull = opt_checkbool(L, "pull", false);
     if (opt_get(L, "isolate", LUA_TTABLE)) {
       for (int i = 1; ; i++) {

--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -110,20 +110,20 @@ static int node_bootreason( lua_State *L)
 #if defined(CONFIG_IDF_TARGET_ESP32) || defined(CONFIG_IDF_TARGET_ESP32C6)
     case SDIO_RESET:
 #endif
-#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32H2)
     case GLITCH_RTC_RESET:
 #endif
-#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32H2)
     case EFUSE_RESET:
 #endif
 #if defined(CONFIG_IDF_TARGET_ESP32C6)
     case JTAG_RESET:
 #endif
-#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6)
+#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32C6) || defined(CONFIG_IDF_TARGET_ESP32H2)
     case USB_UART_CHIP_RESET:
     case USB_JTAG_CHIP_RESET:
 #endif
-#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET_ESP32S3) || defined(CONFIG_IDF_TARGET_ESP32C3) || defined(CONFIG_IDF_TARGET_ESP32H2)
     case POWER_GLITCH_RESET:
 #endif
     case TG0WDT_SYS_RESET:
@@ -271,7 +271,7 @@ static int node_sleep (lua_State *L)
     esp_sleep_enable_timer_wakeup(usecs);
   }
 
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(CONFIG_IDF_TARGET_ESP32H2)
   // touch option: boolean
   if (opt_checkbool(L, "touch", false)) {
     int err = esp_sleep_enable_touchpad_wakeup();
@@ -344,7 +344,7 @@ static int node_dsleep (lua_State *L)
       }
     }
 
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(CONFIG_IDF_TARGET_ESP32H2)
     bool pull = opt_checkbool(L, "pull", false);
     if (opt_get(L, "isolate", LUA_TTABLE)) {
       for (int i = 1; ; i++) {

--- a/components/platform/Kconfig
+++ b/components/platform/Kconfig
@@ -72,6 +72,7 @@ menu "NodeMCU platform config"
             default y if IDF_TARGET_ESP32S2
             default y if IDF_TARGET_ESP32S3
             default y if IDF_TARGET_ESP32C3
+            default y if IDF_TARGET_ESP32C6
             default y if IDF_TARGET_ESP32H2
 
         config NODEMCU_UART_AT_LEAST_3

--- a/components/platform/onewire.c
+++ b/components/platform/onewire.c
@@ -197,7 +197,7 @@ static int onewire_rmt_attach_pin( uint8_t gpio_num )
     return PLATFORM_ERR;
 
   if (gpio_num != ow_rmt.gpio) {
-#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6) && !defined(CONFIG_IDF_TARGET_ESP32H2)
     // attach GPIO to previous pin
     if (gpio_num < 32) {
       GPIO.enable_w1ts = (0x1 << gpio_num);

--- a/components/platform/onewire.c
+++ b/components/platform/onewire.c
@@ -197,7 +197,7 @@ static int onewire_rmt_attach_pin( uint8_t gpio_num )
     return PLATFORM_ERR;
 
   if (gpio_num != ow_rmt.gpio) {
-#if !defined(CONFIG_IDF_TARGET_ESP32C3)
+#if !defined(CONFIG_IDF_TARGET_ESP32C3) && !defined(CONFIG_IDF_TARGET_ESP32C6)
     // attach GPIO to previous pin
     if (gpio_num < 32) {
       GPIO.enable_w1ts = (0x1 << gpio_num);

--- a/components/platform/platform.c
+++ b/components/platform/platform.c
@@ -284,6 +284,11 @@ uint32_t platform_uart_setup( unsigned id, uint32_t baud, int databits, int pari
 
 void platform_uart_setmode(unsigned id, unsigned mode)
 {
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
+  if (id == CONFIG_ESP_CONSOLE_UART_NUM)
+    return;
+#endif
+
 	uart_mode_t uartMode;
 	
 	switch(mode)
@@ -334,6 +339,11 @@ void platform_uart_flush( unsigned id )
 
 int platform_uart_start( unsigned id )
 {
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
+  if (id == CONFIG_ESP_CONSOLE_UART_NUM)
+    return -1;
+#endif
+
   if(uart_event_task_id == 0)
     uart_event_task_id = task_get_id( uart_event_task );
 
@@ -365,16 +375,16 @@ int platform_uart_start( unsigned id )
 
 void platform_uart_stop( unsigned id )
 {
+#if CONFIG_ESP_CONSOLE_UART_DEFAULT || CONFIG_ESP_CONSOLE_UART_CUSTOM
   if (id == CONFIG_ESP_CONSOLE_UART_NUM)
-    ;
-  else {
-    uart_status_t *us = & uart_status[id];  
-    uart_driver_delete(id);
-    if(us->line_buffer) free(us->line_buffer);
-    us->line_buffer = NULL;
-    if(us->taskHandle) vTaskDelete(us->taskHandle);
-    us->taskHandle = NULL;
-  }
+    return;
+#endif
+  uart_status_t *us = & uart_status[id];
+  uart_driver_delete(id);
+  if(us->line_buffer) free(us->line_buffer);
+  us->line_buffer = NULL;
+  if(us->taskHandle) vTaskDelete(us->taskHandle);
+  us->taskHandle = NULL;
 }
 
 int platform_uart_get_config(unsigned id, uint32_t *baudp, uint32_t *databitsp, uint32_t *parityp, uint32_t *stopbitsp) {

--- a/components/task/include/task/task.h
+++ b/components/task/include/task/task.h
@@ -23,6 +23,11 @@ typedef intptr_t task_param_t;
 */
 bool task_post(task_prio_t priority, task_handle_t handle, task_param_t param);
 
+/* Regular task posting is non-blocking, best effort. This version can be used
+ * where blocking-until-slot-is-available functionality is needed.
+ */
+bool task_post_block(task_prio_t priority, task_handle_t handle, task_param_t param);
+
 /* When posting NodeMCU tasks from an ISR, this version MUST be used,
  * and vice versa.
  * Doing otherwise breaks assumptions made by the FreeRTOS kernel in terms of
@@ -43,6 +48,10 @@ bool task_post_isr(task_prio_t priority, task_handle_t handle, task_param_t para
 #define task_post_isr_low(handle,param)    task_post_isr(TASK_PRIORITY_LOW,    handle, param)
 #define task_post_isr_medium(handle,param) task_post_isr(TASK_PRIORITY_MEDIUM, handle, param)
 #define task_post_isr_high(handle,param)   task_post_isr(TASK_PRIORITY_HIGH,   handle, param)
+
+#define task_post_block_low(handle,param)    task_post_block(TASK_PRIORITY_LOW,    handle, param)
+#define task_post_block_medium(handle,param) task_post_block(TASK_PRIORITY_MEDIUM, handle, param)
+#define task_post_block_high(handle,param)   task_post_block(TASK_PRIORITY_HIGH,   handle, param)
 
 typedef void (*task_callback_t)(task_param_t param, task_prio_t prio);
 

--- a/components/uzlib/uzlib.h
+++ b/components/uzlib/uzlib.h
@@ -18,7 +18,7 @@
 #define uz_malloc malloc
 #define uz_free free
 
-#if defined(__XTENSA__) || defined(CONFIG_IDF_TARGET_ESP32C3)
+#if defined(CONFIG_IDF_TARGET)
 
 #define UZLIB_THROW(v) longjmp(unwindAddr, (v))
 #define UZLIB_SETJMP setjmp

--- a/components/uzlib/uzlib_deflate.c
+++ b/components/uzlib/uzlib_deflate.c
@@ -251,7 +251,7 @@ void resizeBuffer(void) {
   /* The outbuf is given an initial size estimate but if we are running */
   /* out of space then extropolate size using current compression */
   double newEstimate = (((double) oBuf->len)*oBuf->inLen) / oBuf->inNdx;
-  oBuf->size = 128 + (uint) newEstimate;
+  oBuf->size = 128 + (uint32_t) newEstimate;
   if (!(nb = realloc(oBuf->buffer, oBuf->size)))
     UZLIB_THROW(UZLIB_MEMORY_ERROR);
   oBuf->buffer = nb;


### PR DESCRIPTION
This is a frustratingly assorted PR, and includes:
 - Reworked console support, to now also work with USB Serial JTAG consoles and USB CDC consoles. All three have been tested across a variety of chips & modules and confirmed to work.
 - Initial support for the ESP32-C6.
 - Initial support for the ESP32-H2.
 - As part of adding those two chips, I also corrected a bunch of incorrect module deps in Kconfig, as well as some in CMakeLists.txt
 - Updated github actions actions to deal with the deprecation warning.
 - In doing so, uncovered that part of the build had been silently broken for quite some time, so I fixed that.
 - Minor IDF upgrade to v5.1.3, in order to get the USB CDC console working properly.
 - One missed type correction over in uzlib, which should've been fixed long ago but hadn't broken the build until now.
 - Addressed a potential null pointer dereference with the Lua prompt which hit me while I was debugging the early startup flow.
 - Finally, an ugly workaround for S2 with USB-CDC console when initialising wifi.
 
 Despite the wide coverage, the changes themselves are rather small. They are also somewhat interlinked, so splitting the PR seemed more hassle that it's worth. You can attempt to convince me otherwise :)
 