### PR TITLE
Fixes for issues in #3648

### DIFF
--- a/components/base_nodemcu/user_main.c
+++ b/components/base_nodemcu/user_main.c
@@ -36,6 +36,24 @@
 #define SIG_LUA 0
 #define SIG_UARTINPUT 1
 
+// Line ending config from Kconfig
+#if CONFIG_NEWLIB_STDIN_LINE_ENDING_CRLF
+# define RX_LINE_ENDINGS_CFG ESP_LINE_ENDINGS_CRLF
+#elif CONFIG_NEWLIB_STDIN_LINE_ENDING_CR
+# define RX_LINE_ENDINGS_CFG ESP_LINE_ENDINGS_CR
+#else
+# define RX_LINE_ENDINGS_CFG ESP_LINE_ENDINGS_LF
+#endif
+
+#if CONFIG_NEWLIB_STDOUT_LINE_ENDING_CRLF
+# define TX_LINE_ENDINGS_CFG ESP_LINE_ENDINGS_CRLF
+#elif CONFIG_NEWLIB_STDOUT_LINE_ENDING_CR
+# define TX_LINE_ENDINGS_CFG ESP_LINE_ENDINGS_CR
+#else
+# define TX_LINE_ENDINGS_CFG ESP_LINE_ENDINGS_LF
+#endif
+
+
 // We don't get argument size data from the esp_event dispatch, so it's
 // not possible to copy and forward events from the default event queue
 // to one running within our task context. To cope with this, we instead
@@ -214,9 +232,9 @@ static void console_init(void)
   /* Based on console/advanced example */
 
   esp_vfs_dev_uart_port_set_rx_line_endings(
-    CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CR);
+    CONFIG_ESP_CONSOLE_UART_NUM, RX_LINE_ENDINGS_CFG);
   esp_vfs_dev_uart_port_set_tx_line_endings(
-    CONFIG_ESP_CONSOLE_UART_NUM, ESP_LINE_ENDINGS_CRLF);
+    CONFIG_ESP_CONSOLE_UART_NUM, TX_LINE_ENDINGS_CFG);
 
   /* Configure UART. Note that REF_TICK is used so that the baud rate remains
    * correct while APB frequency is changing in light sleep mode.
@@ -242,8 +260,8 @@ static void console_init(void)
 #elif CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG
   /* Based on @pjsg's work */
 
-  esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
-  esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+  esp_vfs_dev_usb_serial_jtag_set_rx_line_endings(RX_LINE_ENDINGS_CFG);
+  esp_vfs_dev_usb_serial_jtag_set_tx_line_endings(TX_LINE_ENDINGS_CFG);
 
   usb_serial_jtag_driver_config_t usb_serial_jtag_config =
     USB_SERIAL_JTAG_DRIVER_CONFIG_DEFAULT();
@@ -254,8 +272,8 @@ static void console_init(void)
 #elif CONFIG_ESP_CONSOLE_USB_CDC
   /* Based on console/advanced_usb_cdc */
 
-  esp_vfs_dev_cdcacm_set_rx_line_endings(ESP_LINE_ENDINGS_CR);
-  esp_vfs_dev_cdcacm_set_tx_line_endings(ESP_LINE_ENDINGS_CRLF);
+  esp_vfs_dev_cdcacm_set_rx_line_endings(RX_LINE_ENDINGS_CFG);
+  esp_vfs_dev_cdcacm_set_tx_line_endings(TX_LINE_ENDINGS_CFG);
 #else
 # error "Unsupported console type"
 #endif

--- a/components/modules/node.c
+++ b/components/modules/node.c
@@ -174,6 +174,13 @@ static int node_chipid( lua_State *L )
 }
 #endif
 
