### PR TITLE
Increase default system event task stack size.

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -12,6 +12,8 @@ CONFIG_COMPILER_OPTIMIZATION_SIZE=y
 
 # Empirical value to prevent a firmware crash due to stack overflow.
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=8192
+# Increase the event task stack size to avoid crash on C3 during WiFi connect.
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=3072
 
 # Enable panic handler for task wdt to reset the firmware upon wdt timeout
 CONFIG_ESP_TASK_WDT_PANIC=y


### PR DESCRIPTION
Fixes #3660.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [n/a] The code changes are reflected in the documentation at `docs/*`.

The IDF defaults to a stack size of 2304. Bumping this to 3072 avoids the stack overrun crash during `ESP_LOGI()` in the `esp_netif_action_got_ip()` function during WiFi connect.