### PR TITLE
Fixing the Esp32 firmware build error on Debian and Raspberry

### DIFF
--- a/components/modules/CMakeLists.txt
+++ b/components/modules/CMakeLists.txt
@@ -254,7 +254,7 @@ execute_process(
 COMMAND grep "^lfs,.*" ${PROJECT_DIR}/components/platform/partitions.csv
 COMMAND cut -d, -f5
 COMMAND tr -d " "
-COMMAND awk "{print strtonum( $1 )}"
+COMMAND xargs printf "%d"
 OUTPUT_STRIP_TRAILING_WHITESPACE
 OUTPUT_VARIABLE buildinfo_lfs_size
 )


### PR DESCRIPTION
Fixes #3674 .

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [ ] The code changes are reflected in the documentation at `docs/*`.

To calculate BUILDINFO_LFS_SIZE, `awk "{print strtonum( $1 )}"` is currently used.
The `strtonum()` function is a `gawk` extension.
But the `gawk` package is not included by default in Debian stable.
To ensure the firmware build on all systems, we have to replace `awk "{print strtonum( $1 )}"` with `xargs printf "%d"`
