### PR TITLE
Fix typo in function name in u8g2

### DIFF
--- a/components/modules/u8g2.c
+++ b/components/modules/u8g2.c
@@ -600,7 +600,7 @@ LROT_BEGIN(lu8g2_display, NULL, LROT_MASK_INDEX)
   LROT_FUNCENTRY( setFontRefHeightExtendedText, lu8g2_setFontRefHeightExtendedText )
   LROT_FUNCENTRY( setFontRefHeightText,         lu8g2_setFontRefHeightText )
   LROT_FUNCENTRY( setPowerSave,       lu8g2_setPowerSave )
-  LROT_FUNCENTRY( updateDispla,       lu8g2_updateDisplay )
+  LROT_FUNCENTRY( updateDisplay,       lu8g2_updateDisplay )
   LROT_FUNCENTRY( updateDisplayArea,  lu8g2_updateDisplayArea )
 LROT_END(lu8g2_display, NULL, LROT_MASK_INDEX)
 


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

Fix typo in function name updateDisplay() 

Unfortunately, the description of  _updateDisplay_ and _updateDisplayArea_  functions is missing in u8g2.md