### PR TITLE
Respect SPIFFS_FIXED_LOCATION in default PT

### DIFF
--- a/app/user/user_main.c
+++ b/app/user/user_main.c
@@ -88,7 +88,7 @@ static const struct defaultpt rompt IROM_PTABLE_ATTR USED_ATTR  = {
     { SYSTEM_PARTITION_PHY_DATA,          0x0F000,     PHY_DATA_SIZE},
     { NODEMCU_PARTITION_IROM0TEXT,        0x10000,     0x0000},
     { NODEMCU_PARTITION_LFS,              0x0,         LUA_FLASH_STORE},
-    { NODEMCU_PARTITION_SPIFFS,           0x0,         SPIFFS_MAX_FILESYSTEM_SIZE},
+    { NODEMCU_PARTITION_SPIFFS,           SPIFFS_FIXED_LOCATION, SPIFFS_MAX_FILESYSTEM_SIZE},
     { SYSTEM_PARTITION_SYSTEM_PARAMETER,  0x0,         SYSTEM_PARAMETER_SIZE},
     {0,(uint32_t) &_irom0_text_end,0}
   }
@@ -260,7 +260,7 @@ static uint32_t first_time_setup(partition_item_t *pt, uint32_t n, uint32_t flas
             if (p->size == ~0x0) {         /* Maximum SPIFFS partition */               
                 if (p->addr == 0)
                     p->addr = last;
-                p->size = flash_size - SYSTEM_PARAMETER_SIZE - last;
+                p->size = flash_size - SYSTEM_PARAMETER_SIZE - p->addr;
             } else if (p->size > 0x0) {    /* Explicit SPIFFS size */
                 if (p->addr < last)   // SPIFFS can't overlap the previous region; 
                     p->addr = 0; 


### PR DESCRIPTION
_Make sure all boxes are checked (add x inside the brackets) when you submit your contribution, remove this sentence before doing so._

- [x] This PR is for the `dev` branch rather than for the `release` branch.
- [x] This PR is compliant with the [other contributing guidelines](/CONTRIBUTING.md) as well (if not, please describe why).
- [x] I have thoroughly tested my contribution.
- [x] The code changes are reflected in the documentation at `docs/*`.

_To be completed below: Description of and rationale behind this PR._

SPIFFS_FIXED_LOCATION is described in docs, defined in user_config.h, and used by tools/Makefile while generating SPIFFS. However, the default partition table does not use it.

Makes the default PT use the correct location for fixed SPIFFS partition.