### PR TITLE
Correct ordering of pixbuf metatable, so that its tests pass.

### DIFF
--- a/app/modules/pixbuf.c
+++ b/app/modules/pixbuf.c
@@ -680,10 +680,13 @@ static int pixbuf_tostring_lua(lua_State *L) {
 }
 
 LROT_BEGIN(pixbuf_map, NULL, LROT_MASK_INDEX | LROT_MASK_EQ)
-  LROT_TABENTRY ( __index, pixbuf_map )
-  LROT_FUNCENTRY( __eq, pixbuf_eq_lua )
-
+  /* https://nodemcu.readthedocs.io/en/dev/lua53/#rotables notes:
+   * "Some ordering limitations apply", namely that entries beginning
+   * with '__' must be first and must be sorted.
+   */
   LROT_FUNCENTRY( __concat, pixbuf_concat_lua )
+  LROT_FUNCENTRY( __eq, pixbuf_eq_lua )
+  LROT_TABENTRY ( __index, pixbuf_map )
   LROT_FUNCENTRY( __tostring, pixbuf_tostring_lua )
 
   LROT_FUNCENTRY( channels, pixbuf_channels_lua )


### PR DESCRIPTION
Fixes #3699. In particular `NTest_pixbuf.lua` now has no failures.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.
