### PR TITLE
Fix failure to close listening socket (#3678).

### DIFF
--- a/components/modules/net.c
+++ b/components/modules/net.c
@@ -351,11 +351,11 @@ void handle_dns_event(task_param_t param, task_prio_t prio)
 
 
 static err_t netconn_close_and_delete(struct netconn *conn) {
-  err_t err = netconn_close(conn);
-  if (err == ERR_OK)
-    netconn_delete(conn);
-
-  return err;
+  // netconn_close() no longer returns valid return codes, as the code
+  // path we get in the IDF ends up using uninitialised memory.
+  netconn_close(conn);
+  netconn_delete(conn);
+  return ERR_OK;
 }
 
 


### PR DESCRIPTION
Fixes #3678 

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

The IDF LWIP's `netconn_close()` no longer returns valid error codes as the #ifdef'd code path the IDF uses does not end up actually doing much, which unfortunately includes actually setting the error code. As such, checking the return code is actively harmful to proper operation for us. The fix here is simply to carry on with the `netconn_delete()`. This _should_ be safe even if `netconn_close()` actually errored.