### PR TITLE
Align behaviour of `pixbuf.buffer:sub()` with that of `string.sub()`.

### DIFF
--- a/app/modules/pixbuf.c
+++ b/app/modules/pixbuf.c
@@ -21,11 +21,26 @@ pixbuf *pixbuf_opt_from_lua_arg(lua_State *L, int arg) {
   return luaL_testudata(L, arg, PIXBUF_METATABLE);
 }
 
+// Cribbed from lua/lstrlib.c
 static ssize_t posrelat(ssize_t pos, size_t len) {
   /* relative string position: negative means back from end */
   if (pos < 0)
     pos += (ssize_t)len + 1;
-  return MIN(MAX(pos, 1), len);
+  return (pos >= 0) ? pos : 0;
+}
+
+// Models how string.sub treats i
+static int posrelat_start(int start, int l) {
+  start = posrelat(start, l);
+  if (start < 1) start = 1;
+  return start;
+}
+
+// Models how string.sub treats j
+static int posrelat_end(int end, int l) {
+  end = posrelat(end, l);
+  if (end > (ssize_t)l) end = (ssize_t)l;
+  return end;
 }
 
 const size_t pixbuf_channels(pixbuf *p) {
@@ -235,17 +250,17 @@ static int pixbuf_map_lua(lua_State *L) {
   if (!buffer1)
     buffer1 = outbuf;
 
-  const int ilo = posrelat(luaL_optinteger(L, 4, 1), buffer1->npix) - 1;
-  const int ihi = posrelat(luaL_optinteger(L, 5, buffer1->npix), buffer1->npix) - 1;
+  const int ilo = posrelat_start(luaL_optinteger(L, 4, 1), buffer1->npix) - 1;
+  const int ihi = posrelat_end(luaL_optinteger(L, 5, buffer1->npix), buffer1->npix) - 1;
 
-  luaL_argcheck(L, ihi > ilo, 3, "Buffer limits out of order");
+  luaL_argcheck(L, ihi >= ilo, 3, "Buffer limits out of order");
 
   size_t npix = ihi - ilo + 1;
 
   luaL_argcheck(L, npix == outbuf->npix, 1, "Output buffer wrong size");
 
   pixbuf *buffer2 = pixbuf_opt_from_lua_arg(L, 6);
-  const int ilo2 = buffer2 ? posrelat(luaL_optinteger(L, 7, 1), buffer2->npix) - 1 : 0;
+  const int ilo2 = buffer2 ? posrelat_start(luaL_optinteger(L, 7, 1), buffer2->npix) - 1 : 0;
 
   if (buffer2) {
     luaL_argcheck(L, ilo2 + npix <= buffer2->npix, 6, "Second buffer too short");
@@ -430,7 +445,7 @@ static int pixbuf_powerI_lua(lua_State *L) {
 
 static int pixbuf_replace_lua(lua_State *L) {
   pixbuf *buffer = pixbuf_from_lua_arg(L, 1);
-  ptrdiff_t start = posrelat(luaL_optinteger(L, 3, 1), buffer->npix);
+  ptrdiff_t start = posrelat_start(luaL_optinteger(L, 3, 1), buffer->npix);
   size_t channels = buffer->nchan;
 
   uint8_t *src;
@@ -561,8 +576,8 @@ int pixbuf_shift_lua(lua_State *L) {
   pixbuf *buffer = pixbuf_from_lua_arg(L, 1);
   const int shift_shift = luaL_checkinteger(L, 2) * buffer->nchan;
   const unsigned shift_type = luaL_optinteger(L, 3, PIXBUF_SHIFT_LOGICAL);
-  const int pos_start = posrelat(luaL_optinteger(L, 4, 1), buffer->npix);
-  const int pos_end = posrelat(luaL_optinteger(L, 5, -1), buffer->npix);
+  const int pos_start = posrelat_start(luaL_optinteger(L, 4, 1), buffer->npix);
+  const int pos_end = posrelat_end(luaL_optinteger(L, 5, -1), buffer->npix);
 
   if (shift_shift < 0) {
     sp.shiftLeft = true;
@@ -609,8 +624,8 @@ int pixbuf_shift_lua(lua_State *L) {
 void pixbuf_prepare_shift(pixbuf *buffer, struct pixbuf_shift_params *sp,
     int shift, enum pixbuf_shift type, int start, int end)
 {
-  start = posrelat(start, buffer->npix);
-  end = posrelat(end, buffer->npix);
+  start = posrelat_start(start, buffer->npix);
+  end = posrelat_end(end, buffer->npix);
 
   lua_assert((end > start) && (start > 0) && (end < buffer->npix));
 
@@ -636,8 +651,9 @@ static int pixbuf_size_lua(lua_State *L) {
 static int pixbuf_sub_lua(lua_State *L) {
   pixbuf *lhs = pixbuf_from_lua_arg(L, 1);
   size_t l = lhs->npix;
-  ssize_t start = posrelat(luaL_checkinteger(L, 2), l);
-  ssize_t end = posrelat(luaL_optinteger(L, 3, -1), l);
+  ssize_t start = posrelat_start(luaL_checkinteger(L, 2), l);
+  ssize_t end = posrelat_end(luaL_optinteger(L, 3, -1), l);
+
   if (start <= end) {
     pixbuf *result = pixbuf_new(L, end - start + 1, lhs->nchan);
     memcpy(result->values, lhs->values + lhs->nchan * (start - 1),

--- a/tests/NTest_pixbuf.lua
+++ b/tests/NTest_pixbuf.lua
@@ -58,6 +58,13 @@ N.test('replace correctly issue #2921', function()
     ok(eq(buffer:dump(), string.char(3,255,165,33,0,244,12,87,255,0,0,0,0,0,0)), "RGBW")
 end)
 
+N.test('replace correctly issue #3702', function()
+    local buffer1 = pixbuf.newBuffer(4, 4)
+    buffer1:set(1, "AAAABBBBCCCCDDDD")
+    fail(function() buffer1:replace("XXXX", 5) end,
+         "does not fit into destination")
+end)
+
 N.test('get/set correctly', function()
     local buffer = pixbuf.newBuffer(3, 4)
     buffer:fill(1,222,55,13)
@@ -193,6 +200,13 @@ N.test('shift LOGICAL issue #2946', function()
     fail(function() buffer1:shift(-6) end, "shifting more elements than buffer size")
 end)
 
+N.test('shift LOGICAL issue #3702', function()
+    local buffer1 = pixbuf.newBuffer(4, 4)
+    initBuffer(buffer1,7,8,9,12)
+    fail(function() buffer1:shift(1, pixbuf.SHIFT_LOGICAL, 5, 5) end,
+         "end position must be >= start")
+end)
+
 N.test('shift CIRCULAR', function()
     local buffer1 = pixbuf.newBuffer(4, 4)
     local buffer2 = pixbuf.newBuffer(4, 4)
@@ -281,6 +295,61 @@ N.test('map', function()
     buffer3:set(1,"EFGHIJKLM")
     buffer1:map(function(c,a,b,d) return a,b,c,d end, buffer2, 1, 2, buffer3, 2)
     ok(eq("HIAJKLBM", buffer1:dump()), "partial zip")
+end)
+
+N.test('map issue #3702', function()
+    local buffer1 = pixbuf.newBuffer(4, 4)
+    local buffer2 = pixbuf.newBuffer(1, 4)
+    local f = function(a, b, c, d) return a+10, b+10, c+10, d+10 end
+    buffer1:fill(65,66,67,68)
+    buffer2:map(f, buffer1, -1, -1) -- just the last pixel
+    ok(eq("KLMN", buffer2:dump()), "map last pixel only")
+end)
+
+N.test('sub boundaries behave like string.sub', function()
+    local buffer1 = pixbuf.newBuffer(4, 4)
+    local function quadruple(s)
+        local q = ""
+        for i = 1, #s do
+            local c = s:byte(i)
+            q = ("%s%c%c%c%c"):format(q, c, c, c, c)
+        end
+        return q
+    end
+
+    local str1 = "ABCD"
+    buffer1:set(1, quadruple(str1))
+
+    for _, range in ipairs({
+        {2, 3},  -- all in range
+        {2, nil},  -- implicit end
+        {2, -1},  -- explicit end
+        {-2, nil}, -- suffix of length 2
+        {-4, nil}, -- suffix of length 4: entire sequence
+        {-5, nil}, -- still entire sequence
+        {-100, nil}, -- still entire sequence
+        {-5, 1}, -- overlap just first element
+        {-5, -3}, -- overlap first two elements
+        {0, 2}, -- overlap first two elements
+        {-5, 0}, -- empty
+        {3, 2}, -- empty
+        {3, -2}, -- just third element
+        {4, 5}, -- just last element
+        {4, 6}, -- still just last element
+        {4, -1}, -- also just last element
+        {5, 6}, -- empty
+        {5, -1}, -- empty
+        {6, -5}, -- empty
+        {-5, 10}, -- entire sequence
+    }) do
+        local first, last = range[1], range[2]
+        local range_name = ("(%s to %s)"):format(first or 'nil', last or 'nil')
+
+        local sub_buf = buffer1:sub(first, last)
+        local sub_str = str1:sub(first, last)
+
+        ok(eq(sub_buf:dump(), quadruple(sub_str)), range_name)
+    end
 end)
 
 --[[


### PR DESCRIPTION
In particular this fixes a bug where `pixbuf.buffer:sub(-1, 0)` would give a buffer of length 1, as opposed to an empty string for `string.sub(-1, 0)`.

Also adjust `map()`, `replace()` and `shift()` index calculations correspondingly.

Fixes #3702.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

