### PR TITLE
Zero out ledc timer config in newChannel

### DIFF
--- a/components/modules/ledc.c
+++ b/components/modules/ledc.c
@@ -20,7 +20,7 @@ static int lledc_new_channel( lua_State *L )
   luaL_checktable (L, 1);
 
   /* Setup timer */
-  ledc_timer_config_t ledc_timer;
+  ledc_timer_config_t ledc_timer = {};
 
   ledc_timer.duty_resolution = opt_checkint_range (L, "bits", LEDC_TIMER_13_BIT, 0, LEDC_TIMER_BIT_MAX-1);
 


### PR DESCRIPTION
ledc.newChannel was broken for me on `dev-esp32`:

```
> pwm = ledc.newChannel({
>>   gpio = 4,
>>   bits = ledc.TIMER_10_BIT,
>>   mode = ledc.HIGH_SPEED,
>>   timer = ledc.TIMER_0,
>>   channel = ledc.CHANNEL_0,
>>   frequency = 1000,
>>   duty = 512,
>> })
 (421647) ledc: ledc_timer_del(589): LEDC is not initialized
Lua error: 	stdin:1: timer configuration failed code 259
stack traceback:
	[C]: in function 'ledc.newChannel'
	stdin:1: in main chunk
	[C]: in ?
	[C]: in ?
```

espressif/esp-idf#15806 indicates this is due to a (presumably) new field, zeroing out the struct fixes it.
