### PR TITLE
TLS: add SNI support for secure connections

### DIFF
--- a/app/http/httpclient.c
+++ b/app/http/httpclient.c
@@ -533,6 +533,7 @@ static void ICACHE_FLASH_ATTR http_dns_callback( const char * hostname, ip_addr_
 #ifdef CLIENT_SSL_ENABLE
 		if ( req->secure )
 		{
+			espconn_secure_set_hostname( hostname );
 			espconn_secure_connect( conn );
 		}
 		else

--- a/app/include/lwip/app/espconn.h
+++ b/app/include/lwip/app/espconn.h
@@ -516,6 +516,15 @@ extern sint8 espconn_secure_send(struct espconn *espconn, uint8 *psent, uint16 l
 extern sint8 espconn_secure_sent(struct espconn *espconn, uint8 *psent, uint16 length);
 
 /******************************************************************************
+ * FunctionName : espconn_secure_set_hostname
+ * Description  : set hostname for SNI (Server Name Indication) support
+ * Parameters   : hostname -- hostname string to send during TLS handshake
+ * Returns      : true on success, false on memory allocation failure
+*******************************************************************************/
+
+extern bool espconn_secure_set_hostname(const char* hostname);
+
+/******************************************************************************
  * FunctionName : espconn_secure_ca_enable
  * Description  : enable the certificate authenticate and set the flash sector
  *                               as client or server

--- a/app/include/sys/espconn_mbedtls.h
+++ b/app/include/sys/espconn_mbedtls.h
@@ -94,6 +94,7 @@ struct ssl_options {
 
 	int cert_verify_callback;
 	int cert_auth_callback;
+	char *hostname; // SNI support
 };
 
 #define SSL_KEEP_INTVL  1

--- a/app/mbedtls/app/espconn_mbedtls.c
+++ b/app/mbedtls/app/espconn_mbedtls.c
@@ -626,6 +626,20 @@ static bool mbedtls_msg_config(mbedtls_msg *msg)
 	ret = mbedtls_ssl_setup(&msg->ssl, &msg->conf);
 	lwIP_REQUIRE_NOERROR(ret, exit);
 
+	/* Add hostname for SNI support */
+	if (ssl_client_options.hostname != NULL) {
+		os_printf("Configuring SNI for hostname: %s\n", ssl_client_options.hostname);
+        ret = mbedtls_ssl_set_hostname(&msg->ssl, ssl_client_options.hostname);
+		if (ret == 0) {
+     	   os_printf("SNI hostname configured successfully\n");
+    	} else {
+	        os_printf("SNI hostname configuration failed: -0x%x\n", -ret);
+	    }
+        lwIP_REQUIRE_NOERROR(ret, exit);
+    } else {
+		os_printf("Hostname was not set!\n");
+	}
+
 	/*Initialize the RNG and the session data*/
 	ret = mbedtls_ctr_drbg_seed(&msg->ctr_drbg, mbedtls_entropy_func, &msg->entropy, "client", 6);
 	lwIP_REQUIRE_NOERROR(ret, exit);

--- a/app/mbedtls/app/espconn_secure.c
+++ b/app/mbedtls/app/espconn_secure.c
@@ -115,6 +115,11 @@ espconn_secure_disconnect(struct espconn *espconn)
 	if (espconn == NULL)
 		return ESPCONN_ARG;
 
+	if (ssl_client_options.hostname) {
+    	os_free(ssl_client_options.hostname);
+    	ssl_client_options.hostname = NULL;
+	}
+	
 	value = espconn_find_connection(espconn, &pnode);
 	if (value){
 		if (pnode->pespconn->state == ESPCONN_CLOSE)
@@ -169,6 +174,35 @@ espconn_secure_sent(struct espconn *espconn, uint8 *psent, uint16 length)
 *******************************************************************************/
 
 sint8 espconn_secure_send(struct espconn *espconn, uint8 *psent, uint16 length) __attribute__((alias("espconn_secure_sent")));
+
+/******************************************************************************
+ * FunctionName : espconn_secure_set_hostname
+ * Description  : set hostname for SNI (Server Name Indication) support
+ * Parameters   : hostname -- hostname string to send during TLS handshake
+ * Returns      : true on success, false on memory allocation failure
+*******************************************************************************/
+bool ICACHE_FLASH_ATTR 
+espconn_secure_set_hostname(const char* hostname)
+{
+	printf("Setting SNI hostname: %s\n", hostname ? hostname : "NULL");
+
+    if (ssl_client_options.hostname) {
+        os_free(ssl_client_options.hostname);
+        ssl_client_options.hostname = NULL;
+    }
+    
+    if (hostname) {
+        ssl_client_options.hostname = (char*)os_malloc(strlen(hostname) + 1);
+        if (ssl_client_options.hostname) {
+            strcpy(ssl_client_options.hostname, hostname);
+			printf("SNI hostname set successfully: %s\n", ssl_client_options.hostname);
+            return true;
+        }
+        return false;
+    }
+    
+    return true;
+}
 
 /******************************************************************************
  * FunctionName : espconn_secure_ca_enable

--- a/app/mbedtls/app/espconn_secure.c
+++ b/app/mbedtls/app/espconn_secure.c
@@ -184,7 +184,6 @@ sint8 espconn_secure_send(struct espconn *espconn, uint8 *psent, uint16 length) 
 bool ICACHE_FLASH_ATTR 
 espconn_secure_set_hostname(const char* hostname)
 {
-	printf("Setting SNI hostname: %s\n", hostname ? hostname : "NULL");
 
     if (ssl_client_options.hostname) {
         os_free(ssl_client_options.hostname);
@@ -195,7 +194,6 @@ espconn_secure_set_hostname(const char* hostname)
         ssl_client_options.hostname = (char*)os_malloc(strlen(hostname) + 1);
         if (ssl_client_options.hostname) {
             strcpy(ssl_client_options.hostname, hostname);
-			printf("SNI hostname set successfully: %s\n", ssl_client_options.hostname);
             return true;
         }
         return false;

--- a/app/modules/mqtt.c
+++ b/app/modules/mqtt.c
@@ -989,6 +989,7 @@ static sint8 mqtt_socket_do_connect(struct lmqtt_userdata *mud)
   if(mud->conf.flags.secure)
   {
     NODE_DBG("mqtt_socket_do_connect using espconn_secure\n");
+    
     espconn_status = espconn_secure_connect(&mud->pesp_conn);
   }
   else
@@ -1020,6 +1021,13 @@ static void socket_dns_found(const char *name, ip_addr_t *ipaddr, void *arg)
   NODE_DBG("socket_dns_found success: ");
   NODE_DBG(IPSTR, IP2STR(&(ipaddr->addr)));
   NODE_DBG("\n");
+  #ifdef CLIENT_SSL_ENABLE
+  if(mud->conf.flags.secure)
+  {
+    NODE_DBG("socket_dns_found configuring hostname for SNI\n");
+    espconn_secure_set_hostname( name );
+  }
+  #endif
 
   if(mqtt_socket_do_connect(mud) != ESPCONN_OK) {
       NODE_DBG("socket_dns_found, got DNS but connect failed\n");

--- a/app/modules/tls.c
+++ b/app/modules/tls.c
@@ -174,6 +174,7 @@ static void tls_socket_dns_cb( const char* domain, const ip_addr_t *ip_addr, tls
     lua_gc(L, LUA_GCRESTART, 0);
   } else {
     os_memcpy(ud->pesp_conn.proto.tcp->remote_ip, &addr.addr, 4);
+		espconn_secure_set_hostname( domain );
     espconn_secure_connect(&ud->pesp_conn);
   }
 }
@@ -204,7 +205,6 @@ static int tls_socket_connect( lua_State *L ) {
   ud->pesp_conn.proto.tcp->remote_port = port;
   
   espconn_secure_set_hostname(domain);
-  
   espconn_regist_connectcb(&ud->pesp_conn, (espconn_connect_callback)tls_socket_onconnect);
   espconn_regist_disconcb(&ud->pesp_conn, (espconn_connect_callback)tls_socket_ondisconnect);
   espconn_regist_reconcb(&ud->pesp_conn, (espconn_reconnect_callback)tls_socket_onreconnect);

--- a/app/modules/tls.c
+++ b/app/modules/tls.c
@@ -204,7 +204,6 @@ static int tls_socket_connect( lua_State *L ) {
   ud->pesp_conn.state = ESPCONN_NONE;
   ud->pesp_conn.proto.tcp->remote_port = port;
   
-  espconn_secure_set_hostname(domain);
   espconn_regist_connectcb(&ud->pesp_conn, (espconn_connect_callback)tls_socket_onconnect);
   espconn_regist_disconcb(&ud->pesp_conn, (espconn_connect_callback)tls_socket_ondisconnect);
   espconn_regist_reconcb(&ud->pesp_conn, (espconn_reconnect_callback)tls_socket_onreconnect);

--- a/app/modules/tls.c
+++ b/app/modules/tls.c
@@ -202,6 +202,9 @@ static int tls_socket_connect( lua_State *L ) {
   ud->pesp_conn.type = ESPCONN_TCP;
   ud->pesp_conn.state = ESPCONN_NONE;
   ud->pesp_conn.proto.tcp->remote_port = port;
+  
+  espconn_secure_set_hostname(domain);
+  
   espconn_regist_connectcb(&ud->pesp_conn, (espconn_connect_callback)tls_socket_onconnect);
   espconn_regist_disconcb(&ud->pesp_conn, (espconn_connect_callback)tls_socket_ondisconnect);
   espconn_regist_reconcb(&ud->pesp_conn, (espconn_reconnect_callback)tls_socket_onreconnect);

--- a/app/websocket/websocketclient.c
+++ b/app/websocket/websocketclient.c
@@ -712,6 +712,7 @@ static void dns_callback(const char *hostname, ip_addr_t *addr, void *arg) {
 
   if (ws->isSecure) {
     NODE_DBG("secure connecting \n");
+    espconn_secure_set_hostname( hostname );
     espconn_secure_connect(conn);
   }
   else {

--- a/docs/modules/tls.md
+++ b/docs/modules/tls.md
@@ -43,16 +43,6 @@ most common features supported.  Specifically, it provides:
 
 !!! warning
 
-	The TLS glue provided by Espressif provides no interface to TLS SNI.
-	As such, NodeMCU TLS should not be expected to function with endpoints
-	requiring the use of SNI, which is a growing fraction of the Internet
-	and includes, for example, Cloudflare sites using their "universal SSL"
-	service and other, similar "virtual" TLS servers.  TLS servers to which
-	you wish NodeMCU to connect should have their own, dedicated IP/port
-	pair.
-
-!!! warning
-
 	The TLS handshake is very heap intensive, requiring between 25 and 30
 	**kilobytes** of heap, even with our reduced buffer sizes.  Some, but
 	not all, of that is made available again once the handshake has


### PR DESCRIPTION
Probably fixes most TLS (https) issues #2970 #1707 #1484.

- [X] This PR is for the `dev` branch rather than for the `release` branch.
- [X] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [X] I have thoroughly tested my contribution.
- [X] The code changes are reflected in the documentation at `docs/*`.

This will add SNI support for secure connections by providing these modifications:

 - [`ssl_options`](https://github.com/caiohamamura/nodemcu-firmware/blob/547ed87695839d8024ec5077fcf3126568fa2405/app/include/sys/espconn_mbedtls.h#L97): Add a `char *hostname` field
 - [`espconn_secure_set_hostname`](https://github.com/caiohamamura/nodemcu-firmware/blob/547ed87695839d8024ec5077fcf3126568fa2405/app/mbedtls/app/espconn_secure.c#L185C8-L185C50): function to provides an interface to set the `ssl_client_options.hostname` . 
 - Within `httpclient.c` [`http_dns_callback`](https://github.com/caiohamamura/nodemcu-firmware/blob/547ed87695839d8024ec5077fcf3126568fa2405/app/http/httpclient.c#L495) function: before connecting through `espconn_secure_connect` it will set [`espconn_secure_set_hostname( hostname )`](https://github.com/caiohamamura/nodemcu-firmware/blob/547ed87695839d8024ec5077fcf3126568fa2405/app/http/httpclient.c#L536)
 - During [`mbedtls_msg_config`](https://github.com/caiohamamura/nodemcu-firmware/blob/547ed87695839d8024ec5077fcf3126568fa2405/app/mbedtls/app/espconn_mbedtls.c#L617): it will now call `mbedtls_ssl_set_hostname` given `ssl_client_options.hostname` is provided, which will then address SNI.