### PR TITLE
Add missing wifi module in esp32c3 build

### DIFF
--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -77,6 +77,7 @@ elseif(IDF_TARGET STREQUAL "esp32s3")
   )
 elseif(IDF_TARGET STREQUAL "esp32c3")
   list(APPEND module_srcs
+    ${wifi_modules}
   )
 elseif(IDF_TARGET STREQUAL "esp32c6")
   list(APPEND module_srcs


### PR DESCRIPTION
Fixes #3654.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

This PR adds missing wifi module in esp32c3 build.
I have tested it on esp32c3 supermini.

