### PR TITLE
node.chipid() returns "0x_unknown" for ESP32xx chips

### DIFF
--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -155,10 +155,10 @@ static int node_bootreason( lua_State *L)
   return 2;
 }
 
-#if defined(CONFIG_IDF_TARGET_ESP32)
 // Lua: node.chipid()
 static int node_chipid( lua_State *L )
 {
+#if defined(CONFIG_IDF_TARGET_ESP32)
   // This matches the way esptool.py generates a chipid for the ESP32 as of
   // esptool commit e9e9179f6fc3f2ecfc568987d3224b5e53a05f06
   // Oddly, this drops the lowest byte what's effectively the MAC address, so
@@ -169,10 +169,12 @@ static int node_chipid( lua_State *L )
   uint64_t cid = ((word17 & MAX_UINT24) << 24) | ((word16 >> 8) & MAX_UINT24);
   char chipid[17] = { 0 };
   sprintf(chipid, "0x%llx", cid);
+#else
+  const char *chipid = "0x_unknown";
+#endif
   lua_pushstring(L, chipid);
   return 1;
 }
-#endif
 
 // Lua: node.heap()
 static int node_heap( lua_State* L )
@@ -865,9 +867,7 @@ LROT_END(node_wakeup, NULL, 0)
 
 LROT_BEGIN(node, NULL, 0)
   LROT_FUNCENTRY( bootreason, node_bootreason )
-#if defined(CONFIG_IDF_TARGET_ESP32)
   LROT_FUNCENTRY( chipid,     node_chipid )
-#endif
   LROT_FUNCENTRY( compile,    node_compile )
   LROT_FUNCENTRY( dsleep,     node_dsleep )
 #if defined(CONFIG_LUA_VERSION_51)


### PR DESCRIPTION
- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

The reason for this change is that the [nodemcu-tool](https://github.com/serg3295/NodeMCU-Tool/tree/dev-esp32) utility expects the `node.chipid()` command to exist in the Lua environment.
However, ESP32c6|s2|h2 chips do not have a chipid, so `node.chipid() `function will return `0x_unknown` for these chips.
