### PR TITLE
Issue restart rather than second lua_main() call on LFS reload.

### DIFF
--- a/components/base_nodemcu/user_main.c
+++ b/components/base_nodemcu/user_main.c
@@ -120,7 +120,7 @@ static void start_lua ()
 {
   NODE_DBG("Task task_lua started.\n");
   if (lua_main()) // If it returns true then LFS restart is needed
-    lua_main();
+    esp_restart();
 }
 
 static void nodemcu_init(void)

--- a/components/lua/lua-5.3/lnodemcu.c
+++ b/components/lua/lua-5.3/lnodemcu.c
@@ -629,10 +629,9 @@ LUAI_FUNC int luaN_init (lua_State *L) {
   lua_getglobal(L, #t); luaL_getmetafield( L, 1, #f ); lua_remove(L, -2);
 
 LUALIB_API void luaL_lfsreload (lua_State *L) {
-#if defined(CONFIG_NODEMCU_EMBEDDED_FLS_SIZE)
-  (void)L;
+#if defined(CONFIG_NODEMCU_EMBEDDED_LFS_SIZE)
   lua_pushstring(L, "Not allowed to write to LFS section");
-  return 1;
+  return;
 #else
 #ifdef LUA_USE_ESP
   size_t l;


### PR DESCRIPTION
By the time we get informed that there's an LFS reload we've already opened all the user libraries as well (and run their init code), so it's not safe to simply redo that with a fresh lua_State without also starting with a fresh hardware state. Currently attempting to do the second lua_main() call results in a hang, and a manual reset is required to progress. Doing the automatic restart is the correct approach here, even though this adds another reboot to the LFS reload process.

Also fixed up a couple of minor issues when embedded-LFS is used.

Fixes #3667.

- [x] This PR is for the `dev-esp32` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

