### PR TITLE
DS18Bb20: broadcast CONVERT_T to parasite powered devices

### DIFF
--- a/lua_modules/ds18b20/ds18b20-integer.lua
+++ b/lua_modules/ds18b20/ds18b20-integer.lua
@@ -100,30 +100,11 @@ end
 
 conversion = (function (self)
   local sens = self.sens
-  local powered_only = true
-  for _, s in ipairs(sens) do powered_only = powered_only and s:byte(9) ~= 1 end
-  if powered_only then
-    debugPrint("starting conversion: all sensors")
-    ow_reset(pin)
-    ow_skip(pin)  -- skip ROM selection, talk to all sensors
-    ow_write(pin, CONVERT_T, MODE)  -- and start conversion
-    for i, _ in ipairs(sens) do status[i] = 1 end
-  else
-    local started = false
-    for i, s in ipairs(sens) do
-      if status[i] == 0 then
-        local addr, parasite = s:sub(1,8), s:byte(9) == 1
-        if parasite and started then break end -- do not start concurrent conversion of powered and parasite
-        debugPrint("starting conversion:", to_string(addr), parasite and "parasite" or "")
-        ow_reset(pin)
-        ow_select(pin, addr)  -- select the sensor
-        ow_write(pin, CONVERT_T, MODE)  -- and start conversion
-        status[i] = 1
-        if parasite then break end -- parasite sensor blocks bus during conversion
-        started = true
-      end
-    end
-  end
+  debugPrint("starting conversion: all sensors")
+  ow_reset(pin)
+  ow_skip(pin)  -- skip ROM selection, talk to all sensors
+  ow_write(pin, CONVERT_T, MODE)  -- and start conversion
+  for i, _ in ipairs(sens) do status[i] = 1 end
   tmr_create():alarm(750, tmr_ALARM_SINGLE, function() return readout(self) end)
 end)
 

--- a/lua_modules/ds18b20/ds18b20.lua
+++ b/lua_modules/ds18b20/ds18b20.lua
@@ -97,30 +97,11 @@ end
 
 conversion = (function (self)
   local sens = self.sens
-  local powered_only = true
-  for _, s in ipairs(sens) do powered_only = powered_only and s:byte(9) ~= 1 end
-  if powered_only then
-    debugPrint("starting conversion: all sensors")
-    ow_reset(pin)
-    ow_skip(pin)  -- skip ROM selection, talk to all sensors
-    ow_write(pin, CONVERT_T, MODE)  -- and start conversion
-    for i, _ in ipairs(sens) do status[i] = 1 end
-  else
-    local started = false
-    for i, s in ipairs(sens) do
-      if status[i] == 0 then
-        local addr, parasite = s:sub(1,8), s:byte(9) == 1
-        if parasite and started then break end -- do not start concurrent conversion of powered and parasite
-        debugPrint("starting conversion:", to_string(addr), parasite and "parasite" or "")
-        ow_reset(pin)
-        ow_select(pin, addr)  -- select the sensor
-        ow_write(pin, CONVERT_T, MODE)  -- and start conversion
-        status[i] = 1
-        if parasite then break end -- parasite sensor blocks bus during conversion
-        started = true
-      end
-    end
-  end
+  debugPrint("starting conversion: all sensors")
+  ow_reset(pin)
+  ow_skip(pin)  -- skip ROM selection, talk to all sensors
+  ow_write(pin, CONVERT_T, MODE)  -- and start conversion
+  for i, _ in ipairs(sens) do status[i] = 1 end
   tmr_create():alarm(750, tmr_ALARM_SINGLE, function() return readout(self) end)
 end)
 


### PR DESCRIPTION
Fixes #3682.

- [X] This PR is for the `dev` branch rather than for the `release` branch.
- [X] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/*`.

This PR will remove the special handling for parasite powered devices, because `ow_write` is already able to correctly handle the strong pull-up required by the DS18B20 and will return to its usual state when issuing new `ow` operations. 

## Testing

During testings I parasitic powered two different sensors with a 1m length cable each: pins 1 and 3 are GND and pin 2 directly connected to pin=7 (D7) of a NodeMCU. 

I uploaded the ds18b20.lua and the following init.lua:

```
local t = require("ds18b20")
local pin = 7
gpio.mode(pin, gpio.INPUT, gpio.PULLUP)

function readout(temp)
  t:read_temp(readout, pin, t.C)
  if t.sens then
    print("Total number of DS18B20 sensors: ".. #t.sens)
    for i, s in ipairs(t.sens) do
      print(string.format("  sensor #%d address: %s%s",  i, ('%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X'):format(s:byte(1,8)), s:byte(9) == 1 and " (parasite)" or ""))
    end
  end
  for addr, temp in pairs(temp) do
    print(string.format("Sensor %s: %s °C", ('%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X'):format(addr:byte(1,8)), temp))
  end
end


t:read_temp(readout, pin, t.C)
```

Opened the serial monitor and everything is working as expected, printing every ~750ms.




