### PR TITLE
Fix SDK pruning to use toolchain's `ar`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,9 +333,11 @@ $(TOP_DIR)/sdk/.extracted-$(SDK_VER): $(TOP_DIR)/cache/$(SDK_FILE_VER).zip
 $(TOP_DIR)/sdk/.pruned-$(SDK_VER):
 	rm -f $(SDK_DIR)/lib/liblwip.a $(SDK_DIR)/lib/libssl.a $(SDK_DIR)/lib/libmbedtls.a
 	$(summary) PRUNE libmain.a libc.a
-	echo "$(PATH)"
-	$(AR) d $(SDK_DIR)/lib/libmain.a time.o
-	$(AR) d $(SDK_DIR)/lib/libc.a lib_a-time.o
+	# On Make <=3.81 (such as MacOS provides) these commands need to be run
+	# in shells rather than directly by Make, so that $(AR) is found using
+	# the updated `PATH` that is computed above.
+	(exec $(AR) d $(SDK_DIR)/lib/libmain.a time.o)
+	(exec $(AR) d $(SDK_DIR)/lib/libc.a lib_a-time.o)
 	touch $@
 
 $(TOP_DIR)/cache/$(SDK_FILE_VER).zip:


### PR DESCRIPTION
Fixes #3705.

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

The main `Makefile` adjusts `PATH` to be able to find the toolchain's executables, but (for GNU make <= 3.81, including that shipped with MacOS) commands that require those executables must be executed in subshells otherwise [they will not see](https://stackoverflow.com/a/77925167) the updated value of `PATH`.