+// Lua: node.chipmodel()
+static int node_chipmodel(lua_State *L)
+{
+  lua_pushstring(L, CONFIG_IDF_TARGET);
+  return 1;
+}
+
 // Lua: node.heap()
 static int node_heap( lua_State* L )
 {
@@ -868,6 +875,7 @@ LROT_BEGIN(node, NULL, 0)
 #if defined(CONFIG_IDF_TARGET_ESP32)
   LROT_FUNCENTRY( chipid,     node_chipid )
 #endif
+  LROT_FUNCENTRY( chipmodel,  node_chipmodel )
   LROT_FUNCENTRY( compile,    node_compile )
   LROT_FUNCENTRY( dsleep,     node_dsleep )
 #if defined(CONFIG_LUA_VERSION_51)

--- a/components/platform/include/platform.h
+++ b/components/platform/include/platform.h
@@ -91,15 +91,12 @@ typedef struct {
 typedef struct {
   QueueHandle_t queue;
   TaskHandle_t taskHandle;
-  int receive_rf;
-  int error_rf;
-  char *line_buffer;
-  size_t line_position;
-  uint16_t need_len;
-  int16_t end_char;
 } uart_status_t;
 
-extern uart_status_t uart_status[NUM_UART];
+// We have a bit of legacy spaghetti - these point into modules/uart.c
+extern bool uart_has_on_data_cb(unsigned id);
+extern void uart_feed_data(unsigned id, const char *buf, size_t len);
+extern bool uart_on_error_cb(unsigned id, const char *buf, size_t len);
 
 // Flow control types (this is a bit mask, one can specify PLATFORM_UART_FLOW_RTS | PLATFORM_UART_FLOW_CTS )
 #define PLATFORM_UART_FLOW_NONE               0

--- a/docs/modules/node.md
+++ b/docs/modules/node.md
@@ -71,7 +71,7 @@ if reset_reason == 0 then print("Power UP!") end
 
 ## node.chipid()
 
-Returns the ESP chip ID.
+Returns the ESP chip ID. Only available on the base ESP32 model.
 
 #### Syntax
 `node.chipid()`
@@ -84,6 +84,19 @@ chip ID (string)
 
 Note that due to the chip id being a much larger value on the ESP32, it is
 reported as a string now. E.g. `"0x1818fe346a88"`.
+
+## node.chipmodel()
+
+Returns the model of the ESP chip.
+
+#### Syntax
+`node.chipmodel()`
+
+#### Parameters
+none
+
+#### Returns
+The chip model as a string, e.g. "esp32c3". This is the string corresponding to the IDF's Kconfig parameter `IDF_TARGET`.
 
 ## node.compile()
 
@@ -153,20 +166,6 @@ node.dsleep({ gpio = 13, level = 0, pull = true })
 - [`node.sleep()`](#nodesleep)
 
 
-## node.flashid()
-
-Returns the flash chip ID.
-
-#### Syntax
-`node.flashid()`
-
-#### Parameters
-none
-
-#### Returns
-flash ID (number)
-
-
 ## node.flashindex() --deprecated
 
 Deprecated synonym for [`node.LFS.get()`](#nodelfsget) to return an LFS function reference.
@@ -191,31 +190,6 @@ none
 #### Returns
 system heap size left in bytes (number)
 
-## node.info()
-
-Returns NodeMCU version, chipid, flashid, flash size, flash mode, flash speed.
-
-#### Syntax
-`node.info()`
-
-#### Parameters
-none
-
-#### Returns
- - `majorVer` (number)
- - `minorVer` (number)
- - `devVer` (number)
- - `chipid` (number)
- - `flashid` (number)
- - `flashsize` (number)
- - `flashmode` (number)
- - `flashspeed` (number)
-
-#### Example
-```lua
-majorVer, minorVer, devVer, chipid, flashid, flashsize, flashmode, flashspeed = node.info()
-print("NodeMCU "..majorVer.."."..minorVer.."."..devVer)
-```
 
 ## node.input()
 

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -32,3 +32,7 @@ CONFIG_LWIP_TCP_MSL=5000
 # Disable esp-idf's bluetooth component by default.
 # The bthci module is also disabled and will enable bt when selected
 CONFIG_BT_ENABLED=n
+
+# Disable CR/LF translation, for legacy compatibility
+CONFIG_NEWLIB_STDIN_LINE_ENDING_LF=y
+CONFIG_NEWLIB_STDOUT_LINE_ENDING_LF=y


### PR DESCRIPTION
Fixes #3648.

- [x] This PR is for the `dev-esp32` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

It was pointed out that the switch to use the IDF's `stdin` inadvertently broke some IDE's due to different CR/LF handling, as well as breaking `uart.on('data')` handling on the console uart. This PR addresses both. The first by changing the default IDF CR/LF handling to do no translation which should match what we used to do, and the second by refactoring the `uart.on('data')` handling and hooking it into the new console task in addition to the uart task. In the future, we should probably consider adding a `console.on('data')` module/function to allow this sort of functionality also on models which use CDC or USB-Serial-JTAG consoles (at which point the uart.on('data') should just be a forward to that, for the console uart).

Additionally I've added `node.chipmodel()` to allow querying the model of ESP32 that NodeMCU is running on.

I've tested this on ESP32-C3 as that was what I had on my desk at the moment, and as far as I can tell it now works correctly. CR/LF handling is madly confusing with local terminal line discipline, ttyUSB line discipline, and ESP internal CR/LF translation all acting together and causing confusion.

@serg3295 could you please take this for a spin? I do not have VS Code to test with, and I can't find an ESPlorer version that supports `io.open()` instead of the old `file.open()` to test file uploads there.